### PR TITLE
Prover interfaces and types

### DIFF
--- a/prover/Prover.go
+++ b/prover/Prover.go
@@ -23,7 +23,7 @@ type ProofVerifier interface {
 	BuildProof(block types.Block, tx types.Transaction) SpvProof
 
 	// VerifyProof verifies a SPV proof by proving commitment to its root (not to block hash)
-	VerifyProof(SpvProof) bool
+	VerifyProof(merklePath []byte, proof SpvProof) bool
 }
 
 // LightClientProof supports cryptographic verification


### PR DESCRIPTION
This PR implements the interfaces and types for a basic prover with two verification strategies - SPV Proof verification and proof-of-stake based Threshold Vote verification.