### PR TITLE
Increase validator session length to 4 hours in beefy light client

### DIFF
--- a/ethereum/contracts/BeefyLightClient.sol
+++ b/ethereum/contracts/BeefyLightClient.sol
@@ -132,7 +132,7 @@ contract BeefyLightClient {
 
     // We must ensure at least one block is processed every session,
     // so these constants are checked to enforce a maximum gap between commitments.
-    uint64 public constant NUMBER_OF_BLOCKS_PER_SESSION = 100;
+    uint64 public constant NUMBER_OF_BLOCKS_PER_SESSION = 2400;
     uint64 public constant ERROR_AND_SAFETY_BUFFER = 10;
     uint64 public constant MAXIMUM_BLOCK_GAP =
         NUMBER_OF_BLOCKS_PER_SESSION - ERROR_AND_SAFETY_BUFFER;


### PR DESCRIPTION
Necessary to have a working testnet, as deploying everything in a 10 minute span (100 blocks) is difficult to accomplish. And neither is such a short _from-scratch_ deployment cycle a goal of our production environment.

Passed E2E tests.

As an aside, the session length on Polkadot is 4 hours, and 1 hour on Kusama.