### PR TITLE
Remove unsafe RPC calls

### DIFF
--- a/relayer/chain/relaychain/connection.go
+++ b/relayer/chain/relaychain/connection.go
@@ -127,6 +127,12 @@ func (co *Connection) FetchParaHeads(blockHash types.Hash) (map[uint32]ParaHead,
 		return nil, err
 	}
 
+	co.log.WithFields(logrus.Fields{
+		"numKeys": len(keys),
+		"storageKeyPrefix": fmt.Sprintf("%#x", keyPrefix),
+		"block": blockHash.Hex(),
+	}).Debug("Found keys for Paras.Heads storage map")
+
 	changeSets, err := co.GetAPI().RPC.State.QueryStorageAt(keys, blockHash)
 	if err != nil {
 		co.log.WithError(err).Error("Failed to get all parachain headers")
@@ -154,6 +160,12 @@ func (co *Connection) FetchParaHeads(blockHash types.Hash) (map[uint32]ParaHead,
 				co.log.WithError(err).Error("Failed to decode HeadData wrapper")
 				return nil, err
 			}
+
+			co.log.WithFields(logrus.Fields{
+				"ParaID": paraID,
+				"LeafIndex": index,
+				"HeadData": fmt.Sprintf("%#x", headData),
+			}).Debug("Processed storage key for head in Paras.Heads")
 
 			heads[paraID] = ParaHead{
 				LeafIndex: index,

--- a/relayer/chain/relaychain/connection_test.go
+++ b/relayer/chain/relaychain/connection_test.go
@@ -5,14 +5,10 @@ package relaychain_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/snowfork/go-substrate-rpc-client/v3/scale"
-	"github.com/snowfork/go-substrate-rpc-client/v3/types"
-	"github.com/snowfork/go-substrate-rpc-client/v3/xxhash"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/relaychain"
 )
 
@@ -26,71 +22,3 @@ func TestConnect(t *testing.T) {
 	}
 	conn.Close()
 }
-
-
-type OptionHeadData struct {
-	Option
-	Value types.Bytes
-}
-
-func (o *OptionHeadData) Decode(decoder scale.Decoder) error {
-	return decoder.DecodeOption(&o.hasValue, &o.Value)
-}
-
-type Option struct {
-	hasValue bool
-}
-
-func (o Option) IsNone() bool {
-	return !o.hasValue
-}
-
-func (o Option) IsSome() bool {
-	return o.hasValue
-}
-
-// Creates a storage key prefix for a map
-func CreateStorageKeyPrefix(prefix, method string) []byte {
-	return append(xxhash.New128([]byte(prefix)).Sum(nil), xxhash.New128([]byte(method)).Sum(nil)...)
-}
-
-func TestGetAllParaheadsWithOwn(t *testing.T) {
-	log := logrus.NewEntry(logrus.New())
-
-	conn := relaychain.NewConnection("wss://polkadot-rpc.snowbridge.network", log)
-	err := conn.Connect(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	conn.Close()
-
-	blockHash, err := conn.GetAPI().RPC.Chain.GetFinalizedHead()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageKeyPrefix := CreateStorageKeyPrefix("Paras", "Heads")
-	fmt.Printf("Prefix: %#x\n", storageKeyPrefix)
-
-	storageKeys, err := conn.GetAPI().RPC.State.GetKeys(storageKeyPrefix, blockHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, key := range storageKeys {
-		fmt.Printf("Key: %#x\n", key)
-	}
-
-	heads := []OptionHeadData{}
-
-
-	ok, err := conn.GetAPI().RPC.State.GetStorageLatest(storageKeys[0], &heads)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !ok {
-		t.Fatal(ok)
-	}
-}
-

--- a/relayer/chain/relaychain/connection_test.go
+++ b/relayer/chain/relaychain/connection_test.go
@@ -5,10 +5,14 @@ package relaychain_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/snowfork/go-substrate-rpc-client/v3/scale"
+	"github.com/snowfork/go-substrate-rpc-client/v3/types"
+	"github.com/snowfork/go-substrate-rpc-client/v3/xxhash"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/relaychain"
 )
 
@@ -22,3 +26,71 @@ func TestConnect(t *testing.T) {
 	}
 	conn.Close()
 }
+
+
+type OptionHeadData struct {
+	Option
+	Value types.Bytes
+}
+
+func (o *OptionHeadData) Decode(decoder scale.Decoder) error {
+	return decoder.DecodeOption(&o.hasValue, &o.Value)
+}
+
+type Option struct {
+	hasValue bool
+}
+
+func (o Option) IsNone() bool {
+	return !o.hasValue
+}
+
+func (o Option) IsSome() bool {
+	return o.hasValue
+}
+
+// Creates a storage key prefix for a map
+func CreateStorageKeyPrefix(prefix, method string) []byte {
+	return append(xxhash.New128([]byte(prefix)).Sum(nil), xxhash.New128([]byte(method)).Sum(nil)...)
+}
+
+func TestGetAllParaheadsWithOwn(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+
+	conn := relaychain.NewConnection("wss://polkadot-rpc.snowbridge.network", log)
+	err := conn.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+
+	blockHash, err := conn.GetAPI().RPC.Chain.GetFinalizedHead()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storageKeyPrefix := CreateStorageKeyPrefix("Paras", "Heads")
+	fmt.Printf("Prefix: %#x\n", storageKeyPrefix)
+
+	storageKeys, err := conn.GetAPI().RPC.State.GetKeys(storageKeyPrefix, blockHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range storageKeys {
+		fmt.Printf("Key: %#x\n", key)
+	}
+
+	heads := []OptionHeadData{}
+
+
+	ok, err := conn.GetAPI().RPC.State.GetStorageLatest(storageKeys[0], &heads)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ok {
+		t.Fatal(ok)
+	}
+}
+

--- a/relayer/cmd/subscribe_beefy.go
+++ b/relayer/cmd/subscribe_beefy.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -13,8 +12,6 @@ import (
 	"github.com/snowfork/polkadot-ethereum/relayer/workers/beefyrelayer/store"
 	"github.com/spf13/cobra"
 )
-
-const OUR_PARACHAIN_ID = 200
 
 func subBeefyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -102,9 +99,16 @@ func subBeefyJustifications(ctx context.Context, paraID uint32) error {
 			}
 			log.WithField("blockHash", nextBlockHash.Hex()).Info("Got blockhash")
 			GetMMRLeafForBlock(uint64(blockNumber), nextBlockHash, relaychainConn)
-			allParaheads, ourParahead := GetAllParaheads(nextBlockHash, relaychainConn, paraID)
+			heads, err := fetchParaHeads(relaychainConn, nextBlockHash)
+
+			var ourParahead types.Header
+			if err := types.DecodeFromBytes(heads[paraID], &ourParahead); err != nil {
+				log.WithError(err).Error("Failed to decode Header")
+				return err
+			}
+
 			log.WithFields(logrus.Fields{
-				"allParaheads": allParaheads,
+				"allParaheads": heads,
 				"ourParahead":  ourParahead,
 			}).Info("Got all para heads")
 
@@ -114,81 +118,53 @@ func subBeefyJustifications(ctx context.Context, paraID uint32) error {
 	}
 }
 
-func GetAllParaheads(blockHash types.Hash, relaychainConn *relaychain.Connection, ourParachainID uint32) ([]types.Header, types.Header) {
-	none := types.NewOptionU32Empty()
-	encoded, err := types.EncodeToBytes(none)
-	if err != nil {
-		log.WithError(err).Error("Error")
-	}
+// Copied over from relaychain.Connection
+func fetchParaHeads(co *relaychain.Connection, blockHash types.Hash) (map[uint32][]byte, error) {
 
-	baseParaHeadsStorageKey, err := types.CreateStorageKey(
-		relaychainConn.GetMetadata(),
-		"Paras",
-		"Heads", encoded, nil)
-	if err != nil {
-		log.WithError(err).Error("Failed to create parachain header storage key")
-	}
+	keyPrefix := types.CreateStorageKeyPrefix("Paras", "Heads")
 
-	//TODO fix this manual slice.
-	// The above types.CreateStorageKey does not give the same base key as polkadotjs needs for getKeys.
-	// It has some extra bytes.
-	// maybe from the none u32 in golang being wrong, or maybe slightly off CreateStorageKey call? we slice it
-	// here as a hack.
-	actualBaseParaHeadsStorageKey := baseParaHeadsStorageKey[:32]
-	log.WithField("actualBaseParaHeadsStorageKey", actualBaseParaHeadsStorageKey.Hex()).Info("actualBaseParaHeadsStorageKey")
-
-	keysResponse, err := relaychainConn.GetAPI().RPC.State.GetKeys(actualBaseParaHeadsStorageKey, blockHash)
+	keys, err := co.GetAPI().RPC.State.GetKeys(keyPrefix, blockHash)
 	if err != nil {
 		log.WithError(err).Error("Failed to get all parachain keys")
+		return nil, err
 	}
 
-	headersResponse, err := relaychainConn.GetAPI().RPC.State.QueryStorage(keysResponse, blockHash, blockHash)
+	changeSets, err := co.GetAPI().RPC.State.QueryStorageAt(keys, blockHash)
 	if err != nil {
 		log.WithError(err).Error("Failed to get all parachain headers")
+		return nil, err
 	}
 
-	log.Info("Got all parachain headers")
-	var headers []types.Header
-	var ourParachainHeader types.Header
-	for _, headerResponse := range headersResponse {
-		for _, change := range headerResponse.Changes {
+	heads := make(map[uint32][]byte)
 
-			// TODO fix this manual slice with a proper type decode. only the last few bytes are for the ParaId,
-			// not sure what the early ones are for.
-			key := change.StorageKey[40:]
-			var parachainID types.U32
-			if err := types.DecodeFromBytes(key, &parachainID); err != nil {
+	for _, changeSet := range changeSets {
+		for _, change := range changeSet.Changes {
+			if change.StorageData.IsNone() {
+				continue
+			}
+
+			var paraID uint32
+
+			if err := types.DecodeFromBytes(change.StorageKey[40:], &paraID); err != nil {
 				log.WithError(err).Error("Failed to decode parachain ID")
+				return nil, err
 			}
 
-			log.WithField("parachainId", parachainID).Info("Decoding header for parachain")
-			var encodableOpaqueHeader types.Bytes
-			if err := types.DecodeFromBytes(change.StorageData, &encodableOpaqueHeader); err != nil {
-				log.WithError(err).Error("Failed to decode MMREncodableOpaqueLeaf")
+			_, headDataWrapped := change.StorageData.Unwrap()
+
+			var headData types.Bytes
+			if err := types.DecodeFromBytes(headDataWrapped, &headData); err != nil {
+				log.WithError(err).Error("Failed to decode HeadData wrapper")
+				return nil, err
 			}
 
-			var header types.Header
-			if err := types.DecodeFromBytes(encodableOpaqueHeader, &header); err != nil {
-				log.WithError(err).Error("Failed to decode Header")
-			}
-			log.WithFields(logrus.Fields{
-				"headerBytes":           fmt.Sprintf("%#x", encodableOpaqueHeader),
-				"header.ParentHash":     header.ParentHash.Hex(),
-				"header.Number":         header.Number,
-				"header.StateRoot":      header.StateRoot.Hex(),
-				"header.ExtrinsicsRoot": header.ExtrinsicsRoot.Hex(),
-				"header.Digest":         header.Digest,
-				"parachainId":           parachainID,
-			}).Info("Decoded header for parachain")
-			headers = append(headers, header)
-
-			if parachainID == types.U32(ourParachainID) {
-				ourParachainHeader = header
-			}
+			heads[paraID] = headData
 		}
 	}
-	return headers, ourParachainHeader
+
+	return heads, nil
 }
+
 
 func GetMMRLeafForBlock(blockNumber uint64, blockHash types.Hash, relaychainConn *relaychain.Connection) {
 	log.WithFields(logrus.Fields{

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79
-	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93
+	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79
-	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3
+	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79
-	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d
+	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/wealdtech/go-merkletree v1.0.0
-	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -543,10 +543,6 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79 h1:GD0O2pb4qpC4n4ljsNri3snVljfxxPf6Q+k55xbFJVk=
 github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79/go.mod h1:Yy1jPDuUtVPG1b3XnRGiEHWPs09Yd5UphOTqPhN9XPU=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3 h1:sqmImqfcJVjDXKAJZSiSBVqg8DCrNFnLG0eaFxWJEfA=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93 h1:LErNhNI++ZE5yA4VdCWQeYhDyRp1LUG32FrEdHK5HTc=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d h1:ydZZ2MHhFEfLYLcfg+9QW4OLhDX4SDN5e872+B5+J+I=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -545,6 +545,8 @@ github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79 h1:GD0O2pb4qp
 github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79/go.mod h1:Yy1jPDuUtVPG1b3XnRGiEHWPs09Yd5UphOTqPhN9XPU=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3 h1:sqmImqfcJVjDXKAJZSiSBVqg8DCrNFnLG0eaFxWJEfA=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93 h1:LErNhNI++ZE5yA4VdCWQeYhDyRp1LUG32FrEdHK5HTc=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -543,8 +543,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79 h1:GD0O2pb4qpC4n4ljsNri3snVljfxxPf6Q+k55xbFJVk=
 github.com/snowfork/ethashproof v0.0.0-20210708164253-a74e2d12ad79/go.mod h1:Yy1jPDuUtVPG1b3XnRGiEHWPs09Yd5UphOTqPhN9XPU=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d h1:ydZZ2MHhFEfLYLcfg+9QW4OLhDX4SDN5e872+B5+J+I=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4 h1:5Rj2Znuh40xVxngBR7b2MNEG/0+u8S13sVSeN18vxeE=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -547,6 +547,8 @@ github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3 h1:sqmImqfcJVjDXKAJZSiSBVq
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.3/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93 h1:LErNhNI++ZE5yA4VdCWQeYhDyRp1LUG32FrEdHK5HTc=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724125305-3ecbba823f93/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d h1:ydZZ2MHhFEfLYLcfg+9QW4OLhDX4SDN5e872+B5+J+I=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4-0.20210724130822-b34f07e6ef2d/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/relayer/workers/beefyrelayer/beefy-relaychain-listener.go
+++ b/relayer/workers/beefyrelayer/beefy-relaychain-listener.go
@@ -3,6 +3,7 @@ package beefyrelayer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -136,31 +137,20 @@ func (li *BeefyRelaychainListener) getBeefyAuthorities(blockNumber uint64) ([]co
 		return nil, err
 	}
 
-	meta, err := li.relaychainConn.GetAPI().RPC.State.GetMetadataLatest()
+	storageKey, err := types.CreateStorageKey(li.relaychainConn.GetMetadata(), "Beefy", "Authorities", nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	storageKey, err := types.CreateStorageKey(meta, "Beefy", "Authorities", nil, nil)
+	var authorities substrate.Authorities
+
+	ok, err := li.relaychainConn.GetAPI().RPC.State.GetStorage(storageKey, &authorities, blockHash)
 	if err != nil {
 		return nil, err
 	}
 
-	storageChangeSet, err := li.relaychainConn.GetAPI().RPC.State.QueryStorage([]types.StorageKey{storageKey}, blockHash, blockHash)
-	if err != nil {
-		return nil, err
-	}
-
-	authorities := substrate.Authorities{}
-	for _, storageChange := range storageChangeSet {
-		for _, keyValueOption := range storageChange.Changes {
-
-			err = types.DecodeFromHexString(keyValueOption.StorageData.Hex(), &authorities)
-			if err != nil {
-				return nil, err
-			}
-
-		}
+	if !ok {
+		return nil, fmt.Errorf("Beefy authorities not found")
 	}
 
 	// Convert from beefy authorities to ethereum addresses

--- a/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
+++ b/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
@@ -88,6 +88,15 @@ func (li *BeefyListener) Start(ctx context.Context, eg *errgroup.Group) error {
 			return err
 		}
 
+		li.log.WithFields(logrus.Fields{
+			"header.ParentHash":     paraHead.ParentHash.Hex(),
+			"header.Number":         paraHead.Number,
+			"header.StateRoot":      paraHead.StateRoot.Hex(),
+			"header.ExtrinsicsRoot": paraHead.ExtrinsicsRoot.Hex(),
+			"header.Digest":         paraHead.Digest,
+			"parachainId":           paraID,
+		}).Info("Fetched finalized header for parachain")
+
 		paraBlockNumber := uint64(paraHead.Number)
 
 		paraBlockHash, err := li.parachainConnection.GetAPI().RPC.Chain.GetBlockHash(paraBlockNumber)

--- a/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
+++ b/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
@@ -76,26 +76,27 @@ func (li *BeefyListener) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	eg.Go(func() error {
 
-		verifiedBeefyBlockNumber, verifiedBeefyBlockHash, err := li.fetchLatestVerifiedBeefyBlock(ctx)
+		relayBlockNumber, relayBlockHash, err := li.fetchLatestVerifiedBeefyBlock(ctx)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get latest relay chain block number and hash")
 			return err
 		}
 
-		verifiedParaBlockNumber, err := li.relaychainConn.FetchLatestFinalizedParaBlockNumber(
-			verifiedBeefyBlockHash, paraID)
+		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(relayBlockHash, paraID)
 		if err != nil {
-			li.log.WithError(err).Error("Failed to get latest finalized para block number from relay chain")
+			li.log.WithError(err).Error("Failed to get finalized para head from relay chain")
 			return err
 		}
 
-		verifiedParaBlockHash, err := li.parachainConnection.GetAPI().RPC.Chain.GetBlockHash(verifiedParaBlockNumber)
+		paraBlockNumber := uint64(paraHead.Number)
+
+		paraBlockHash, err := li.parachainConnection.GetAPI().RPC.Chain.GetBlockHash(paraBlockNumber)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get latest finalized para block hash")
 			return err
 		}
 
-		messagePackages, err := li.buildMissedMessagePackages(ctx, verifiedBeefyBlockNumber, verifiedParaBlockNumber, verifiedParaBlockHash)
+		messagePackages, err := li.buildMissedMessagePackages(ctx, relayBlockNumber, paraBlockNumber, paraBlockHash)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to build missed message package")
 			return err
@@ -174,19 +175,22 @@ func (li *BeefyListener) processBeefyLightClientEvents(ctx context.Context, even
 		}
 		li.log.WithField("relayBlockHash", relayBlockHash.Hex()).Info("Got relay chain blockhash")
 
-		verifiedParaBlockNumber, err := li.relaychainConn.FetchLatestFinalizedParaBlockNumber(
-			relayBlockHash, li.paraID)
+		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(relayBlockHash, li.paraID)
 		if err != nil {
-			li.log.WithError(err).Error("Failed to get latest finalized para block number from relay chain")
+			li.log.WithError(err).Error("Failed to get finalized para head from relay chain")
 			return err
 		}
-		verifiedParaBlockHash, err := li.parachainConnection.GetAPI().RPC.Chain.GetBlockHash(verifiedParaBlockNumber)
+
+		paraBlockNumber := uint64(paraHead.Number)
+
+
+		paraBlockHash, err := li.parachainConnection.GetAPI().RPC.Chain.GetBlockHash(paraBlockNumber)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get latest finalized para block hash")
 			return err
 		}
 
-		messagePackages, err := li.buildMissedMessagePackages(ctx, beefyBlockNumber, verifiedParaBlockNumber, verifiedParaBlockHash)
+		messagePackages, err := li.buildMissedMessagePackages(ctx, beefyBlockNumber, paraBlockNumber, paraBlockHash)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to build missed message packages")
 			return err

--- a/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
+++ b/relayer/workers/parachaincommitmentrelayer/beefy-listener.go
@@ -76,13 +76,13 @@ func (li *BeefyListener) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	eg.Go(func() error {
 
-		relayBlockNumber, relayBlockHash, err := li.fetchLatestVerifiedBeefyBlock(ctx)
+		beefyBlockNumber, beefyBlockHash, err := li.fetchLatestVerifiedBeefyBlock(ctx)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get latest relay chain block number and hash")
 			return err
 		}
 
-		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(relayBlockHash, paraID)
+		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(beefyBlockHash, paraID)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get finalized para head from relay chain")
 			return err
@@ -96,7 +96,7 @@ func (li *BeefyListener) Start(ctx context.Context, eg *errgroup.Group) error {
 			return err
 		}
 
-		messagePackages, err := li.buildMissedMessagePackages(ctx, relayBlockNumber, paraBlockNumber, paraBlockHash)
+		messagePackages, err := li.buildMissedMessagePackages(ctx, beefyBlockNumber, paraBlockNumber, paraBlockHash)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to build missed message package")
 			return err
@@ -168,14 +168,14 @@ func (li *BeefyListener) processBeefyLightClientEvents(ctx context.Context, even
 		}).Info("Witnessed a new MMRRoot event")
 
 		li.log.WithField("beefyBlockNumber", beefyBlockNumber).Info("Getting hash for relay chain block")
-		relayBlockHash, err := li.relaychainConn.GetAPI().RPC.Chain.GetBlockHash(uint64(beefyBlockNumber))
+		beefyBlockHash, err := li.relaychainConn.GetAPI().RPC.Chain.GetBlockHash(uint64(beefyBlockNumber))
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get block hash")
 			return err
 		}
-		li.log.WithField("relayBlockHash", relayBlockHash.Hex()).Info("Got relay chain blockhash")
+		li.log.WithField("beefyBlockHash", beefyBlockHash.Hex()).Info("Got relay chain blockhash")
 
-		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(relayBlockHash, li.paraID)
+		paraHead, err := li.relaychainConn.FetchFinalizedParaHead(beefyBlockHash, li.paraID)
 		if err != nil {
 			li.log.WithError(err).Error("Failed to get finalized para head from relay chain")
 			return err

--- a/relayer/workers/parachaincommitmentrelayer/catchup.go
+++ b/relayer/workers/parachaincommitmentrelayer/catchup.go
@@ -178,20 +178,20 @@ func (li *BeefyListener) parablocksWithProofs(blocks []ParaBlockWithDigest, late
 				return nil, err
 			}
 
-			li.log.WithFields(logrus.Fields{
-				"header.ParentHash":     header.ParentHash.Hex(),
-				"header.Number":         header.Number,
-				"header.StateRoot":      header.StateRoot.Hex(),
-				"header.ExtrinsicsRoot": header.ExtrinsicsRoot.Hex(),
-				"header.Digest":         header.Digest,
-				"parachainId":           li.paraID,
-			}).Info("Decoded header for parachain")
-
 			allParaHeads = li.relaychainConn.AsProofInput(heads)
 			ownParaHead = header
 			ownParaHeadLeafIndex = heads[li.paraID].LeafIndex
 
 			relayChainBlockNumber--
+		}
+
+		li.log.Debug("Have inputs for proof generation")
+		for i, v := range allParaHeads {
+			li.log.WithFields(logrus.Fields{
+				"LeafIndex": i,
+				"HeadData": fmt.Sprintf("%#x", v),
+				"IsSnowbridgePara": i == ownParaHeadLeafIndex,
+			}).Debug("Head data")
 		}
 
 		// Note - relayChainBlockNumber will be one less than the block number discovered

--- a/relayer/workers/parachaincommitmentrelayer/catchup.go
+++ b/relayer/workers/parachaincommitmentrelayer/catchup.go
@@ -173,12 +173,7 @@ func (li *BeefyListener) parablocksWithProofs(blocks []ParaBlockWithDigest, late
 				return nil, err
 			}
 
-			tmp := make([]types.Bytes, 0, len(heads))
-			for _, v := range heads {
-				tmp = append(tmp, v.Data)
-			}
-
-			allParaHeads = tmp
+			allParaHeads = li.relaychainConn.AsProofInput(heads)
 			ownParaHead = header
 			ownParaHeadLeafIndex = heads[li.paraID].LeafIndex
 

--- a/relayer/workers/parachaincommitmentrelayer/catchup.go
+++ b/relayer/workers/parachaincommitmentrelayer/catchup.go
@@ -183,9 +183,6 @@ func (li *BeefyListener) parablocksWithProofs(blocks []ParaBlockWithDigest, late
 			relayChainBlockNumber--
 		}
 
-		fmt.Printf("allParaHeads: %#v\n", allParaHeads)
-		fmt.Printf("ownParaHead: %#v\n", ownParaHead)
-
 		// Note - relayChainBlockNumber will be one less than the block number discovered
 		// due to the decrement at the end of the loop, but the mmr leaves are 0 indexed whereas
 		// block numbers start from 1, so we actually do want to query for the leaf at

--- a/relayer/workers/parachaincommitmentrelayer/catchup.go
+++ b/relayer/workers/parachaincommitmentrelayer/catchup.go
@@ -156,12 +156,17 @@ func (li *BeefyListener) parablocksWithProofs(blocks []ParaBlockWithDigest, late
 				li.log.WithError(err).Error("Failed to get block hash")
 				return nil, err
 			}
+
 			li.log.WithField("relayBlockHash", relayBlockHash.Hex()).Info("Got relay chain blockhash")
 			heads, err := li.relaychainConn.FetchParaHeads(relayBlockHash)
 			if err != nil {
 				li.log.WithError(err).Error("Failed to get paraheads")
 				return nil, err
 			}
+
+			li.log.WithFields(logrus.Fields{
+				"count": len(heads),
+			}).Info("Fetched para heads")
 
 			if _, ok := heads[li.paraID]; !ok {
 				return nil, fmt.Errorf("chain is not a registered parachain")
@@ -172,6 +177,15 @@ func (li *BeefyListener) parablocksWithProofs(blocks []ParaBlockWithDigest, late
 				li.log.WithError(err).Error("Failed to decode Header")
 				return nil, err
 			}
+
+			li.log.WithFields(logrus.Fields{
+				"header.ParentHash":     header.ParentHash.Hex(),
+				"header.Number":         header.Number,
+				"header.StateRoot":      header.StateRoot.Hex(),
+				"header.ExtrinsicsRoot": header.ExtrinsicsRoot.Hex(),
+				"header.Digest":         header.Digest,
+				"parachainId":           li.paraID,
+			}).Info("Decoded header for parachain")
 
 			allParaHeads = li.relaychainConn.AsProofInput(heads)
 			ownParaHead = header


### PR DESCRIPTION
This is necessary for our relay to be interoperable with our staging testnet, Kusama, and Polkadot. The beefy errors we saw in our staging env earlier this week are are directly related to this.

We can't use the `state_queryStorage` RPC in production. Its marked as unsafe and is blocked on public networks, as it can easily be exploited to kill a node. Instead we need to use `state_queryStorageAt`, which will only retrieve changes for a single block. I've added support for this newer RPC in GSRPC (see companion PR below).

The affected code paths involve fetching beefy authorities and parachain heads. Some of this code I've cleaned up, and pushed logic down into GSRPC where appropriate.

Companion PR for GSRPC: https://github.com/Snowfork/go-substrate-rpc-client/pull/13

E2E tests are passing