### PR TITLE
Update JS type for StoredHeader

### DIFF
--- a/types/src/v1.ts
+++ b/types/src/v1.ts
@@ -43,7 +43,8 @@ export const types: RegistryTypes = {
     StoredHeader: {
       submitter: "Option<AccountId>",
       header: "EthereumHeader",
-      totalDifficulty: "U256"
+      totalDifficulty: "U256",
+      finalized: "bool"
     },
     EthashProofData: {
       dagNodes: "[H512; 2]",


### PR DESCRIPTION
Necessary in order to query and troubleshoot headers in the PolkadotJS ui.