### PR TITLE
Update ethashproof dependency

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
-	github.com/snowfork/ethashproof v0.0.0-20210727164350-02f2b5741c50
+	github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454
 	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -545,8 +545,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snowfork/ethashproof v0.0.0-20210727164350-02f2b5741c50 h1:m2QK7nGXxGHE7lp8EATWvlyBRZmhclq+hWmFb+3oqsE=
-github.com/snowfork/ethashproof v0.0.0-20210727164350-02f2b5741c50/go.mod h1:C5irsRKMm2oEfPRjAJlvPKHtRZrXhcWLS0Z2IMXneSE=
+github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454 h1:aKd0iBLZGBzMAjhOQ969tmzgh7/2FZxL5qvJ/+lHZRs=
+github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454/go.mod h1:C5irsRKMm2oEfPRjAJlvPKHtRZrXhcWLS0Z2IMXneSE=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4 h1:5Rj2Znuh40xVxngBR7b2MNEG/0+u8S13sVSeN18vxeE=
 github.com/snowfork/go-substrate-rpc-client/v3 v3.0.4/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
This is a followup to #475 to update deps since https://github.com/Snowfork/ethashproof/pull/4 has been merged.