### PR TITLE
Eip 2718 fix

### DIFF
--- a/relayer/chain/ethereum/header_cache_state.go
+++ b/relayer/chain/ethereum/header_cache_state.go
@@ -205,16 +205,6 @@ func (s *HeaderCacheState) GetReceiptTrie(ctx context.Context, hash gethCommon.H
 		return nil, err
 	}
 
-	if hash.Hex() == "0xeff468b3d9328c04182c37f27c0548e76b65ecaf24aa85d0f7cf2fdac8117931" {
-		fmt.Println("block, receipts")
-		fmt.Println(block, receipts)
-		fmt.Println("block.ReceiptHash().Hex()", block.ReceiptHash().Hex())
-		fmt.Println("block.Transactions()", block.Transactions())
-		fmt.Println("block.Transactions().Len()", block.Transactions().Len())
-		fmt.Println("receipts[0]", receipts[0])
-		fmt.Println("receipts[1]", receipts[1])
-	}
-
 	receiptTrie, err = MakeTrie(receipts)
 	if err != nil {
 		return nil, err

--- a/relayer/chain/ethereum/header_cache_state.go
+++ b/relayer/chain/ethereum/header_cache_state.go
@@ -100,8 +100,8 @@ type EthashproofCacheLoader interface {
 	MakeCache(epoch uint64) (*ethashproof.DatasetMerkleTreeCache, error)
 }
 
-type DefaultCacheLoader struct{
-	DataDir string
+type DefaultCacheLoader struct {
+	DataDir  string
 	CacheDir string
 }
 
@@ -205,13 +205,23 @@ func (s *HeaderCacheState) GetReceiptTrie(ctx context.Context, hash gethCommon.H
 		return nil, err
 	}
 
+	if hash.Hex() == "0xeff468b3d9328c04182c37f27c0548e76b65ecaf24aa85d0f7cf2fdac8117931" {
+		fmt.Println("block, receipts")
+		fmt.Println(block, receipts)
+		fmt.Println("block.ReceiptHash().Hex()", block.ReceiptHash().Hex())
+		fmt.Println("block.Transactions()", block.Transactions())
+		fmt.Println("block.Transactions().Len()", block.Transactions().Len())
+		fmt.Println("receipts[0]", receipts[0])
+		fmt.Println("receipts[1]", receipts[1])
+	}
+
 	receiptTrie, err = MakeTrie(receipts)
 	if err != nil {
 		return nil, err
 	}
 
 	if receiptTrie.Hash() != block.ReceiptHash() {
-		return nil, fmt.Errorf("Receipt trie does not match block receipt hash")
+		return nil, fmt.Errorf("receipt trie does not match block receipt hash")
 	}
 
 	s.blockCache.Insert(block, receiptTrie)

--- a/relayer/chain/ethereum/trie.go
+++ b/relayer/chain/ethereum/trie.go
@@ -2,26 +2,65 @@ package ethereum
 
 import (
 	"bytes"
+	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
 func MakeTrie(items types.Receipts) (*trie.Trie, error) {
-	keyBuf := new(bytes.Buffer)
+
 	trie := new(trie.Trie)
 
-	for i := 0; i < items.Len(); i++ {
-		keyBuf.Reset()
-		rlp.Encode(keyBuf, uint(i))
+	receiptTrie := CreateTrie(types.Receipts(items), trie)
 
-		value, err := rlp.EncodeToBytes(items[i])
-		if err != nil {
-			return nil, err
-		}
+	return receiptTrie, nil
+}
 
-		trie.Update(keyBuf.Bytes(), value)
+// Note - all code below is mostly copied from:
+// https://github.com/ethereum/go-ethereum/blob/85afdeef37e17bffd9d098e86312c569995705e0/core/types/hashing.go#L87
+
+// CreateTrie creates the tree hashes of transactions and receipts in a block header.
+func CreateTrie(list types.DerivableList, trie *trie.Trie) *trie.Trie {
+	trie.Reset()
+
+	valueBuf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(valueBuf)
+
+	// StackTrie requires values to be inserted in increasing hash order, which is not the
+	// order that `list` provides hashes in. This insertion sequence ensures that the
+	// order is correct.
+	var indexBuf []byte
+	for i := 1; i < list.Len() && i <= 0x7f; i++ {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
+		value := encodeForDerive(list, i, valueBuf)
+		trie.Update(indexBuf, value)
 	}
-	return trie, nil
+	if list.Len() > 0 {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], 0)
+		value := encodeForDerive(list, 0, valueBuf)
+		trie.Update(indexBuf, value)
+	}
+	for i := 0x80; i < list.Len(); i++ {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
+		value := encodeForDerive(list, i, valueBuf)
+		trie.Update(indexBuf, value)
+	}
+	return trie
+}
+
+func encodeForDerive(list types.DerivableList, i int, buf *bytes.Buffer) []byte {
+	buf.Reset()
+	list.EncodeIndex(i, buf)
+	// It's really unfortunate that we need to do perform this copy.
+	// StackTrie holds onto the values until Hash is called, so the values
+	// written to it must not alias.
+	return common.CopyBytes(buf.Bytes())
+}
+
+// deriveBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
+var encodeBufferPool = sync.Pool{
+	New: func() interface{} { return new(bytes.Buffer) },
 }


### PR DESCRIPTION
Eip 2718 changed the transaction receipt encoding with multiple types of transaction receipts, so the trie generation needs to accomodate those types. (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2718.md#receipts)

I noticed this when the eth-relayer crashed on a block that had the new kind of eip-2718 transaction in it. After applying this fix, the relayer resumed and continued past that block gracefully, so I'm assuming this fix is sufficient and works due to that.

all e2e tests pass