### PR TITLE
add enumerable test ERC721

### DIFF
--- a/ethereum/contracts/test/TestToken721Enumerable.sol
+++ b/ethereum/contracts/test/TestToken721Enumerable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+
+contract TestToken721Enumerable is ERC721Enumerable {
+    constructor(string memory _name, string memory _symbol)
+        ERC721(_name, _symbol)
+    {}
+
+    function mint(address to, uint256 tokenId) public {
+        _mint(to, tokenId);
+    }
+}

--- a/ethereum/deploy/12-erc20-app.ts
+++ b/ethereum/deploy/12-erc20-app.ts
@@ -47,10 +47,4 @@ module.exports = async ({
     log: true,
   });
 
-  await deployments.deploy("TestToken721Enumerable", {
-    from: deployer,
-    args: ["Test Enum", "TESTE"],
-    log: true,
-  });
-
 };

--- a/ethereum/deploy/12-erc20-app.ts
+++ b/ethereum/deploy/12-erc20-app.ts
@@ -1,11 +1,11 @@
 require("dotenv").config();
 
-import {HardhatRuntimeEnvironment} from "hardhat/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 module.exports = async ({
-    deployments,
-    getUnnamedAccounts,
-    network,
+  deployments,
+  getUnnamedAccounts,
+  network,
 }: HardhatRuntimeEnvironment) => {
   let [deployer] = await getUnnamedAccounts();
 
@@ -24,7 +24,7 @@ module.exports = async ({
 
   await deployments.deploy("ERC20App", {
     from: deployer,
-    args:[
+    args: [
       {
         inbound: channels.basic.inbound.address,
         outbound: channels.basic.outbound.address,
@@ -35,7 +35,7 @@ module.exports = async ({
       }
     ],
     libraries: {
-        ScaleCodec: scaleCodecLibrary.address
+      ScaleCodec: scaleCodecLibrary.address
     },
     log: true,
     autoMine: true,
@@ -43,7 +43,13 @@ module.exports = async ({
 
   await deployments.deploy("TestToken", {
     from: deployer,
-    args:["Test Token", "TEST"],
+    args: ["Test Token", "TEST"],
+    log: true,
+  });
+
+  await deployments.deploy("TestToken721Enumerable", {
+    from: deployer,
+    args: ["Test Enum", "TESTE"],
     log: true,
   });
 

--- a/ethereum/deploy/13-erc721-app.ts
+++ b/ethereum/deploy/13-erc721-app.ts
@@ -1,5 +1,6 @@
 require("dotenv").config();
 
+import { ethers } from "hardhat";
 import {HardhatRuntimeEnvironment} from "hardhat/types";
 
 module.exports = async ({
@@ -7,7 +8,7 @@ module.exports = async ({
     getUnnamedAccounts,
     network,
 }: HardhatRuntimeEnvironment) => {
-  let [deployer] = await getUnnamedAccounts();
+  let [deployer, developer] = await getUnnamedAccounts();
 
   let channels = {
     basic: {
@@ -54,4 +55,13 @@ module.exports = async ({
     log: true,
   });
 
+  const nft = await deployments.get('TestToken721Enumerable');
+  const TestNft = await ethers.getContractAt('TestToken721Enumerable', nft.address);
+  const signer = await ethers.getSigner(deployer);
+  const NftWithSigner = await TestNft.connect(signer);
+
+  for (let i = 0; i < 10; i++) {
+    let tx = await NftWithSigner.mint(developer, Date.now().toString());
+    await tx.wait();
+  }
 };

--- a/ethereum/deploy/13-erc721-app.ts
+++ b/ethereum/deploy/13-erc721-app.ts
@@ -48,4 +48,10 @@ module.exports = async ({
     autoMine: true,
   });
 
+  await deployments.deploy("TestToken721Enumerable", {
+    from: deployer,
+    args: ["Test Enum", "TESTE"],
+    log: true,
+  });
+
 };

--- a/ethereum/deploy/13-erc721-app.ts
+++ b/ethereum/deploy/13-erc721-app.ts
@@ -55,13 +55,5 @@ module.exports = async ({
     log: true,
   });
 
-  const nft = await deployments.get('TestToken721Enumerable');
-  const TestNft = await ethers.getContractAt('TestToken721Enumerable', nft.address);
-  const signer = await ethers.getSigner(deployer);
-  const NftWithSigner = await TestNft.connect(signer);
-
-  for (let i = 0; i < 10; i++) {
-    let tx = await NftWithSigner.mint(developer, Date.now().toString());
-    await tx.wait();
-  }
+  
 };

--- a/ethereum/scripts/mint-nft.ts
+++ b/ethereum/scripts/mint-nft.ts
@@ -1,0 +1,20 @@
+const hre = require("hardhat");
+
+async function main() {
+  const {deployments, ethers} = hre;
+  const [deployer, developer] = await hre.getUnnamedAccounts();
+
+  const nft = await deployments.get('TestToken721Enumerable');
+  const TestNft = await ethers.getContractAt('TestToken721Enumerable', nft.address);
+
+  for (let i = 0; i < 10; i++) {
+    await TestNft.mint(developer, Date.now().toString());
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
We wanted to test transfers though the UI with multiple different contracts so this deploys another ERC721 contract. This contract also implements IERC721Enumerable to enable to UI to display all the tokens owned by the user 