### PR TITLE
Fix killing edge case in start-services

### DIFF
--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -201,7 +201,7 @@ cleanup() {
     kill -- -"$(ps -o pgid:1= $$)"
 }
 
-trap cleanup SIGINT SIGTERM
+trap cleanup SIGINT SIGTERM EXIT
 
 start_geth
 deploy_contracts


### PR DESCRIPTION
Fixed process management regression in the start-services script.

When a command in the script fails, the script will exit since it has `set -o errexit` enabled. So we need to trap on `EXIT` as well in order to kill all children.