### PR TITLE
Sync historical beefy justifications on relayer start up

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rs/cors v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454
-	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6
+	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -554,8 +554,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454 h1:aKd0iBLZGBzMAjhOQ969tmzgh7/2FZxL5qvJ/+lHZRs=
 github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454/go.mod h1:C5irsRKMm2oEfPRjAJlvPKHtRZrXhcWLS0Z2IMXneSE=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6 h1:edomJ9IBN/Rvz/W2Ku+kteEiFd9P/3b/8EEFhg1ZfL8=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7 h1:3GSs23kpy3+viMh8y0cEmNWvTn2ZMBSZKIvKVcQkx/c=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -18,6 +18,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const BlockCatchUpLimit = 1
+
 type BeefyRelaychainListener struct {
 	config         *Config
 	relaychainConn *relaychain.Connection
@@ -39,9 +41,62 @@ func NewBeefyRelaychainListener(
 func (li *BeefyRelaychainListener) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	eg.Go(func() error {
+		// TODO: Get the starting block from some place other than config.
+		err := li.syncBeefyJustifications(li.config.Source.Polkadot.BeefyStartingBlock)
+		if err != nil {
+			return err
+		}
 		return li.subBeefyJustifications(ctx)
 	})
 
+	return nil
+}
+
+func (li *BeefyRelaychainListener) syncBeefyJustifications(startBlockNumber uint64) error {
+	latestHeader, err := li.relaychainConn.API().RPC.Chain.GetHeaderLatest()
+	if err != nil {
+		return err
+	}
+
+	endBlockNumber := uint64(latestHeader.Number)
+
+	log.Info("Syncing BEEFY justifications from block number ", startBlockNumber, " to ", endBlockNumber, ".")
+
+	for blockNumber := startBlockNumber; blockNumber < endBlockNumber; blockNumber += BlockCatchUpLimit {
+		blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(blockNumber)
+		if err != nil {
+			return err
+		}
+		log.Info("Syncing BEEFY justifications for block ", blockNumber)
+		
+		block, err := li.relaychainConn.API().RPC.Chain.GetBlock(blockHash)
+		if err != nil {
+			return err
+		}
+		log.Debug("Justification", block.Justification)
+		if block.Justification != nil {
+			signedCommitment := &store.SignedCommitment{}
+			err := types.DecodeFromBytes(block.Justification, signedCommitment)
+			if err != nil {
+				log.WithError(err).Error("Failed to decode BEEFY commitment messages")
+			}
+
+			log.WithFields(logrus.Fields{
+				"signedCommitment.Commitment.BlockNumber":    signedCommitment.Commitment.BlockNumber,
+				"signedCommitment.Commitment.Payload":        signedCommitment.Commitment.Payload.Hex(),
+				"signedCommitment.Commitment.ValidatorSetID": signedCommitment.Commitment.ValidatorSetID,
+				"signedCommitment.Signatures":                signedCommitment.Signatures,
+			}).Info("Synchronizing a BEEFY commitment: ", block.Justification)
+
+			err = li.processBeefyJustifications(signedCommitment)
+			if err != nil {
+				log.WithError(err).Error("Failed to synchronise BEEFY commitment.");
+				return err
+			}
+		}
+	}
+
+	log.Info("Syncing BEEFY justifications complete. Resuming subcription.")
 	return nil
 }
 
@@ -75,72 +130,81 @@ func (li *BeefyRelaychainListener) subBeefyJustifications(ctx context.Context) e
 				"signedCommitment.Commitment.ValidatorSetID": signedCommitment.Commitment.ValidatorSetID,
 				"signedCommitment.Signatures":                signedCommitment.Signatures,
 			}).Info("Witnessed a new BEEFY commitment: ", msg.(string))
-			if len(signedCommitment.Signatures) == 0 {
-				log.Info("BEEFY commitment has no signatures, skipping...")
-				continue
-			}
 
-			signedCommitmentBytes, err := json.Marshal(signedCommitment)
+			err = li.processBeefyJustifications(signedCommitment)
 			if err != nil {
-				log.WithError(err).Error("Failed to marshal signed commitment:", signedCommitment)
-				continue
-			}
-
-			blockNumber := uint64(signedCommitment.Commitment.BlockNumber)
-
-			beefyAuthorities, err := li.getBeefyAuthorities(blockNumber)
-			if err != nil {
-				log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
 				return err
 			}
-
-			beefyAuthoritiesBytes, err := json.Marshal(beefyAuthorities)
-			if err != nil {
-				log.WithError(err).Error("Failed to marshal BEEFY authorities:", beefyAuthorities)
-				continue
-			}
-
-			blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(uint64(blockNumber))
-			if err != nil {
-				log.WithError(err).Error("Failed to get block hash")
-			}
-			log.WithField("blockHash", blockHash.Hex()).Info("Got next blockhash")
-
-			latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber-1, blockHash, li.config.Source.Polkadot.BeefyStartingBlock)
-			if err != nil {
-				log.WithError(err).Error("Failed get MMR Leaf")
-				return err
-			}
-
-			mmrLeafCount, err := li.relaychainConn.FetchMMRLeafCount(blockHash)
-			if err != nil {
-				log.WithError(err).Error("Failed get MMR Leaf Count")
-				return err
-			}
-
-			if mmrLeafCount == 0 {
-				err := fmt.Errorf("MMR is empty and has no leaves")
-				log.WithError(err)
-				return err
-			}
-
-			serializedProof, err := types.EncodeToBytes(latestMMRProof)
-			if err != nil {
-				log.WithError(err).Error("Failed to serialize MMR Proof")
-				return err
-			}
-			log.WithField("latestMMRProof", latestMMRProof.Leaf.Version).Info("Got latestMMRProof")
-
-			info := store.BeefyRelayInfo{
-				ValidatorAddresses:       beefyAuthoritiesBytes,
-				SignedCommitment:         signedCommitmentBytes,
-				Status:                   store.CommitmentWitnessed,
-				SerializedLatestMMRProof: serializedProof,
-				MMRLeafCount:             mmrLeafCount,
-			}
-			li.beefyMessages <- info
 		}
 	}
+}
+
+func (li *BeefyRelaychainListener) processBeefyJustifications(signedCommitment *store.SignedCommitment) error {
+	if len(signedCommitment.Signatures) == 0 {
+		log.Info("BEEFY commitment has no signatures, skipping...")
+		return nil
+	}
+
+	signedCommitmentBytes, err := json.Marshal(signedCommitment)
+	if err != nil {
+		log.WithError(err).Error("Failed to marshal signed commitment:", signedCommitment)
+		return nil
+	}
+
+	blockNumber := uint64(signedCommitment.Commitment.BlockNumber)
+
+	beefyAuthorities, err := li.getBeefyAuthorities(blockNumber)
+	if err != nil {
+		log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
+		return err
+	}
+
+	beefyAuthoritiesBytes, err := json.Marshal(beefyAuthorities)
+	if err != nil {
+		log.WithError(err).Error("Failed to marshal BEEFY authorities:", beefyAuthorities)
+		return nil
+	}
+
+	blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(uint64(blockNumber))
+	if err != nil {
+		log.WithError(err).Error("Failed to get block hash")
+	}
+	log.WithField("blockHash", blockHash.Hex()).Info("Got next blockhash")
+
+	latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber-1, blockHash, li.config.Source.Polkadot.BeefyStartingBlock)
+	if err != nil {
+		log.WithError(err).Error("Failed get MMR Leaf")
+		return err
+	}
+
+	mmrLeafCount, err := li.relaychainConn.FetchMMRLeafCount(blockHash)
+	if err != nil {
+		log.WithError(err).Error("Failed get MMR Leaf Count")
+		return err
+	}
+
+	if mmrLeafCount == 0 {
+		err := fmt.Errorf("MMR is empty and has no leaves")
+		log.WithError(err)
+		return err
+	}
+
+	serializedProof, err := types.EncodeToBytes(latestMMRProof)
+	if err != nil {
+		log.WithError(err).Error("Failed to serialize MMR Proof")
+		return err
+	}
+	log.WithField("latestMMRProof", latestMMRProof.Leaf.Version).Info("Got latestMMRProof")
+
+	info := store.BeefyRelayInfo{
+		ValidatorAddresses:       beefyAuthoritiesBytes,
+		SignedCommitment:         signedCommitmentBytes,
+		Status:                   store.CommitmentWitnessed,
+		SerializedLatestMMRProof: serializedProof,
+		MMRLeafCount:             mmrLeafCount,
+	}
+	li.beefyMessages <- info
+	return nil
 }
 
 func (li *BeefyRelaychainListener) getBeefyAuthorities(blockNumber uint64) ([]common.Address, error) {

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -10,7 +10,8 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Polkadot config.PolkadotConfig `mapstructure:"polkadot"`
+	Polkadot            config.PolkadotConfig `mapstructure:"polkadot"`
+	SyncBlockNumberJump uint64                `mapstructure:"sync-block-number-jump"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -11,7 +11,8 @@ type Config struct {
 
 type SourceConfig struct {
 	Polkadot            config.PolkadotConfig `mapstructure:"polkadot"`
-	SyncBlockNumberJump uint64                `mapstructure:"sync-block-number-jump"`
+	PollSkipBlockCount  uint64                `mapstructure:"poll-skip-block-count"`
+	PollIntervalSeconds uint64                `mapstructure:"poll-interval-seconds"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beefy/store/gsrpc.go
+++ b/relayer/relays/beefy/store/gsrpc.go
@@ -35,6 +35,36 @@ type SignedCommitment struct {
 	Signatures []OptionBeefySignature
 }
 
+type OptionalSignedCommitment struct {
+	Option
+	Value SignedCommitment
+}
+
+func (o OptionalSignedCommitment) Encode(encoder scale.Encoder) error {
+	return encoder.EncodeOption(o.hasValue, o.Value)
+}
+
+func (o *OptionalSignedCommitment) Decode(decoder scale.Decoder) error {
+	return decoder.DecodeOption(&o.hasValue, &o.Value)
+}
+
+// SetSome sets a value
+func (o *OptionalSignedCommitment) SetSome(value SignedCommitment) {
+	o.hasValue = true
+	o.Value = value
+}
+
+// SetNone removes a value and marks it as missing
+func (o *OptionalSignedCommitment) SetNone() {
+	o.hasValue = false
+	o.Value = SignedCommitment{}
+}
+
+// Unwrap returns a flag that indicates whether a value is present and the stored value
+func (o OptionalSignedCommitment) Unwrap() (ok bool, value SignedCommitment) {
+	return o.hasValue, o.Value
+}
+
 // BeefySignature is a beefy signature
 type BeefySignature [65]byte
 

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -3,7 +3,8 @@
     "polkadot": {
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
-    }
+    },
+    "sync-block-number-jump": 49
   },
   "sink": {
     "ethereum": {

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -4,7 +4,7 @@
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
     },
-    "sync-block-number-jump": 49
+    "sync-block-number-jump": 50
   },
   "sink": {
     "ethereum": {

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -4,7 +4,8 @@
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
     },
-    "sync-block-number-jump": 50
+    "poll-skip-block-count": 50,
+    "poll-interval-seconds": 6
   },
   "sink": {
     "ethereum": {

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -160,7 +160,7 @@ start_relayer()
         : > beefy-relay.log
         while :
         do
-            echo "Starting beefy relay"
+            echo "Starting beefy relay at $(date)"
             "${relay_bin}" run beefy \
                 --config "$output_dir/beefy-relay.json" \
                 --ethereum.private-key "0x935b65c833ced92c43ef9de6bff30703d941bd92a2637cb00cfad389f5862109" \
@@ -174,7 +174,7 @@ start_relayer()
         : > parachain-relay.log
         while :
         do
-            echo "Starting parachain relay"
+          echo "Starting parachain relay at $(date)"
             "${relay_bin}" run parachain \
                 --config "$output_dir/parachain-relay.json" \
                 --ethereum.private-key "0x8013383de6e5a891e7754ae1ef5a21e7661f1fe67cd47ca8ebf4acd6de66879a" \
@@ -188,7 +188,7 @@ start_relayer()
         : > ethereum-relay.log
         while :
         do
-            echo "Starting ethereum relay"
+          echo "Starting ethereum relay at $(date)"
             "${relay_bin}" run ethereum \
                 --config $output_dir/ethereum-relay.json \
                 --substrate.private-key "//Relay" \


### PR DESCRIPTION
https://trello.com/c/g3iv7eFj/124-beefy-relayer-historical-sync

## Info
This PR implements the following workflow:
* At startup use the query api to check how far behind the relay is behind the latest block.
* Catch up those blocks.
* Resume subscription to beefy justifications.

## Testing
E2E tests pass so there is no regression in functionality. However the new sync code path is till being debugged and tested

## Notes
1. For this revision we use `BeefyStartingBlock` from the config as the last known block. The relayer needs to instead find the last block it knows about.
2. Originally `BlockCatchUpLimit` was meant to implement a mechanism to catch up 50 blocks at a time. However after looking at the data, we only know if a block has a justification by fetching it and we cannot skip blocks in between as we would miss justifications. In this PR it is set to `1` to check every block. If my assumption that we have to inspect every block is correct than this can be removed and replaced with running only running the sync if we are more than 50 blocks behind.
3. While debugging I noticed that the `Justification` field of `SignedBlock` is always nil. Hence the processing code is not yet fully tested. 
4. Possible edge case that is not catered for in this PR yet is that if the relayer is far behind and has to sync a lot of blocks, it could lead to a situation where by the time it has sync'd the backlog of blocks, it is still more than 50 blocks behind because new blocks have been created while processing.