### PR TITLE
`npx hardhat test` fails with config error. - fixes #503 

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -17,7 +17,7 @@ Install dependencies with yarn:
 yarn install
 ```
 
-Create an `.env` file using the `env.template` as a template. Note that deploying to ropsten network requires setting the INFURA_PROJECT_ID and MNEMONIC environment variables.
+Create an `.env` file using the `env.template` as a template. Note that deploying to ropsten network requires setting the INFURA_PROJECT_ID and ROPSTEN_PRIVATE_KEY environment variables.
 
 Example:
 

--- a/ethereum/env.template
+++ b/ethereum/env.template
@@ -1,5 +1,5 @@
 # Deployment credentials (only necessary for ropsten and mainnet)
-ROPSTEN_PRIVATE_KEY=
+ROPSTEN_PRIVATE_KEY=0x00
 INFURA_PROJECT_ID=
 ETHERSCAN_API_KEY=
 


### PR DESCRIPTION
Defaults the `template.env` to a default that allows the tests to pass.