### PR TITLE
Sync historical beefy justifications on relayer start up

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rs/cors v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454
-	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6
+	github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -554,8 +554,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454 h1:aKd0iBLZGBzMAjhOQ969tmzgh7/2FZxL5qvJ/+lHZRs=
 github.com/snowfork/ethashproof v0.0.0-20210729080250-93b61cd82454/go.mod h1:C5irsRKMm2oEfPRjAJlvPKHtRZrXhcWLS0Z2IMXneSE=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6 h1:edomJ9IBN/Rvz/W2Ku+kteEiFd9P/3b/8EEFhg1ZfL8=
-github.com/snowfork/go-substrate-rpc-client/v3 v3.0.6/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7 h1:3GSs23kpy3+viMh8y0cEmNWvTn2ZMBSZKIvKVcQkx/c=
+github.com/snowfork/go-substrate-rpc-client/v3 v3.0.7/go.mod h1:n+dDFUtmhedjdLsXi8m+rWwwx1SEAEN1Uo2PFePK3bU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -81,17 +81,16 @@ func (li *BeefyRelaychainListener) syncBeefyJustifications(ctx context.Context) 
 			return err
 		}
 
-		finalizedBlockNumber := uint64(finalizedHeader.Number)
-		if current > finalizedBlockNumber {
-			log.WithFields(log.Fields{
-				"blockNumber":          current,
-				"finalizedBlockNumber": finalizedHeader.Number}).Info("Beefy relaychain listener synchronizing complete.")
-			return nil
-		}
-
 		logFields := log.Fields{
 			"blockNumber":          current,
 			"finalizedBlockNumber": finalizedHeader.Number}
+
+		finalizedBlockNumber := uint64(finalizedHeader.Number)
+		if current > finalizedBlockNumber {
+			log.WithFields(logFields).Info("Beefy relaychain listener synchronizing complete.")
+			return nil
+		}
+
 		log.WithFields(logFields).Info("Probing block.")
 
 		hash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(current)

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -60,12 +60,12 @@ func (li *BeefyRelaychainListener) Start(ctx context.Context, eg *errgroup.Group
 
 func (li *BeefyRelaychainListener) syncBeefyJustifications(ctx context.Context) error {
 	startingBlock := li.config.Source.Polkadot.BeefyStartingBlock
-	syncSkipBlockCount := li.config.Source.SyncSkipBlockCount
+	beefySkipPeriod := li.config.Source.BeefySkipPeriod
 
 	log.WithFields(
 		log.Fields{
-			"startingBlock":      startingBlock,
-			"syncSkipBlockCount": syncSkipBlockCount,
+			"startingBlock":  startingBlock,
+			"beefSkipPeriod": beefySkipPeriod,
 		}).Info("Synchronizing beefy relaychain listener")
 
 	current := startingBlock
@@ -137,7 +137,7 @@ func (li *BeefyRelaychainListener) syncBeefyJustifications(ctx context.Context) 
 			log.WithFields(logFields).Info("Justifications found.")
 			// The beefy relayer can skip a certain amount of blocks provided it does not skip a whole
 			// validator sessions worth of blocks.
-			current += syncSkipBlockCount
+			current += beefySkipPeriod
 		} else {
 			log.WithFields(logFields).Info("Justifications not found.")
 			current += 1

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v3/types"
 	"golang.org/x/sync/errgroup"
 
@@ -40,17 +39,111 @@ func NewBeefyRelaychainListener(
 func (li *BeefyRelaychainListener) Start(ctx context.Context, eg *errgroup.Group) error {
 	eg.Go(func() error {
 		defer close(li.beefyMessages)
-		err := li.subBeefyJustifications(ctx)
-		log.WithField("reason", err).Info("Shutting down polkadot listener")
+
+		err := li.syncBeefyJustifications(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
 			}
 			return err
 		}
+
+		err = li.subBeefyJustifications(ctx)
+		log.WithField("reason", err).Info("Shutting down polkadot listener")
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
 		return nil
 	})
 	return nil
+}
+
+func (li *BeefyRelaychainListener) syncBeefyJustifications(ctx context.Context) error {
+	startingBlock := li.config.Source.Polkadot.BeefyStartingBlock
+	syncSkipBlockCount := li.config.Source.SyncSkipBlockCount
+
+	log.WithFields(
+		log.Fields{
+			"startingBlock":      startingBlock,
+			"syncSkipBlockCount": syncSkipBlockCount,
+		}).Info("Synchronizing beefy relaychain listener")
+
+	current := startingBlock
+	for {
+		finalizedHash, err := li.relaychainConn.API().RPC.Chain.GetFinalizedHead()
+		if err != nil {
+			log.WithError(err).Error("Failed to fetch finalized head.")
+			return err
+		}
+		finalizedHeader, err := li.relaychainConn.API().RPC.Chain.GetHeader(finalizedHash)
+		if err != nil {
+			log.WithError(err).WithField("finalizedBlockHash", finalizedHash.Hex()).Error("Failed to fetch header for finalised head.")
+			return err
+		}
+
+		finalizedBlockNumber := uint64(finalizedHeader.Number)
+		if current > finalizedBlockNumber {
+			log.WithFields(log.Fields{
+				"blockNumber":          current,
+				"finalizedBlockNumber": finalizedHeader.Number}).Info("Beefy relaychain listener synchronizing complete.")
+			return nil
+		}
+
+		logFields := log.Fields{
+			"blockNumber":          current,
+			"finalizedBlockNumber": finalizedHeader.Number}
+		log.WithFields(logFields).Info("Probing block.")
+
+		hash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(current)
+		if err != nil {
+			log.WithError(err).WithFields(logFields).Error("Failed to fetch block hash.")
+			return err
+		}
+		logFields["blockHash"] = hash.Hex()
+
+		block, err := li.relaychainConn.API().RPC.Chain.GetBlock(hash)
+		if err != nil {
+			log.WithError(err).WithFields(logFields).Error("Failed to fetch block hash.")
+			return err
+		}
+
+		commitments := []store.SignedCommitment{}
+		for j := range block.Justifications {
+			sc := store.OptionalSignedCommitment{}
+			if block.Justifications[j].EngineID() == "BEEF" {
+				err := types.DecodeFromBytes(block.Justifications[j].Payload(), &sc)
+				if err != nil {
+					log.WithFields(logFields).WithError(err).Error("Failed to decode BEEFY commitment messages")
+				} else if sc.IsSome() {
+					commitments = append(commitments, sc.Value)
+				}
+			}
+		}
+
+		for c := range commitments {
+			log.WithFields(logFields).WithFields(log.Fields{
+				"signedCommitment.Commitment.BlockNumber":    commitments[c].Commitment.BlockNumber,
+				"signedCommitment.Commitment.Payload":        commitments[c].Commitment.Payload.Hex(),
+				"signedCommitment.Commitment.ValidatorSetID": commitments[c].Commitment.ValidatorSetID,
+				"signedCommitment.Signatures":                commitments[c].Signatures,
+			}).Info("Synchronizing a BEEFY commitment.")
+
+			err = li.processBeefyJustifications(ctx, &commitments[c])
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(commitments) > 0 {
+			log.WithFields(logFields).Info("Justifications found.")
+			// The beefy relayer can skip a certain amount of blocks provided it does not skip a whole
+			// validator sessions worth of blocks.
+			current += syncSkipBlockCount
+		} else {
+			log.WithFields(logFields).Info("Justifications not found.")
+			current += 1
+		}
+	}
 }
 
 func (li *BeefyRelaychainListener) subBeefyJustifications(ctx context.Context) error {
@@ -84,83 +177,93 @@ func (li *BeefyRelaychainListener) subBeefyJustifications(ctx context.Context) e
 				log.WithError(err).Error("Failed to decode BEEFY commitment messages")
 			}
 
-			log.WithFields(logrus.Fields{
+			log.WithFields(log.Fields{
 				"signedCommitment.Commitment.BlockNumber":    signedCommitment.Commitment.BlockNumber,
 				"signedCommitment.Commitment.Payload":        signedCommitment.Commitment.Payload.Hex(),
 				"signedCommitment.Commitment.ValidatorSetID": signedCommitment.Commitment.ValidatorSetID,
 				"signedCommitment.Signatures":                signedCommitment.Signatures,
-			}).Info("Witnessed a new BEEFY commitment: ", msg.(string))
-			if len(signedCommitment.Signatures) == 0 {
-				log.Info("BEEFY commitment has no signatures, skipping...")
-				continue
-			}
+				"rawMessage":                                 msg.(string),
+			}).Info("Witnessed a new BEEFY commitment.")
 
-			signedCommitmentBytes, err := json.Marshal(signedCommitment)
+			err = li.processBeefyJustifications(ctx, signedCommitment)
 			if err != nil {
-				log.WithError(err).Error("Failed to marshal signed commitment:", signedCommitment)
-				continue
-			}
-
-			blockNumber := uint64(signedCommitment.Commitment.BlockNumber)
-
-			beefyAuthorities, err := li.getBeefyAuthorities(blockNumber)
-			if err != nil {
-				log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
 				return err
-			}
-
-			beefyAuthoritiesBytes, err := json.Marshal(beefyAuthorities)
-			if err != nil {
-				log.WithError(err).Error("Failed to marshal BEEFY authorities:", beefyAuthorities)
-				return err
-			}
-
-			blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(uint64(blockNumber))
-			if err != nil {
-				log.WithError(err).Error("Failed to get block hash")
-				return err
-			}
-			log.WithField("blockHash", blockHash.Hex()).Info("Got next blockhash")
-
-			latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber-1, blockHash, li.config.Source.Polkadot.BeefyStartingBlock)
-			if err != nil {
-				log.WithError(err).Error("Failed get MMR Leaf")
-				return err
-			}
-
-			mmrLeafCount, err := li.relaychainConn.FetchMMRLeafCount(blockHash)
-			if err != nil {
-				log.WithError(err).Error("Failed get MMR Leaf Count")
-				return err
-			}
-
-			if mmrLeafCount == 0 {
-				err := fmt.Errorf("MMR is empty and has no leaves")
-				log.WithError(err)
-				return err
-			}
-
-			serializedProof, err := types.EncodeToBytes(latestMMRProof)
-			if err != nil {
-				log.WithError(err).Error("Failed to serialize MMR Proof")
-				return err
-			}
-			log.WithField("latestMMRProof", latestMMRProof.Leaf.Version).Info("Got latestMMRProof")
-
-			info := store.BeefyRelayInfo{
-				ValidatorAddresses:       beefyAuthoritiesBytes,
-				SignedCommitment:         signedCommitmentBytes,
-				Status:                   store.CommitmentWitnessed,
-				SerializedLatestMMRProof: serializedProof,
-				MMRLeafCount:             mmrLeafCount,
-			}
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case li.beefyMessages <- info:
 			}
 		}
+	}
+}
+
+func (li *BeefyRelaychainListener) processBeefyJustifications(ctx context.Context, signedCommitment *store.SignedCommitment) error {
+	if len(signedCommitment.Signatures) == 0 {
+		log.Info("BEEFY commitment has no signatures, skipping...")
+		return nil
+	}
+
+	signedCommitmentBytes, err := json.Marshal(signedCommitment)
+	if err != nil {
+		log.WithField("signedCommitment", signedCommitment).WithError(err).Error("Failed to marshal signed commitment.")
+		return nil
+	}
+
+	blockNumber := uint64(signedCommitment.Commitment.BlockNumber)
+
+	beefyAuthorities, err := li.getBeefyAuthorities(blockNumber)
+	if err != nil {
+		log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
+		return err
+	}
+
+	beefyAuthoritiesBytes, err := json.Marshal(beefyAuthorities)
+	if err != nil {
+		log.WithField("beefyAuthorities", beefyAuthorities).WithError(err).Error("Failed to marshal BEEFY authorities.")
+		return err
+	}
+
+	blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(uint64(blockNumber))
+	if err != nil {
+		log.WithError(err).Error("Failed to get block hash")
+		return err
+	}
+	log.WithField("blockHash", blockHash.Hex()).Info("Got next blockhash")
+
+	latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber-1, blockHash, li.config.Source.Polkadot.BeefyStartingBlock)
+	if err != nil {
+		log.WithError(err).Error("Failed get MMR Leaf")
+		return err
+	}
+
+	mmrLeafCount, err := li.relaychainConn.FetchMMRLeafCount(blockHash)
+	if err != nil {
+		log.WithError(err).Error("Failed get MMR Leaf Count")
+		return err
+	}
+
+	if mmrLeafCount == 0 {
+		err := fmt.Errorf("MMR is empty and has no leaves")
+		log.WithError(err)
+		return err
+	}
+
+	serializedProof, err := types.EncodeToBytes(latestMMRProof)
+	if err != nil {
+		log.WithError(err).Error("Failed to serialize MMR Proof")
+		return err
+	}
+	log.WithField("latestMMRProof", latestMMRProof.Leaf.Version).Info("Got latestMMRProof")
+
+	info := store.BeefyRelayInfo{
+		ValidatorAddresses:       beefyAuthoritiesBytes,
+		SignedCommitment:         signedCommitmentBytes,
+		Status:                   store.CommitmentWitnessed,
+		SerializedLatestMMRProof: serializedProof,
+		MMRLeafCount:             mmrLeafCount,
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case li.beefyMessages <- info:
+		return nil
 	}
 }
 

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -10,8 +10,8 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Polkadot           config.PolkadotConfig `mapstructure:"polkadot"`
-	SyncSkipBlockCount uint64                `mapstructure:"sync-skip-block-count"`
+	Polkadot        config.PolkadotConfig `mapstructure:"polkadot"`
+	BeefySkipPeriod uint64                `mapstructure:"beefy-skip-period"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -10,9 +10,8 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Polkadot            config.PolkadotConfig `mapstructure:"polkadot"`
-	PollSkipBlockCount  uint64                `mapstructure:"poll-skip-block-count"`
-	PollIntervalSeconds uint64                `mapstructure:"poll-interval-seconds"`
+	Polkadot           config.PolkadotConfig `mapstructure:"polkadot"`
+	SyncSkipBlockCount uint64                `mapstructure:"sync-skip-block-count"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -10,7 +10,9 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Polkadot config.PolkadotConfig `mapstructure:"polkadot"`
+	Polkadot            config.PolkadotConfig `mapstructure:"polkadot"`
+	PollSkipBlockCount  uint64                `mapstructure:"poll-skip-block-count"`
+	PollIntervalSeconds uint64                `mapstructure:"poll-interval-seconds"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beefy/store/gsrpc.go
+++ b/relayer/relays/beefy/store/gsrpc.go
@@ -35,6 +35,36 @@ type SignedCommitment struct {
 	Signatures []OptionBeefySignature
 }
 
+type OptionalSignedCommitment struct {
+	Option
+	Value SignedCommitment
+}
+
+func (o OptionalSignedCommitment) Encode(encoder scale.Encoder) error {
+	return encoder.EncodeOption(o.hasValue, o.Value)
+}
+
+func (o *OptionalSignedCommitment) Decode(decoder scale.Decoder) error {
+	return decoder.DecodeOption(&o.hasValue, &o.Value)
+}
+
+// SetSome sets a value
+func (o *OptionalSignedCommitment) SetSome(value SignedCommitment) {
+	o.hasValue = true
+	o.Value = value
+}
+
+// SetNone removes a value and marks it as missing
+func (o *OptionalSignedCommitment) SetNone() {
+	o.hasValue = false
+	o.Value = SignedCommitment{}
+}
+
+// Unwrap returns a flag that indicates whether a value is present and the stored value
+func (o OptionalSignedCommitment) Unwrap() (ok bool, value SignedCommitment) {
+	return o.hasValue, o.Value
+}
+
 // BeefySignature is a beefy signature
 type BeefySignature [65]byte
 

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -4,7 +4,7 @@
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
     },
-    "sync-skip-block-count": 50
+    "beefy-skip-period": 50
   },
   "sink": {
     "ethereum": {

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -3,7 +3,9 @@
     "polkadot": {
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
-    }
+    },
+    "poll-skip-block-count": 50,
+    "poll-interval-seconds": 6
   },
   "sink": {
     "ethereum": {

--- a/test/config/beefy-relay.json
+++ b/test/config/beefy-relay.json
@@ -4,8 +4,7 @@
       "endpoint": "ws://localhost:9944",
       "beefy-starting-block": 0
     },
-    "poll-skip-block-count": 50,
-    "poll-interval-seconds": 6
+    "sync-skip-block-count": 50
   },
   "sink": {
     "ethereum": {

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -160,7 +160,7 @@ start_relayer()
         : > beefy-relay.log
         while :
         do
-            echo "Starting beefy relay"
+            echo "Starting beefy relay at $(date)"
             "${relay_bin}" run beefy \
                 --config "$output_dir/beefy-relay.json" \
                 --ethereum.private-key "0x935b65c833ced92c43ef9de6bff30703d941bd92a2637cb00cfad389f5862109" \
@@ -174,7 +174,7 @@ start_relayer()
         : > parachain-relay.log
         while :
         do
-            echo "Starting parachain relay"
+          echo "Starting parachain relay at $(date)"
             "${relay_bin}" run parachain \
                 --config "$output_dir/parachain-relay.json" \
                 --ethereum.private-key "0x8013383de6e5a891e7754ae1ef5a21e7661f1fe67cd47ca8ebf4acd6de66879a" \
@@ -188,7 +188,7 @@ start_relayer()
         : > ethereum-relay.log
         while :
         do
-            echo "Starting ethereum relay"
+          echo "Starting ethereum relay at $(date)"
             "${relay_bin}" run ethereum \
                 --config $output_dir/ethereum-relay.json \
                 --substrate.private-key "//Relay" \


### PR DESCRIPTION
This is a continuation from PR https://github.com/Snowfork/snowbridge/pull/497. That PR is closed because we have switched back to hybrid and the `main` branch has had updates which need to be included.

We had to switch back to a hybrid model where we poll for synchronization and subscribe for new justifications as the poll code misses justifications. It seems like the beefy justifications are sometimes added after block finalization.