### PR TITLE
Increase max watched extrinsics to 30

### DIFF
--- a/relayer/chain/parachain/outgoing_extrinsics.go
+++ b/relayer/chain/parachain/outgoing_extrinsics.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
-const MaxWatchedExtrinsics = 10
+const MaxWatchedExtrinsics = 30
 
 type ExtrinsicPool struct {
 	conn     *Connection


### PR DESCRIPTION
On ropsten, the ethereum relay isn't keeping up with the rate of block production.