### PR TITLE
Configure Relayer to output JSON logs.

### DIFF
--- a/relayer/main.go
+++ b/relayer/main.go
@@ -16,9 +16,20 @@ limitations under the License.
 package main
 
 import (
+	log "github.com/sirupsen/logrus"
 	"github.com/snowfork/snowbridge/relayer/cmd"
 )
 
+func configureLogger() {
+	log.SetFormatter(&log.JSONFormatter{
+		FieldMap: log.FieldMap{
+			log.FieldKeyTime: "@timestamp",
+			log.FieldKeyMsg:  "message",
+		},
+	})
+}
+
 func main() {
+	configureLogger()
 	cmd.Execute()
 }

--- a/relayer/main.go
+++ b/relayer/main.go
@@ -16,12 +16,15 @@ limitations under the License.
 package main
 
 import (
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/snowfork/snowbridge/relayer/cmd"
 )
 
 func configureLogger() {
 	log.SetFormatter(&log.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
 		FieldMap: log.FieldMap{
 			log.FieldKeyTime: "@timestamp",
 			log.FieldKeyMsg:  "message",


### PR DESCRIPTION
Added the fields expected by elastic.

example output:
```json
{"@timestamp":"2021-09-13T23:41:29.689595678Z","count":0,"endBlock":186,"level":"debug","message":"Queried for FinalVerificationSuccessful events","startBlock":186}
```

Resolves SNO-36