### PR TITLE
The beefy relay no longer tries to process historical verification events

### DIFF
--- a/relayer/relays/beefy/beefy-ethereum-writer.go
+++ b/relayer/relays/beefy/beefy-ethereum-writer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -93,6 +94,12 @@ func (wr *BeefyEthereumWriter) writeMessagesLoop(ctx context.Context) error {
 					log.WithError(err).Error("Failed to write complete signature commitment")
 					return err
 				}
+			}
+			// Rate-limit transaction sending to reduce the chance of transactions using the same pending nonce.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(2 * time.Second):
 			}
 		}
 	}

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -16,7 +16,6 @@ type SourceConfig struct {
 
 type SinkConfig struct {
 	Ethereum              config.EthereumConfig `mapstructure:"ethereum"`
-	StartBlock            uint64                `mapstructure:"start-block"`
 	DescendantsUntilFinal uint64                `mapstructure:"descendants-until-final"`
 	Contracts             ContractsConfig       `mapstructure:"contracts"`
 }


### PR DESCRIPTION
The historical processing actually never really worked anyway because the sqlite DB is reset between restarts. Now that we have beefy catchup in place, the DB will be refilled with _new_ events for _old_ beefy blocks. so we should be safe.

Also reduced the chances of submitting ethereum transactions with the same nonce. Not a perfect solution, can be improved later on.

E2E tests pass