### PR TITLE
Experiments fetching MMR Leafs

### DIFF
--- a/relayer/chain/relaychain/connection.go
+++ b/relayer/chain/relaychain/connection.go
@@ -71,7 +71,7 @@ func (co *Connection) Close() {
 func (co *Connection) GetMMRLeafForBlock(
 	blockNumber uint64,
 	blockHash types.Hash,
-	beefyStartingBlock uint64,
+	beefyActivationBlock uint64,
 ) (types.GenerateMMRProofResponse, error) {
 	log.WithFields(log.Fields{
 		"blockNumber": blockNumber,
@@ -83,7 +83,13 @@ func (co *Connection) GetMMRLeafForBlock(
 	// However, some chains only started using beefy late in their existence, so there are no leafs for
 	// blocks produced before beefy was activated. We subtract the block in which beefy was started on the
 	// chain to account for this.
-	leafIndex := blockNumber - beefyStartingBlock - 1
+
+	var leafIndex uint64
+	if beefyActivationBlock == 0 {
+		leafIndex = blockNumber - 1
+	} else {
+		leafIndex = blockNumber - beefyActivationBlock
+	}
 
 	proofResponse, err := co.API().RPC.MMR.GenerateProof(leafIndex, blockHash)
 	if err != nil {

--- a/relayer/chain/relaychain/connection_test.go
+++ b/relayer/chain/relaychain/connection_test.go
@@ -16,5 +16,6 @@ func TestConnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	conn.Close()
 }

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -2,7 +2,6 @@ package config
 
 type PolkadotConfig struct {
 	Endpoint           string `mapstructure:"endpoint"`
-	BeefyStartingBlock uint64 `mapstructure:"beefy-starting-block"`
 }
 
 type ParachainConfig struct {

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -224,7 +224,7 @@ func (li *BeefyRelaychainListener) processBeefyJustifications(ctx context.Contex
 	}
 	log.WithField("blockHash", blockHash.Hex()).Info("Got next blockhash")
 
-	latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber-1, blockHash, li.config.Source.Polkadot.BeefyStartingBlock)
+	latestMMRProof, err := li.relaychainConn.GetMMRLeafForBlock(blockNumber, blockHash, li.config.Source.BeefyActivationBlock)
 	if err != nil {
 		log.WithError(err).Error("Failed get MMR Leaf")
 		return err

--- a/relayer/relays/beefy/config.go
+++ b/relayer/relays/beefy/config.go
@@ -10,8 +10,11 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Polkadot        config.PolkadotConfig `mapstructure:"polkadot"`
-	BeefySkipPeriod uint64                `mapstructure:"beefy-skip-period"`
+	Polkadot             config.PolkadotConfig `mapstructure:"polkadot"`
+	// Block number when Beefy was activated
+	BeefyActivationBlock uint64                `mapstructure:"beefy-activation-block"`
+	// Number of blocks to skip between reading justifications
+	BeefySkipPeriod      uint64                `mapstructure:"beefy-skip-period"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/parachain/catchup.go
+++ b/relayer/relays/parachain/catchup.go
@@ -195,7 +195,7 @@ func (li *BeefyListener) parablocksWithProofs(
 		// due to the decrement at the end of the loop, so we increment by 1. Additionally,
 		// parachain merkle roots are created 1 block later than the actual parachain headers,
 		// so we increment twice.
-		mmrProof, err := li.relaychainConn.GetMMRLeafForBlock(uint64(relayChainBlockNumber+2), latestRelaychainBlockHash, li.config.Polkadot.BeefyStartingBlock)
+		mmrProof, err := li.relaychainConn.GetMMRLeafForBlock(uint64(relayChainBlockNumber+2), latestRelaychainBlockHash, li.config.BeefyActivationBlock)
 		if err != nil {
 			log.WithError(err).Error("Failed to get mmr leaf")
 			return nil, err

--- a/relayer/relays/parachain/config.go
+++ b/relayer/relays/parachain/config.go
@@ -11,11 +11,13 @@ type SourceConfig struct {
 	Polkadot  config.PolkadotConfig  `mapstructure:"polkadot"`
 	Parachain config.ParachainConfig `mapstructure:"parachain"`
 	Ethereum  config.EthereumConfig  `mapstructure:"ethereum"`
-	Contracts SourceContractsConfig   `mapstructure:"contracts"`
+	Contracts SourceContractsConfig  `mapstructure:"contracts"`
+	// Block number when Beefy was activated
+	BeefyActivationBlock uint64 `mapstructure:"beefy-activation-block"`
 }
 
 type SourceContractsConfig struct {
-	BeefyLightClient string `mapstructure:"BeefyLightClient"`
+	BeefyLightClient           string `mapstructure:"BeefyLightClient"`
 	BasicInboundChannel        string `mapstructure:"BasicInboundChannel"`
 	IncentivizedInboundChannel string `mapstructure:"IncentivizedInboundChannel"`
 }


### PR DESCRIPTION
Looks like the E2E test still pass repeatedly when we don't decrement the block number when calling `GetMMRLeafForBlock`.

Also some cleanups for the configuration of when Beefy was activated on the the relay chain.

Leaving in draft I while I attend to other pressing matters.