### PR TITLE
Handle optional signatures correctly

### DIFF
--- a/relayer/relays/beefy/beefy-ethereum-writer.go
+++ b/relayer/relays/beefy/beefy-ethereum-writer.go
@@ -148,11 +148,10 @@ func (wr *BeefyEthereumWriter) WriteNewSignatureCommitment(ctx context.Context, 
 	}
 
 	signedValidators := []*big.Int{}
-	for i := range beefyJustification.SignedCommitment.Signatures {
-		// TODO: skip over empty/missing signatures
-		// if signature.Option.IsSome() {
-		signedValidators = append(signedValidators, big.NewInt(int64(i)))
-		// }
+	for i, signature := range beefyJustification.SignedCommitment.Signatures {
+		if signature.Option.IsSome() {
+			signedValidators = append(signedValidators, big.NewInt(int64(i)))
+		}
 	}
 	numberOfValidators := big.NewInt(int64(len(beefyJustification.SignedCommitment.Signatures)))
 	initialBitfield, err := contract.CreateInitialBitfield(

--- a/relayer/relays/beefy/store/gsrpc.go
+++ b/relayer/relays/beefy/store/gsrpc.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 
 	"github.com/snowfork/go-substrate-rpc-client/v3/scale"
 	"github.com/snowfork/go-substrate-rpc-client/v3/types"
@@ -111,6 +112,28 @@ func (o *OptionBeefySignature) SetNone() {
 // Unwrap returns a flag that indicates whether a value is present and the stored value
 func (o OptionBeefySignature) Unwrap() (ok bool, value BeefySignature) {
 	return o.hasValue, o.Value
+}
+
+func (o OptionBeefySignature) MarshalJSON() ([]byte, error) {
+	if !o.hasValue {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(o.Value)
+}
+
+func (o *OptionBeefySignature) UnmarshalJSON(b []byte) error {
+	var tmp *BeefySignature
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	if tmp != nil {
+		o.hasValue = true
+		o.Value = *tmp
+	} else {
+		o.hasValue = false
+	}
+
+	return nil
 }
 
 type Option struct {

--- a/relayer/relays/beefy/store/store_test.go
+++ b/relayer/relays/beefy/store/store_test.go
@@ -247,3 +247,50 @@ func loadSampleBeefyRelayInfo() store.BeefyRelayInfo {
 		CompleteOnBlock:           22,
 	}
 }
+
+
+func (t *StoreTestSuite) TestMarshalOptionalBeefySignature() {
+
+	// Test Some(signature) case
+	sig1 := "d0834df8b658963611deecf57b845f906f517c1a9b9467f31e8dc292d1a131d22ccb2201dc6e49043fce104418442f9d20acaa3c5d86d2ce20285de0e64b057a01"
+	sig1Bytes, err := hex.DecodeString(sig1)
+	if err != nil {
+		panic(err)
+	}
+	var sig1Input [65]byte
+	copy(sig1Input[:], sig1Bytes)
+	beefySig1 := store.BeefySignature(sig1Input)
+
+
+	optionalBeefySig1 := store.NewOptionBeefySignature(beefySig1)
+
+	bytes, err := json.Marshal(optionalBeefySig1)
+	if (err != nil) {
+		panic(err)
+	}
+
+	var foo store.OptionBeefySignature
+	err = json.Unmarshal(bytes, &foo)
+	if (err != nil) {
+		panic(err)
+	}
+
+	t.Equal(optionalBeefySig1, foo)
+
+	// Test None case
+
+	optionalBeefySig2 := store.NewOptionBeefySignatureEmpty()
+
+	bytes2, err := json.Marshal(optionalBeefySig2)
+	if (err != nil) {
+		panic(err)
+	}
+
+	var foo2 store.OptionBeefySignature
+	err = json.Unmarshal(bytes2, &foo2)
+	if (err != nil) {
+		panic(err)
+	}
+
+	t.Equal(optionalBeefySig2, foo2)
+}


### PR DESCRIPTION
At least 2/3+1 validators will sign each beefy commitment. This means that when there are 4 or more polkadot validators, some signatures will be missing/optional.

We've never handled optional signatures correctly, and so the bridge broke when I tested today with 4 validators.

I've tested the fix locally, and all newCommitmentSignature TXs were successfully executed.

Resolves #461 