### PR TITLE
Increase confirmation time for Ropsten

### DIFF
--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -562,7 +562,7 @@ impl incentivized_channel_outbound::Config for Runtime {
 }
 
 parameter_types! {
-	pub const DescendantsUntilFinalized: u8 = 3;
+	pub const DescendantsUntilFinalized: u8 = 8;
 	pub const DifficultyConfig: EthereumDifficultyConfig = EthereumDifficultyConfig::ropsten();
 	pub const VerifyPoW: bool = true;
 }


### PR DESCRIPTION
On staging, the parachain accepted a message from a non-canonical fork, which means later messages from the canonical chain were rejected due to an invalid nonce. This is the only interpretation we can make for the invalid nonce errors.

The ethereum light client is currently configured with a very short confirmation time - 3 blocks. Bumping this up to 8 blocks for now. Though we may need to increase it even more after further evaluation.