### PR TITLE
Relay should submit correct MMR proofs for historical commitments

### DIFF
--- a/relayer/relays/parachain/beefy-listener.go
+++ b/relayer/relays/parachain/beefy-listener.go
@@ -26,7 +26,7 @@ type BeefyListener struct {
 	relaychainConn      *relaychain.Connection
 	parachainConnection *parachain.Connection
 	paraID              uint32
-	messages            chan<- MessagePackage
+	messages            chan<- *Task
 }
 
 func NewBeefyListener(
@@ -34,7 +34,7 @@ func NewBeefyListener(
 	ethereumConn *ethereum.Connection,
 	relaychainConn *relaychain.Connection,
 	parachainConnection *parachain.Connection,
-	messages chan<- MessagePackage,
+	messages chan<- *Task,
 ) *BeefyListener {
 	return &BeefyListener{
 		config:              config,

--- a/relayer/relays/parachain/merkle-proof.go
+++ b/relayer/relays/parachain/merkle-proof.go
@@ -69,21 +69,15 @@ func (d MerkleProofData) String() string {
 	return string(b)
 }
 
-func CreateParachainMerkleProof(heads map[uint32]relaychain.ParaHead, paraID uint32) (MerkleProofData, error) {
-	// convert header mapping into slice
-	headsAsSlice := make([]relaychain.ParaHead, 0, len(heads))
-	for _, v := range heads {
-		headsAsSlice = append(headsAsSlice, v)
-	}
-
+func CreateParachainMerkleProof(heads []relaychain.ParaHead, paraID uint32) (MerkleProofData, error) {
 	// sort slice by para ID
-	sort.Sort(ByParaID(headsAsSlice))
+	sort.Sort(ByParaID(heads))
 
 	// loop headers, convert to pre leaves and find header being proven
-	preLeaves := make([][]byte, 0, len(headsAsSlice))
+	preLeaves := make([][]byte, 0, len(heads))
 	var headerToProve []byte
 	var headerIndex int64
-	for i, head := range headsAsSlice {
+	for i, head := range heads {
 		preLeaf, err := types.EncodeToBytes(head)
 		if err != nil {
 			return MerkleProofData{}, err

--- a/relayer/relays/parachain/types.go
+++ b/relayer/relays/parachain/types.go
@@ -3,58 +3,32 @@ package parachain
 import (
 	"github.com/snowfork/go-substrate-rpc-client/v3/types"
 	"github.com/snowfork/snowbridge/relayer/chain/parachain"
+	"github.com/snowfork/snowbridge/relayer/chain/relaychain"
 	"github.com/snowfork/snowbridge/relayer/crypto/merkle"
 )
 
-type ParaBlockWithDigest struct {
-	BlockNumber         uint64
-	DigestItemsWithData []DigestItemWithData
+type Task struct {
+	ParaID      uint32
+	BlockNumber uint64
+	Header      *types.Header
+	Commitments map[parachain.ChannelID]Commitment
+	ProofInput  *ProofInput
+	ProofOutput *ProofOutput
 }
 
-type ParaBlockWithProofs struct {
-	Block            ParaBlockWithDigest
-	MMRProof merkle.SimplifiedMMRProof
-	MMRRootHash      types.Hash
-	Header           types.Header
-	MerkleProofData  MerkleProofData
+type Commitment struct {
+	Hash types.H256
+	Data interface{}
 }
 
-type DigestItemWithData struct {
-	DigestItem parachain.AuxiliaryDigestItem
-	Data       types.StorageDataRaw
+type ProofInput struct {
+	PolkadotBlockNumber uint64
+	ParaHeads           []relaychain.ParaHead
 }
 
-type MessagePackage struct {
-	channelID         parachain.ChannelID
-	commitmentHash    types.H256
-	commitmentData    types.StorageDataRaw
-	paraHead          types.Header
-	merkleProofData   MerkleProofData
-	paraId            uint32
-	mmrRootHash       types.Hash
-	simplifiedMMRProof merkle.SimplifiedMMRProof
-}
-
-func CreateMessagePackages(paraBlocks []ParaBlockWithProofs, mmrLeafCount uint64, paraID uint32) ([]MessagePackage, error) {
-	var messagePackages []MessagePackage
-
-	for _, block := range paraBlocks {
-		for _, item := range block.Block.DigestItemsWithData {
-			commitmentHash := item.DigestItem.AsCommitment.Hash
-			commitmentData := item.Data
-			messagePackage := MessagePackage{
-				item.DigestItem.AsCommitment.ChannelID,
-				commitmentHash,
-				commitmentData,
-				block.Header,
-				block.MerkleProofData,
-				paraID,
-				block.MMRRootHash,
-				block.MMRProof,
-			}
-			messagePackages = append(messagePackages, messagePackage)
-		}
-	}
-
-	return messagePackages, nil
+type ProofOutput struct {
+	MMRProof        merkle.SimplifiedMMRProof
+	MMRRootHash     types.Hash
+	Header          types.Header
+	MerkleProofData MerkleProofData
 }


### PR DESCRIPTION
An early WIP solution that makes the following changes:

* Generation of MMR proofs happens right before transaction is submitted to inbound channels on Ethereum
* Simplifications & potential speedup for the code that scans relay chain blocks.

Resolves SNO-112