### PR TITLE
Update BaseCallFilter to new filter API

### DIFF
--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -187,7 +187,7 @@ parameter_types! {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = ();
+	type BaseCallFilter = Everything;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;
 	/// The maximum length of a block (in bytes).
@@ -889,7 +889,10 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, erc20_app, Erc20App);
 			add_benchmark!(params, batches, eth_app, EthApp);
 
-			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
+			if batches.is_empty() {
+				return Err("Benchmark not found for this pallet.".into())
+			}
+
 			Ok(batches)
 		}
 	}

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -187,7 +187,7 @@ parameter_types! {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = ();
+	type BaseCallFilter = Everything;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;
 	/// The maximum length of a block (in bytes).
@@ -889,11 +889,15 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, erc20_app, Erc20App);
 			add_benchmark!(params, batches, eth_app, EthApp);
 
-			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
+			if batches.is_empty() {
+				return Err("Benchmark not found for this pallet.".into())
+			}
+
 			Ok(batches)
 		}
 	}
 }
+
 struct CheckInherents;
 
 impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {


### PR DESCRIPTION
I missed this issue when upgrading our dependencies to `0.9.9-1` last week. Was causing our staging deployments to fail today with `Bad mandatory: BadOrigin` errors.