### PR TITLE
Add type for EthereumDifficultyConfig

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfork/snowbridge-types",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Type definitions for the Snowbridge parachain",
   "repository": {
     "type": "git",

--- a/types/src/v1.ts
+++ b/types/src/v1.ts
@@ -62,6 +62,12 @@ export const types: RegistryTypes = {
     oldestUnprunedBlock: "u64",
     oldestBlockToKeep: "u64",
   },
+  EthereumDifficultyConfig: {
+    byzantiumForkBlock: "u64",
+    constantinopleForkBlock: "u64",
+    muirGlacierForkBlock: "u64",
+    londonForkBlock: "u64"
+  },
   AssetId: {
     _enum: {
       ETH: null,


### PR DESCRIPTION
Need to add `EthereumDifficultyConfig` to metadata types in order to support https://github.com/Snowfork/snowbridge/pull/527

With FRAME V2, runtime constants can now be introspected via storage metadata.