### PR TITLE
Made fee conversion using Option for error handling

### DIFF
--- a/parachain/pallets/incentivized-channel/src/inbound/envelope.rs
+++ b/parachain/pallets/incentivized-channel/src/inbound/envelope.rs
@@ -63,7 +63,7 @@ impl<T> TryFrom<Log> for Envelope<T>
 		};
 
 		let fee = match iter.next().ok_or(EnvelopeDecodeError)? {
-			Token::Uint(value) => T::FeeConverter::convert(value),
+			Token::Uint(value) => T::FeeConverter::convert(value).unwrap_or(0u32.into()),
 			_ => return Err(EnvelopeDecodeError)
 		};
 

--- a/parachain/pallets/incentivized-channel/src/inbound/mod.rs
+++ b/parachain/pallets/incentivized-channel/src/inbound/mod.rs
@@ -60,7 +60,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type TreasuryAccount: Get<Self::AccountId>;
 
-		type FeeConverter: Convert<U256, BalanceOf<Self>>;
+		type FeeConverter: Convert<U256, Option<BalanceOf<Self>>>;
 
 		/// The origin which may update reward related params
 		type UpdateOrigin: EnsureOrigin<Self::Origin>;

--- a/parachain/pallets/incentivized-channel/src/inbound/test.rs
+++ b/parachain/pallets/incentivized-channel/src/inbound/test.rs
@@ -127,9 +127,9 @@ parameter_types! {
 
 pub struct FeeConverter<T: Config>(PhantomData<T>);
 
-impl<T: Config> Convert<U256, BalanceOf<T>> for FeeConverter<T> {
-	fn convert(_: U256) -> BalanceOf<T> {
-		100u32.into()
+impl<T: Config> Convert<U256, Option<BalanceOf<T>>> for FeeConverter<T> {
+	fn convert(_: U256) -> Option<BalanceOf<T>> {
+		Some(100u32.into())
 	}
 }
 

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -527,10 +527,9 @@ parameter_types! {
 }
 
 pub struct FeeConverter;
-impl Convert<U256, Balance> for FeeConverter {
-	fn convert(amount: U256) -> Balance {
+impl Convert<U256, Option<Balance>> for FeeConverter {
+	fn convert(amount: U256) -> Option<Balance> {
 		dot_app::primitives::unwrap::<Runtime>(amount, Decimals::get())
-			.expect("Should not panic unless runtime is misconfigured")
 	}
 }
 

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -531,10 +531,9 @@ parameter_types! {
 }
 
 pub struct FeeConverter;
-impl Convert<U256, Balance> for FeeConverter {
-	fn convert(amount: U256) -> Balance {
+impl Convert<U256, Option<Balance>> for FeeConverter {
+	fn convert(amount: U256) -> Option<Balance> {
 		dot_app::primitives::unwrap::<Runtime>(amount, Decimals::get())
-			.expect("Should not panic unless runtime is misconfigured")
 	}
 }
 

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -531,10 +531,9 @@ parameter_types! {
 }
 
 pub struct FeeConverter;
-impl Convert<U256, Balance> for FeeConverter {
-	fn convert(amount: U256) -> Balance {
+impl Convert<U256, Option<Balance>> for FeeConverter {
+	fn convert(amount: U256) -> Option<Balance> {
 		dot_app::primitives::unwrap::<Runtime>(amount, Decimals::get())
-			.expect("Should not panic unless runtime is misconfigured")
 	}
 }
 


### PR DESCRIPTION
Fee conversion errors would cause the parachain to panic. This change introduces option types for error handling of conversions. If there is an error converting fees it will default to 0.

Resolves: https://linear.app/snowfork/issue/SNO-134/parachain-should-never-panic

