### PR TITLE
Remove obsolete documentation from READMEs

### DIFF
--- a/parachain/README.md
+++ b/parachain/README.md
@@ -70,47 +70,19 @@ The parachain will output logs to `200.log`.
 
 ## Configuration
 
-For a fully operational chain, further configuration may be required.
+Note: This section is not necessary for local development, as there are scripts to auto-configure the parachain.
 
-### Ethereum Genesis Block
+For a fully operational chain, further configuration of the initial chain spec is required. The specific configuration will depend heavily on your environment, so this guide will remain high-level.
 
-The parachain needs to be synced with the Ethereum chain before it can verify and dispatch Ethereum events. To bootstrap / sync the parachain quickly, it's advisable to set a newly finalized Ethereum block in the chain spec.
-
-To get a newly finalized Ethereum block in a format compatible with Substrate's chain spec, use the `getblock` relayer command:
-
+Build an initial spec:
 ```bash
-cd ../relayer
-# Alternatively, use '--format rust' to get the Rust code
-build/snowbridge-relay getblock --config /tmp/relay-config.toml --format json
+target/debug/snowbridge build-spec --disable-default-bootnode > spec.json
 ```
 
-Insert the output of the `getblock` command in the `initial_header` field in the `ethereum_light_client` section of the chain spec.
+Now edit the spec and configure the following:
+1. Recently finalized ethereum header and difficulty for the ethereum light client
+2. Contract addresses for the Ether, Erc20, and Dot apps.
+3. Authorized principal for the basic channel
+4. Fee and reward parameters for the incentivized channel
 
-### Ethereum Contract Addresses
-
-Each application module (ETH, ERC20) within the parachain must be configured with the contract address for its peer application on the Ethereum side. These addresses are included in Genesis storage via the chain spec.
-
-For development and testing, it is not necessary to configure these. The builtin chain-spec already includes addresses that work out of the box with contracts deployed via `ganache-cli`.
-
-To change the config to use your own addresses, follow these steps:
-
-Generate a development chain-spec:
-
-```bash
-target/debug/snowbridge-node build-spec --dev > spec.json
-```
-
-Edit the generated spec file and replace the following addresses:
-
-```json
-      "ethApp": {
-        "address": "0xfc97a6197dc90bef6bbefd672742ed75e9768553"
-      },
-      "erc20App": {
-        "address": "0xeda338e4dc46038493b885327842fd3e301cab39"
-      }
-```
-
-## API Documentation
-
-See our [Rustdocs](https://polkaeth-rustdocs.netlify.app) for an overview of the crates, APIs, and types that make up our parachain.
+For an example configuration, consult the [setup script](https://github.com/Snowfork/snowbridge/blob/main/test/scripts/start-services.sh) for our local development stack. Specifically the `start_polkadot_launch` bash function.

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -63,65 +63,9 @@ go generate ./...
 
 ## Configuration
 
-Before running the relayer, it needs to be configured first. By default the configuration file is read from  `~/.config/snowbridge-relay/config.toml`, but this can be overriden by passing the `--config PATH` flag to the relayer binary.
+Note: For local development and testing, we use our E2E test stack described [here](../test/README.md). It automatically generates a suitable configuration for testing.
 
-Example Configuration:
-
-```toml
-[ethereum]
-endpoint = "ws://localhost:8545/"
-descendants-until-final = 3
-beefylightclient = "0x8cF6147918A5CBb672703F879f385036f8793a24"
-
-[ethereum.channels.basic]
-inbound = "0x992B9df075935E522EC7950F37eC8557e86f6fdb"
-outbound = "0x2ffA5ecdBe006d30397c7636d3e015EEE251369F"
-
-[ethereum.channels.incentivized]
-inbound = "0xFc97A6197dc90bef6bbEFD672742Ed75E9768553"
-outbound = "0xEDa338E4dC46038493b885327842fD3E301CaB39"
-
-[parachain]
-endpoint = "ws://127.0.0.1:11144/"
-
-[relaychain]
-endpoint = "ws://127.0.0.1:9944/"
-
-[database]
-dialect = "sqlite3"
-dbpath = "tmp.db"
-```
-
-NOTE: For development and testing, we use our E2E test stack described [here](../test/README.md). It automatically generates a suitable configuration for testing.
-
-### Secrets
-
-The relayer requires secret keys for submitting transactions to both chains. It reads these keys from environment variables.
-
-Example:
-
-```bash
-export BEEFY_RELAYER_ETHEREUM_KEY="0x935b65c833ced92c43ef9de6bff30703d941bd92a2637cb00cfad389f5862109"
-export PARACHAIN_COMMITMENT_RELAYER_ETHEREUM_KEY="0x8013383de6e5a891e7754ae1ef5a21e7661f1fe67cd47ca8ebf4acd6de66879a"
-export ARTEMIS_PARACHAIN_KEY="//Relay"
-export ARTEMIS_RELAYCHAIN_KEY="//Alice"
-```
-
-## Build
-
-```bash
-mage build
-```
-
-## Run
-
-Run the relayer with the configuration described in [Configuration](#configuration).
-
-```bash
-build/snowbridge-relay run --config config.toml
-```
-
-NOTE: On its first run, the relayer has to perform some initial computation relating to Ethereum PoW verification. This can take over 10 minutes to complete, and is not a sign that its stuck or frozen.
+For an example configuration, please consult the [setup script](https://github.com/Snowfork/snowbridge/blob/main/test/scripts/start-services.sh) for our local development stack. Specifically the `start_relayer` bash function.
 
 ## Tests
 


### PR DESCRIPTION
The configuration sections were either misleading or just plain wrong/outdated. Especially for new developers onboarding. The local E2E test stack sets up configuration automatically for the parachain and relayer.