### PR TITLE
Solidity ERC20App V2

### DIFF
--- a/ethereum/contracts/ERC20App.sol
+++ b/ethereum/contracts/ERC20App.sol
@@ -79,12 +79,6 @@ contract ERC20App is AccessControl {
             "Invalid channel ID"
         );
 
-        uint8 _decimals;
-        string memory _name;
-        string memory _symbol;
-
-        (_name, _symbol, _decimals) = tokenDetails(_token);
-
         balances[_token] = balances[_token] + _amount;
 
         emit Locked(_token, msg.sender, _recipient, _amount, _paraId);
@@ -93,14 +87,8 @@ contract ERC20App is AccessControl {
             channels[_channelId].outbound
         );
 
-        bytes memory createCall;
         if (!wrappedTokenList[_token]) {
-            createCall = encodeCreateTokenCall(
-                _token,
-                _name,
-                _symbol,
-                _decimals
-            );
+            bytes memory createCall = encodeToken(_token);
             wrappedTokenList[_token] = true;
             channel.submit(msg.sender, createCall);
         }
@@ -225,5 +213,16 @@ contract ERC20App is AccessControl {
             _decimals = 0;
         }
         return (_name, _symbol, _decimals);
+    }
+
+    function encodeToken(address _token) private view returns (bytes memory) {
+        uint8 _decimals;
+        string memory _name;
+        string memory _symbol;
+
+        (_name, _symbol, _decimals) = tokenDetails(_token);
+        bytes memory createCall;
+        createCall = encodeCreateTokenCall(_token, _name, _symbol, _decimals);
+        return (createCall);
     }
 }

--- a/ethereum/contracts/ERC20App.sol
+++ b/ethereum/contracts/ERC20App.sol
@@ -44,8 +44,6 @@ contract ERC20App is AccessControl {
         uint256 amount
     );
 
-    event TokenWrapped(address token, address operator);
-
     struct Channel {
         address inbound;
         address outbound;
@@ -65,16 +63,6 @@ contract ERC20App is AccessControl {
 
         _setupRole(INBOUND_CHANNEL_ROLE, _basic.inbound);
         _setupRole(INBOUND_CHANNEL_ROLE, _incentivized.inbound);
-    }
-
-    function addWrapppedToken(address _token)
-        public
-        onlyRole(INBOUND_CHANNEL_ROLE)
-    {
-        require(!wrappedTokenList[_token], "Wrapped token already exists");
-        wrappedTokenList[_token] = true;
-
-        emit TokenWrapped(_token, msg.sender);
     }
 
     function lock(
@@ -109,6 +97,7 @@ contract ERC20App is AccessControl {
                 _symbol,
                 _decimals
             );
+            wrappedTokenList[_token] = true;
             channel.submit(msg.sender, createCall);
         }
 

--- a/ethereum/contracts/test/MockOutboundChannel.sol
+++ b/ethereum/contracts/test/MockOutboundChannel.sol
@@ -5,7 +5,9 @@ pragma experimental ABIEncoderV2;
 import "../OutboundChannel.sol";
 
 contract MockOutboundChannel is OutboundChannel {
-    function submit(address, bytes calldata) external override {
+    event Message(address source, bytes data);
 
+    function submit(address, bytes calldata data) external override {
+        emit Message(msg.sender, data);
     }
 }

--- a/ethereum/contracts/test/TestToken20.sol
+++ b/ethereum/contracts/test/TestToken20.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+
+contract ERC20 is Context, IERC20 {
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+
+    constructor() {}
+
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+
+        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+        unchecked {
+            _approve(sender, _msgSender(), currentAllowance - amount);
+        }
+
+        return true;
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender] + addedValue);
+        return true;
+    }
+
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        unchecked {
+            _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+        }
+
+        return true;
+    }
+
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        uint256 senderBalance = _balances[sender];
+        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
+        unchecked {
+            _balances[sender] = senderBalance - amount;
+        }
+        _balances[recipient] += amount;
+
+        emit Transfer(sender, recipient, amount);
+
+        _afterTokenTransfer(sender, recipient, amount);
+    }
+
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply += amount;
+        _balances[account] += amount;
+        emit Transfer(address(0), account, amount);
+
+        _afterTokenTransfer(address(0), account, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        uint256 accountBalance = _balances[account];
+        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+        unchecked {
+            _balances[account] = accountBalance - amount;
+        }
+        _totalSupply -= amount;
+
+        emit Transfer(account, address(0), amount);
+
+        _afterTokenTransfer(account, address(0), amount);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+
+
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+}
+
+
+
+contract TestToken20 is ERC20 {
+    constructor(){}
+    
+    function mint(address to, uint256 _amount) public {
+        _mint(to, _amount);
+    }
+}

--- a/ethereum/test/test_erc20_app.js
+++ b/ethereum/test/test_erc20_app.js
@@ -23,12 +23,9 @@ const approveFunds = (token, contract, account, amount) => {
   return token.approve(contract.address, amount, { from: account })
 }
 
-const lockupFunds = (contract, token, name, symbol, decimals, sender, recipient, amount, channel) => {
+const lockupFunds = (contract, token, sender, recipient, amount, channel) => {
   return contract.lock(
     token.address,
-    name,
-    symbol,
-    decimals,
     addressBytes(recipient),
     amount.toString(),
     channel,
@@ -89,7 +86,7 @@ describe("ERC20App", function () {
       await approveFunds(this.token, this.app, userOne, amount * 2)
         .should.be.fulfilled;
 
-      let createMintTokenTransaction = await lockupFunds(this.app, this.token, this.name, this.symbol, this.decimals, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
+      let createMintTokenTransaction = await lockupFunds(this.app, this.token, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
         .should.be.fulfilled;
 
       // Confirm app event emitted with expected values
@@ -115,7 +112,7 @@ describe("ERC20App", function () {
       await approveFunds(this.token, this.app, userOne, amount * 2)
       .should.be.fulfilled;
 
-      let mintOnlyTokenTransaction = await lockupFunds(this.app, this.token, this.name, this.symbol, this.decimals, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
+      let mintOnlyTokenTransaction = await lockupFunds(this.app, this.token, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
         .should.be.fulfilled;
 
       const pastEvents = await MyContract.getPastEvents({fromBlock: 0})
@@ -155,7 +152,7 @@ describe("ERC20App", function () {
       const lockupAmount = 200;
       await approveFunds(this.token, this.app, userOne, lockupAmount * 2)
         .should.be.fulfilled;
-      let tx = await lockupFunds(this.app, this.token, this.name, this.symbol, this.decimals, userOne, POLKADOT_ADDRESS, lockupAmount, ChannelId.Basic)
+      let tx = await lockupFunds(this.app, this.token, userOne, POLKADOT_ADDRESS, lockupAmount, ChannelId.Basic)
         .should.be.fulfilled;
 
       // recipient on the ethereum side

--- a/ethereum/test/test_erc20_app.js
+++ b/ethereum/test/test_erc20_app.js
@@ -165,14 +165,24 @@ describe("ERC20App", function () {
       const pastEvents = await MyContract.getPastEvents({fromBlock: 0})
 
       let messageEventCountforminttx = 0, messageEventCountforMintNcreateTx = 0;
+      let noNameTokenCreateEventTrigged = false;
+
       pastEvents.forEach(event => {
           if(event.transactionHash === createMintTokenTransaction.tx){
             messageEventCountforMintNcreateTx++;
+            const encodeValue =  web3.utils.soliditySha3({type: 'bytes2', value: '0x4202'},this.token1.address, {type: 'bytes1', value: '0x00'}, {type: 'bytes1', value: '0x00'})
+            const encodeTokenData = web3.utils.keccak256(event.returnValues.data);
+
+            if(encodeValue == encodeTokenData) {
+                noNameTokenCreateEventTrigged = true;
+              }
           }
           
           if(event.transactionHash === mintOnlyTokenTransaction.tx)
             messageEventCountforminttx++;
         });
+
+        noNameTokenCreateEventTrigged.should.be.true;
 
         // Confirm message event emitted only twice for 1.create token and 2.mint call.
       messageEventCountforMintNcreateTx.should.be.equal(2)

--- a/ethereum/test/test_erc20_app.js
+++ b/ethereum/test/test_erc20_app.js
@@ -79,8 +79,6 @@ describe("ERC20App", function () {
       this.token = await TestToken.new(this.name, this.symbol);
       await this.token.mint(userOne, "10000").should.be.fulfilled;
 
-      this.wtoken = await TestToken.new("Wrapped Token", "WTKN");
-      await this.wtoken.mint(userOne, "10000").should.be.fulfilled;
     });
 
     it("should lock funds", async function () {
@@ -111,16 +109,13 @@ describe("ERC20App", function () {
  
       let MyContract = new web3.eth.Contract(this.outboundChannel.abi, this.outboundChannel.address);
 
-      await addTokenDeatils(this.app, this.wtoken, inboundChannel)
-      .should.be.fulfilled;
-
-      (await this.app.wrappedTokenList(this.wtoken.address))
+      (await this.app.wrappedTokenList(this.token.address))
       .should.be.equal(true);
       
-      await approveFunds(this.wtoken, this.app, userOne, amount * 2)
+      await approveFunds(this.token, this.app, userOne, amount * 2)
       .should.be.fulfilled;
 
-      let mintOnlyTokenTransaction = await lockupFunds(this.app, this.wtoken, this.name, this.symbol, this.decimals, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
+      let mintOnlyTokenTransaction = await lockupFunds(this.app, this.token, this.name, this.symbol, this.decimals, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic)
         .should.be.fulfilled;
 
       const pastEvents = await MyContract.getPastEvents({fromBlock: 0})


### PR DESCRIPTION
This PR resolves the ticket : https://linear.app/snowfork/issue/SNO-158/solidity-erc20app-v2
It contains the assumption that only address with INBOUND_CHANNEL_ROLE  is allowed to add wrapped token address to the list.