### PR TITLE
Type metadata no longer needs to be maintained offchain

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,6 @@
     "@polkadot/api": "^7.2.1",
     "@polkadot/util": "^8.2.2",
     "@polkadot/util-crypto": "^8.2.2",
-    "@snowfork/snowbridge-types": "file:../types",
     "@types/node": "^16.4.2",
     "@types/yargs": "^17.0.2",
     "bignumber.js": "^9.0.0",

--- a/test/scripts/helpers/subscribeBeefyJustifications.js
+++ b/test/scripts/helpers/subscribeBeefyJustifications.js
@@ -9,7 +9,6 @@ const { ApiPromise, WsProvider } = require('@polkadot/api');
 const WebSocket = require('ws');
 const { base58Decode, addressToEvm, secp256k1Expand, secp256k1Compress, decodeAddress, encodeAddress, ethereumEncode, blake2AsHex, keccakAsHex } = require("@polkadot/util-crypto");
 const { hexToU8a, u8aToHex, u8aToU8a } = require("@polkadot/util");
-let { bundle } = require("@snowfork/snowbridge-types");
 
 const RELAY_CHAIN_RPC_ENDPOINT = 'ws://localhost:9944';
 const RELAY_CHAIN_HTTP_RPC_ENDPOINT = 'http://localhost:30444';
@@ -196,7 +195,6 @@ async function getParaHeadData(paraHead) {
   const parachainWsProvider = new WsProvider(PARACHAIN_RPC_ENDPOINT);
   const parachainApi = await ApiPromise.create({
     provider: parachainWsProvider,
-    typesBundle: bundle,
   });
 
   const truncatedHead = paraHead.toHuman().slice(0, 66);

--- a/test/scripts/make-xcm-transfer.ts
+++ b/test/scripts/make-xcm-transfer.ts
@@ -1,7 +1,6 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import { createType } from "@polkadot/types";
 import { Keyring } from "@polkadot/api";
-import { bundle } from "@snowfork/snowbridge-types";
 import yargs from "yargs"
 
 import type { MultiLocation } from "@polkadot/types/interfaces/xcm/types";
@@ -96,7 +95,6 @@ let main = async () => {
 
   let api = await ApiPromise.create({
     provider,
-    typesBundle: bundle as any,
   });
 
   const keyring = new Keyring({ type: "sr25519" });

--- a/test/src/subclient/index.js
+++ b/test/src/subclient/index.js
@@ -1,5 +1,4 @@
 let { ApiPromise, WsProvider, Keyring } = require('@polkadot/api');
-let { bundle } = require("@snowfork/snowbridge-types");
 const { default: BigNumber } = require('bignumber.js');
 
 class SubClient {
@@ -14,7 +13,6 @@ class SubClient {
     const provider = new WsProvider(this.endpoint);
     this.api = await ApiPromise.create({
       provider,
-      typesBundle: bundle,
     })
 
     this.keyring = new Keyring({ type: 'sr25519' });

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -556,7 +556,7 @@
     "@babel/runtime" "^7.16.7"
     "@polkadot/util" "^8.2.2"
 
-"@polkadot/types@7.2.1", "@polkadot/types@^7.2.1":
+"@polkadot/types@7.2.1":
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.2.1.tgz#b8b1d8a8c38fad979df00ff20e3724d52328edfb"
   integrity sha512-9LDi13JjULcCMMRM8lHcQm/qlEoh+nebqBd1k3f1jbbLnhV0ddTFp1s/ldkbpeL4eXIIV2E3+uENfuTcDdEruQ==
@@ -687,13 +687,6 @@
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
-"@snowfork/snowbridge-types@file:../types":
-  version "0.2.7"
-  dependencies:
-    "@polkadot/api" "^7.2.1"
-    "@polkadot/keyring" "^8.2.2"
-    "@polkadot/types" "^7.2.1"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"

--- a/types/README.md
+++ b/types/README.md
@@ -1,6 +1,9 @@
 # Snowbridge Types
 
-Type definitions for the Snowbridge parachain
+_Note: This package is obsolete and is slated for removal._
+
+Type definitions for the Snowbridge parachain.
+
 
 ## Development
 


### PR DESCRIPTION
As of runtime metadata V14, type metadata is available on-chain: https://github.com/paritytech/substrate/pull/8615