### PR TITLE
Fix nonces as part of recovering from a fork.

### DIFF
--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -151,7 +151,7 @@ const fetchEthNonces = async (
     );
     // get all nonce changing events that happened after the new finalized
     pastEvents[nonce.name] = contract.getPastEvents(nonce.event, {
-      fromBlock: commonAnscestorBlockNumber + 1 - descendantsUntilFinalized,
+      fromBlock: commonAnscestorBlockNumber - descendantsUntilFinalized,
       toBlock: "latest",
     });
     nonces[nonce.name] = contract.methods.nonce().call();
@@ -323,7 +323,7 @@ const main = async () => {
     console.log(`Checking block number ${number}...`);
     const ethBlock = await ethApi.eth.getBlock(number, false);
     const paraBlock: any = await fetchImported(parachainApi, ethBlock.hash);
-    if (paraBlock === null && !paraBlock.finalized) continue;
+    if (paraBlock === null || !paraBlock.finalized) continue;
 
     assert(
       ethBlock.number === paraBlock.header.number,

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -5,6 +5,7 @@ import { exit } from "process";
 import Web3 from "web3";
 import yargs from "yargs";
 import { createInterface } from "readline";
+import * as https from "https";
 
 const rl = createInterface({ input: process.stdin, output: process.stdout });
 const keyring = new Keyring({ type: "sr25519" });
@@ -73,6 +74,90 @@ const fetchImported = async (api: ApiPromise, hash: string) => {
     .toJSON();
 };
 
+const getContracts = (url: string): Promise<any> => {
+  return new Promise<any>(function (ok, err) {
+    const buffers: Array<Buffer> = [];
+    https
+      .get(url, (res) => {
+        if (res.statusCode === 200) {
+          res.on("data", (d) => {
+            buffers.push(d);
+          });
+          res.on("end", () => {
+            ok(JSON.parse(Buffer.concat(buffers).toString("utf8")));
+          });
+        } else err(res.statusMessage);
+      })
+      .on("error", (e) => {
+        err(e);
+      });
+  });
+};
+
+const NONCES = [
+  { name: "BasicInboundChannel", event: "MessageDispatched", storageKey: "0x684b82bef882079feeabe54a5bd7b94a718368a0ace36e2b1b8b6dbd7f8093c0", },
+  { name: "IncentivizedInboundChannel", event: "MessageDispatched", storageKey: "0xf0f4d0b91e760c07da58bc0498033acb718368a0ace36e2b1b8b6dbd7f8093c0" },
+  { name: "BasicOutboundChannel", event: "Message", storageKey: "0x664ff6e369f56e1c7deca5487e631a5c718368a0ace36e2b1b8b6dbd7f8093c0" },
+  { name: "IncentivizedOutboundChannel", event: "Message", storageKey: "0x557df379daaf1cd514a7452dcbf6fccc718368a0ace36e2b1b8b6dbd7f8093c0" },
+];
+
+const fetchEthNonces = async (
+  contractsConfig: any,
+  ethApi: Web3,
+  commonAnscestorBlockNumber: number
+): Promise<any> => {
+
+  const pastEvents = {};
+  const nonces = {};
+  for (const nonce of NONCES) {
+    var contract = new ethApi.eth.Contract(
+      contractsConfig[nonce.name].abi,
+      contractsConfig[nonce.name].address,
+    );
+    // get all nonce changing events that happened after the new finalized
+    pastEvents[nonce.name] = contract.getPastEvents(nonce.event, {
+      fromBlock: commonAnscestorBlockNumber + 1 - 8,
+      toBlock: "latest",
+    });
+    nonces[nonce.name] = contract.methods.nonce().call();
+  }
+
+  await Promise.all(Object.values(pastEvents).concat(Object.values(nonces)));
+
+  const result = {};
+  for (const nonce of NONCES) {
+    const events = await pastEvents[nonce.name];
+    // take the first event if there are any else get take the current nonce.
+    if(events.length > 0) {
+      result[nonce.name] = Number(events[0].returnValues["nonce"]) - 1;
+    } else {
+      result[nonce.name] = Number(await nonces[nonce.name]);
+    }
+  }
+  return result;
+};
+
+const fetchParachainNonces = async (parachainApi: ApiPromise): Promise<any> => {
+  const promises = {};
+  for (const nonce of NONCES) {
+    promises[nonce.name] = parachainApi.query[`${nonce.name[0].toLowerCase()}${nonce.name.substring(1)}`].nonce();
+  }
+
+  await Promise.all(Object.values(promises));
+
+  const result = {};
+  for (const nonce of NONCES) {
+    result[nonce.name] = (await promises[nonce.name]).toNumber();
+  }
+  return result;
+};
+
+const generateUpdates = (ethNonces, parachainNonces) => {
+  const result = [];
+
+  return result;
+};
+
 const main = async () => {
   const argv = yargs.options({
     "eth-url": {
@@ -84,6 +169,11 @@ const main = async () => {
       type: "string",
       demandOption: true,
       describe: "API endpoint of source parachain",
+    },
+    "contracts-url": {
+      type: "string",
+      demandOption: true,
+      describe: "url to contracts.json file.",
     },
     blocks: {
       type: "number",
@@ -97,13 +187,17 @@ const main = async () => {
       describe: "The ethereum block number or hash to start the search.",
       default: null,
     },
-    "fix": {
+    fix: {
       type: "string",
       demandOption: false,
       describe: "Fix the fork with the following user. e.g. '//Alice'",
       default: null,
     },
   }).argv as any;
+
+  console.log("Fetching contracts.");
+  const contractsConfig = await getContracts(argv["contracts-url"]);
+  console.log("Fetch complete.");
 
   // intialize api clients
   const parachainApi = await ApiPromise.create({
@@ -132,12 +226,26 @@ const main = async () => {
   );
   if (ethFinalized.hash === paraFinalized.hash) {
     console.log("There is no fork.");
-    process.exit(0);
+    // process.exit(0);
   }
 
   // Walk backwards until we find a finalized block.
-  console.log("Fork found");
+  console.log("Fork found. Checking nonces.");
 
+  const ethNonces = await fetchEthNonces(contractsConfig.contracts, ethApi, 12007719);
+  const parachainNonces = await fetchParachainNonces(parachainApi);
+
+  console.log("Nonces                Parachain -> ETH");
+  console.log(`Basic Channel:        ${parachainNonces.BasicOutboundChannel} -> ${ethNonces.BasicInboundChannel}`);
+  console.log(`Incentivized Channel: ${parachainNonces.IncentivizedOutboundChannel} -> ${ethNonces.IncentivizedInboundChannel}`);
+
+  console.log("Nonces                Parachain <- ETH");
+  console.log(`Basic Channel:        ${parachainNonces.BasicInboundChannel} <- ${ethNonces.BasicOutboundChannel}`);
+  console.log(`Incentivized Channel: ${parachainNonces.IncentivizedInboundChannel} <- ${ethNonces.IncentivizedOutboundChannel}`);
+
+  console.log(generateUpdates(ethNonces, parachainNonces));
+
+  process.exit(1);// TODO:::::: REMOVE
   const startNumber = (
     await ethApi.eth.getBlock(
       argv["probe-from"] ?? ethFinalized.number - 1,

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -34,14 +34,14 @@ const forceResetToFork = (
     const items = [];
     for (const update of updates) {
       items.push([
-        updates.storageKey,
+        update.storageKey,
         api.createType("u64", update.nonce).toHex(),
       ]);
     }
     calls.push(api.tx.system.setStorage(items));
   }
 
-  const batch = api.tx.utility.batchAll(...calls);
+  const batch = api.tx.utility.batchAll(calls);
 
   return new Promise<ISubmittableResult>(async (ok, err) => {
     const unsub = await api.tx.sudo

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -209,23 +209,6 @@ const generateUpdates = (ethNonces, parachainNonces) => {
       nonce: ethNonces.IncentivizedOutboundChannel,
     });
   }
-  if (parachainNonces.BasicOutboundChannel !== ethNonces.BasicInboundChannel) {
-    result.push({
-      name: NONCES[2].name,
-      storageKey: NONCES[2].storageKey,
-      nonce: ethNonces.BasicInboundChannel,
-    });
-  }
-  if (
-    parachainNonces.IncentivizedOutboundChannel !==
-    ethNonces.IncentivizedInboundChannel
-  ) {
-    result.push({
-      name: NONCES[3].name,
-      storageKey: NONCES[3].storageKey,
-      nonce: ethNonces.IncentivizedInboundChannel,
-    });
-  }
   return result;
 };
 

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -35,7 +35,7 @@ const forceResetToFork = (
     for (const update of updates) {
       items.push([
         update.storageKey,
-        api.createType("u64", update.nonce).toHex(),
+        api.createType("u64", update.nonce).toHex(true),
       ]);
     }
     calls.push(api.tx.system.setStorage(items));

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -261,7 +261,7 @@ const main = async () => {
   );
   if (ethFinalized.hash === paraFinalized.hash) {
     console.log("There is no fork.");
-    // process.exit(0);
+    process.exit(0);
   }
 
   // Walk backwards until we find a finalized block.
@@ -318,7 +318,7 @@ const main = async () => {
       if (!(await areYouSure("Are you sure? ", "yes"))) {
         exit(0);
       }
-      //await forceResetToFork(parachainApi, ethBlock.hash, fixWithUser, updates);
+      await forceResetToFork(parachainApi, ethBlock.hash, fixWithUser, updates);
     }
 
     process.exit(0);

--- a/test/scripts/detect-fork.ts
+++ b/test/scripts/detect-fork.ts
@@ -140,7 +140,7 @@ const fetchEthNonces = async (
   contractsConfig: any,
   ethApi: Web3,
   commonAnscestorBlockNumber: number,
-  decendantsUntilFinalized: number
+  descendantsUntilFinalized: number
 ): Promise<any> => {
   const pastEvents = {};
   const nonces = {};
@@ -151,7 +151,7 @@ const fetchEthNonces = async (
     );
     // get all nonce changing events that happened after the new finalized
     pastEvents[nonce.name] = contract.getPastEvents(nonce.event, {
-      fromBlock: commonAnscestorBlockNumber + 1 - decendantsUntilFinalized,
+      fromBlock: commonAnscestorBlockNumber + 1 - descendantsUntilFinalized,
       toBlock: "latest",
     });
     nonces[nonce.name] = contract.methods.nonce().call();
@@ -264,11 +264,11 @@ const main = async () => {
       describe: "Fix the fork with the following user. e.g. '//Alice'",
       default: null,
     },
-    "decendants-until-finalized": {
+    "descendants-until-finalized": {
       type: "number",
       demandOption: false,
       describe:
-        "The number of decendants until a block is considered finalized.",
+        "The number of descendants until a block is considered finalized.",
       default: 8,
     },
   }).argv as any;
@@ -342,7 +342,7 @@ const main = async () => {
       contractsConfig.contracts,
       ethApi,
       ethBlock.number,
-      argv["decendants-until-finalized"]
+      argv["descendants-until-finalized"]
     );
 
     console.log("Nonces                Parachain -> ETH");


### PR DESCRIPTION
Resolves: SNO-218.

The script will now detect and fix nonce changes. Updating the nonce will allow double spend but this is a compromise to solve the longe range forks in our staging environment.

The way that `force_reset_to_fork` currently works is that it sets the `BestBlock` and rewinds the `FinalizedBlock` by 8 blocks(`DescendantsUntilFinalized`). This is not ideal as the relayer starts from the `FinalizedBlock` and will replay messages from there. This means there is a potential 8 block window in which transactions will be replayed. To change this we would need to change `force_reset_to_fork` to set the `FinalizedBlock` and walk forward 8 blocks to set the `BestBlock`.
