### PR TITLE
Updated libsecp256k1 dependency

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -9725,7 +9725,6 @@ dependencies = [
  "ethereum-types",
  "getrandom 0.2.3",
  "hex-literal",
- "libsecp256k1 0.7.0",
  "parity-bytes",
  "parity-scale-codec",
  "rand 0.7.3",

--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -4026,20 +4026,6 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
@@ -9739,7 +9725,7 @@ dependencies = [
  "ethereum-types",
  "getrandom 0.2.3",
  "hex-literal",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.7.0",
  "parity-bytes",
  "parity-scale-codec",
  "rand 0.7.3",

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -13,7 +13,6 @@ ethbloom = { version = "0.11.0", default-features = false }
 ethereum-types = { version = "0.12.0", default-features = false, features = ["codec", "rlp", "serialize"] }
 hex = { package = "rustc-hex", version = "2.1.0", default-features = false }
 hex-literal = { version = "0.3.1", default-features = false }
-libsecp256k1 = { version = "0.7", default-features = false }
 parity-bytes = { version = "0.1.2", default-features = false }
 rlp = { version = "0.5", default-features = false }
 getrandom = { version = "0.2.1", features = ["js"] }
@@ -46,7 +45,6 @@ std = [
 	"ethbloom/std",
 	"ethereum-types/std",
 	"hex/std",
-	"libsecp256k1/std",
 	"parity-bytes/std",
 	"rlp/std",
 	"sp-core/std",

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -13,7 +13,7 @@ ethbloom = { version = "0.11.0", default-features = false }
 ethereum-types = { version = "0.12.0", default-features = false, features = ["codec", "rlp", "serialize"] }
 hex = { package = "rustc-hex", version = "2.1.0", default-features = false }
 hex-literal = { version = "0.3.1", default-features = false }
-libsecp256k1 = { version = "0.3", default-features = false }
+libsecp256k1 = { version = "0.7", default-features = false }
 parity-bytes = { version = "0.1.2", default-features = false }
 rlp = { version = "0.5", default-features = false }
 getrandom = { version = "0.2.1", features = ["js"] }


### PR DESCRIPTION
Removed all references to libsecp256k1 not `>=0.5.0`.

https://rustsec.org/advisories/RUSTSEC-2021-0076

e2e tests pass.