### PR TITLE
misc cleanups

### DIFF
--- a/ethereum/test/helpers.js
+++ b/ethereum/test/helpers.js
@@ -126,8 +126,6 @@ async function mine(n) {
   }
 }
 
-const addressBytes = (address) => Buffer.from(address.replace(/^0x/, ""), "hex");
-
 const encodeLog = (log) => {
   return rlp.encode([log.address, log.topics, log.data]).toString("hex")
 }
@@ -189,7 +187,6 @@ module.exports = {
   createMerkleTree,
   signatureSubstrateToEthereum,
   mine,
-  addressBytes,
   ChannelId,
   encodeLog,
   mergeKeccak256,

--- a/ethereum/test/test_dot_app.js
+++ b/ethereum/test/test_dot_app.js
@@ -8,7 +8,6 @@ require("chai")
 
 const {
   deployAppWithMockChannels,
-  addressBytes,
   ChannelId,
 } = require("./helpers");
 const { expect } = require("chai");
@@ -31,7 +30,7 @@ const unwrapped = (amount) =>
 
 const burnTokens = (contract, sender, recipient, amount, channel) => {
   return contract.burn(
-    addressBytes(recipient),
+    recipient,
     amount.toString(),
     channel,
     {
@@ -80,7 +79,7 @@ describe("DOTApp", function () {
       const amountWrapped = wrapped(amountNative);
 
       let tx = await this.app.mint(
-        addressBytes(POLKADOT_ADDRESS),
+        POLKADOT_ADDRESS,
         userOne,
         amountWrapped.toString(),
         {
@@ -121,7 +120,7 @@ describe("DOTApp", function () {
       let amountNative = BigNumber("20000000000"); // 2 DOT, uint128
       let amountWrapped = wrapped(amountNative);
       await this.app.mint(
-        addressBytes(POLKADOT_ADDRESS),
+        POLKADOT_ADDRESS,
         userOne,
         amountWrapped.toString(),
         {
@@ -168,14 +167,14 @@ describe("DOTApp", function () {
       const abi = ["event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"];
       this.iface = new ethers.utils.Interface(abi);
     });
-    
+
     it("should revert when called by non-admin", async function () {
       await this.app.upgrade(
         [this.newInboundChannel, this.outboundChannel.address],
         [this.newInboundChannel, this.outboundChannel.address],
         {from: userOne}).should.be.rejectedWith(/AccessControl/);
     });
-    
+
     it("should revert once CHANNEL_UPGRADE_ROLE has been renounced", async function () {
       await this.app.renounceRole(web3.utils.soliditySha3("CHANNEL_UPGRADE_ROLE"), owner, {from: owner});
       await this.app.upgrade(

--- a/ethereum/test/test_erc20_app.js
+++ b/ethereum/test/test_erc20_app.js
@@ -1,7 +1,6 @@
 const BigNumber = require('bignumber.js');
 const {
   deployAppWithMockChannels,
-  addressBytes,
   ChannelId,
 } = require("./helpers");
 require("chai")
@@ -27,7 +26,7 @@ const approveFunds = (token, contract, account, amount) => {
 const lockupFunds = (contract, token, sender, recipient, amount, channel, paraId, fee) => {
   return contract.lock(
     token.address,
-    addressBytes(recipient),
+    recipient,
     amount.toString(),
     channel,
     paraId,
@@ -188,7 +187,7 @@ describe("ERC20App", function () {
 
       let txPromise = this.app.unlock(
         this.token.address,
-        addressBytes(POLKADOT_ADDRESS),
+        POLKADOT_ADDRESS,
         recipient,
         amount.toString(),
         {

--- a/ethereum/test/test_erc721_app.js
+++ b/ethereum/test/test_erc721_app.js
@@ -1,7 +1,6 @@
 const BigNumber = require('bignumber.js');
 const {
   deployAppWithMockChannels,
-  addressBytes,
   ChannelId,
 } = require("./helpers");
 require("chai")
@@ -23,7 +22,7 @@ const lockupToken = (app, tokenContract, tokenId, sender, recipient, channel) =>
   return app.lock(
     tokenContract.address,
     tokenId.toString(),
-    addressBytes(recipient),
+    recipient,
     channel,
     {
       from: sender,
@@ -160,7 +159,7 @@ contract("ERC721App", function (accounts) {
       let tx = await this.app.unlock(
         this.token.address,
         tokenId.toString(),
-        addressBytes(POLKADOT_ACCOUNT_ID),
+        POLKADOT_ACCOUNT_ID,
         userTwo,
         {
           from: inboundChannel
@@ -182,7 +181,7 @@ contract("ERC721App", function (accounts) {
       await this.app.unlock(
         this.token.address,
         tokenId.toString(),
-        addressBytes(POLKADOT_ACCOUNT_ID),
+        POLKADOT_ACCOUNT_ID,
         userTwo,
         {
           from: inboundChannel
@@ -200,7 +199,7 @@ contract("ERC721App", function (accounts) {
       await this.app.unlock(
         this.token.address,
         tokenId.toString(),
-        addressBytes(POLKADOT_ACCOUNT_ID),
+        POLKADOT_ACCOUNT_ID,
         userTwo,
         {
           from: userTwo
@@ -217,14 +216,14 @@ contract("ERC721App", function (accounts) {
       const abi = ["event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"];
       this.iface = new ethers.utils.Interface(abi);
     });
-    
+
     it("should revert when called by non-admin", async function () {
       await this.app.upgrade(
         [this.newInboundChannel, this.outboundChannel.address],
         [this.newInboundChannel, this.outboundChannel.address],
         {from: userOne}).should.be.rejectedWith(/AccessControl/);
     });
-    
+
     it("should revert once CHANNEL_UPGRADE_ROLE has been renounced", async function () {
       await this.app.renounceRole(web3.utils.soliditySha3("CHANNEL_UPGRADE_ROLE"), owner, {from: owner});
       await this.app.upgrade(

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -2,7 +2,6 @@ const BigNumber = require('bignumber.js');
 const MockOutboundChannel = artifacts.require("MockOutboundChannel");
 const {
   deployAppWithMockChannels,
-  addressBytes,
   ChannelId,
 } = require("./helpers");
 
@@ -19,7 +18,7 @@ const ScaleCodec = artifacts.require("ScaleCodec");
 
 const lockupFunds = (contract, sender, recipient, amount, channel, paraId, fee) => {
   return contract.lock(
-    addressBytes(recipient),
+    recipient,
     channel,
     paraId,
     fee,
@@ -138,7 +137,7 @@ describe("ETHApp", function () {
       const unlockAmount = web3.utils.toBN( web3.utils.toWei("2", "ether")).add(web3.utils.toBN(1))
 
        await this.app.unlock(
-        addressBytes(POLKADOT_ADDRESS),
+        POLKADOT_ADDRESS,
         recipient,
         unlockAmount.toString(),
         {
@@ -147,7 +146,7 @@ describe("ETHApp", function () {
       ).should.be.rejectedWith(/Unable to send Ether/);
 
       let { receipt } = await this.app.unlock(
-        addressBytes(POLKADOT_ADDRESS),
+        POLKADOT_ADDRESS,
         recipient,
         amount.toString(),
         {

--- a/ethereum/test/test_simplified_mmr_verification.js
+++ b/ethereum/test/test_simplified_mmr_verification.js
@@ -89,28 +89,4 @@ describe("Simple MMR Verification", function () {
             });
         });
     })
-
-    describe("another test", function () {
-
-        let simplifiedMMRVerification;
-        beforeEach(async function () {
-            simplifiedMMRVerification = await SimpleMMRVerification.new();
-        })
-
-        it("whatever", async function() {
-            expect(await simplifiedMMRVerification.verifyInclusionProof.call(
-                "0x8f836c64528031e7e9252d7b0a2c5328f34142f2be83bba27543419ff96b2216",
-                "0x581725f950ac2c4e2172df60c6128bbaf3acd5d869e814f3139d66e599026e97",
-                {
-                    merkleProofItems: [
-                        "0x097113f3480b168fedf1cc813964fd98c076a4d34e3cf4ec248982de2865f5a0",
-                        "0xa62134c15c19430695a31fe7781065132c71ad10897f838831a6a2ef7aaa8700",
-                        "0x4576b4e71c3f2808f9bc98a93989dbf3066bd4446a61c440357f8f8ea3046450",
-                        "0x06a6e84c57ff5eeec44c8a308e666672b13b7f063d2a0ea1711565e74e03eeda"
-                    ],
-                    merkleProofOrderBitField: 15
-                }
-            )).to.be.true;
-        })
-    })
 });

--- a/relayer/relays/beefy/beefy-relaychain-listener.go
+++ b/relayer/relays/beefy/beefy-relaychain-listener.go
@@ -218,7 +218,7 @@ func (li *BeefyRelaychainListener) processBeefyJustifications(ctx context.Contex
 		return err
 	}
 
-	blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(blockNumber);
+	blockHash, err := li.relaychainConn.API().RPC.Chain.GetBlockHash(blockNumber)
 	if err != nil {
 		log.WithError(err).Error("Failed to get block hash")
 		return err


### PR DESCRIPTION
Some accumulated cleanups sitting in my local checkout that need to be merged in.

* unnecessary `addressBytes` method. web3 automatically converts hex strings into bytes when calling a contract method.
* leftover ethereum debugging code from last week's beefy troubleshooting