### PR TITLE
Let hardhat choose gas price

### DIFF
--- a/ethereum/hardhat.config.ts
+++ b/ethereum/hardhat.config.ts
@@ -37,7 +37,6 @@ const config: HardhatUserConfig = {
       url: `https://ropsten.infura.io/v3/${INFURA_KEY}`,
       accounts: [ROPSTEN_KEY],
       gas: 6000000,
-      gasPrice: 5000000000,
     }
   },
   solidity: {


### PR DESCRIPTION
Using a hardcoded gas price makes deployments fail on ropsten.