### PR TITLE
Import execution header extrinsic

### DIFF
--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -72,14 +72,6 @@ pub struct FinalizedHeaderUpdate {
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct HeaderUpdate {
-	pub attested_header: BeaconHeader,
-	pub execution_header: ExecutionHeader,
-	pub sync_aggregate: SyncAggregate,
-	pub fork_version: ForkVersion,
-}
-
-#[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct BlockUpdate {
 	pub block: BeaconBlock,
 	pub fork_version: ForkVersion,
@@ -316,7 +308,7 @@ pub mod pallet {
 			let _sender = ensure_signed(origin)?;
 
 			log::trace!(
-				target: "ethereum-beacon-light-client",
+				target: "ethereum-beacon-client",
 				"💫 Received transaction to be validated.",
 			);
 
@@ -622,8 +614,14 @@ pub mod pallet {
 			<FinalizedBeaconHeaders<T>>::insert(block_root, header);
 
 			let latest_finalized_header_slot = <LatestFinalizedHeaderSlot<T>>::get();
-			if latest_finalized_header_slot > slot {
-				<LatestFinalizedHeaderSlot<T>>::set(latest_finalized_header_slot);
+
+			if slot > latest_finalized_header_slot {
+				log::trace!(
+					target: "ethereum-beacon-client",
+					"💫 Updated latest finalized slot to {}.",
+					slot
+				);
+				<LatestFinalizedHeaderSlot<T>>::set(slot);
 			}
 		}
 

--- a/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
@@ -147,7 +147,7 @@ pub fn get_ssz_proposer_slashings(proposer_slashings: Vec<ProposerSlashing>) -> 
     let mut proposer_slashings_vec = Vec::new();
 
     for proposer_slashing in proposer_slashings.iter() {
-       proposer_slashings_vec.push(get_ssz_proposer_slashing((*proposer_slashing).clone())?);
+        proposer_slashings_vec.push(get_ssz_proposer_slashing((*proposer_slashing).clone())?);
     }
 
     Ok(List::<SSZProposerSlashing, { config::MAX_PROPOSER_SLASHINGS }>::from_iter(proposer_slashings_vec))
@@ -236,6 +236,14 @@ pub fn hash_tree_root_beacon_header(beacon_header: BeaconHeader) -> Result<[u8; 
     hash_tree_root(get_ssz_beacon_header(beacon_header)?)
 }
 
+pub fn hash_tree_root_beacon_body(body: Body) -> Result<[u8; 32], MerkleizationError> {
+    hash_tree_root(get_ssz_beacon_block_body(body)?)
+}
+
+pub fn hash_tree_root_transactions(transactions: Vec<Vec<u8>>) -> Result<[u8; 32], MerkleizationError> {
+    hash_tree_root(get_ssz_transactions(transactions)?)
+}
+
 pub fn hash_tree_root_sync_committee(sync_committee: SyncCommittee) -> Result<[u8; 32], MerkleizationError> {
     let mut pubkeys_vec = Vec::new();
 
@@ -296,15 +304,15 @@ mod tests {
                 parent_root: hex!(
                     "796ea53efb534eab7777809cc5ee2d84e7f25024b9d0c4d7e5bcaab657e4bdbd"
                 )
-                .into(),
+                    .into(),
                 state_root: hex!(
                     "ba3ff080912be5c9c158b2e962c1b39a91bc0615762ba6fa2ecacafa94e9ae0a"
                 )
-                .into(),
+                    .into(),
                 body_root: hex!(
                     "a18d7fcefbb74a177c959160e0ee89c23546482154e6831237710414465dcae5"
                 )
-                .into(),
+                    .into(),
             }
         );
 
@@ -324,15 +332,15 @@ mod tests {
                 parent_root: hex!(
                     "c069d7b49cffd2b815b0fb8007eb9ca91202ea548df6f3db60000f29b2489f28"
                 )
-                .into(),
+                    .into(),
                 state_root: hex!(
                     "444d293e4533501ee508ad608783a7d677c3c566f001313e8a02ce08adf590a3"
                 )
-                .into(),
+                    .into(),
                 body_root: hex!(
                     "6508a0241047f21ba88f05d05b15534156ab6a6f8e029a9a5423da429834e04a"
                 )
-                .into(),
+                    .into(),
             }
         );
 
@@ -395,7 +403,7 @@ mod tests {
         );
 
         assert_ok!(&hash_root);
-         assert_eq!(
+        assert_eq!(
             hash_root.unwrap(),
             hex!("23607f8bdfdc30eeb30b3db754ad54f820de4a3a68e9eeccb0788f636f0a9581")
         );
@@ -580,7 +588,7 @@ mod tests {
     #[test]
     pub fn test_hash_tree_root_attester_slashing() {
         let payload = merkleization::get_ssz_attester_slashing(
-           get_attester_slashing()
+            get_attester_slashing()
         );
 
         assert_ok!(&payload);

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, SyncCommittees, Error, BeaconHeader, FinalizedBeaconHeaders, ChainGenesis, Genesis, PublicKey, merkleization};
+use crate::{mock::*, SyncCommittees, Error, BeaconHeader, FinalizedBeaconHeaders, PublicKey, merkleization, ValidatorsRoot};
 use frame_support::{assert_ok, assert_err};
 use hex_literal::hex;
 use sp_core::H256;
@@ -29,9 +29,7 @@ fn it_updates_a_committee_period_sync_update() {
 
 	new_tester().execute_with(|| {
 		SyncCommittees::<Test>::insert(current_period, current_sync_committee);
-		ChainGenesis::<Test>::set(Genesis{
-			validators_root: hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into(),
-		});
+		ValidatorsRoot::<Test>::set(hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into());
 
 		assert_ok!(EthereumBeaconClient::sync_committee_period_update(
 			Origin::signed(1),
@@ -54,9 +52,7 @@ fn it_processes_a_finalized_header_update() {
 
 	new_tester().execute_with(|| {
 		SyncCommittees::<Test>::insert(current_period, current_sync_committee);
-		ChainGenesis::<Test>::set(Genesis{
-			validators_root: hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into(),
-		});
+		ValidatorsRoot::<Test>::set(hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into());
 
 		assert_ok!(EthereumBeaconClient::import_finalized_header(Origin::signed(1), update.clone()));
 
@@ -71,9 +67,7 @@ fn it_errors_when_importing_a_header_with_no_sync_commitee_for_period() {
 	let update = get_finalized_header_update();
 
 	new_tester().execute_with(|| {
-		ChainGenesis::<Test>::set(Genesis{
-			validators_root: hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into(),
-		});
+		ValidatorsRoot::<Test>::set(hex!("99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad").into());
 
 		assert_err!(EthereumBeaconClient::import_finalized_header(Origin::signed(1), update), Error::<Test>::SyncCommitteeMissing);
 	});
@@ -143,11 +137,11 @@ pub fn test_compute_signing_root_bls() {
 				parent_root: hex!(
 					"1f8dc05ea427f78e84e2e2666e13c3befb7106fd1d40ef8a3f67cf615f3f2a4c"
 				)
-				.into(),
+					.into(),
 				state_root: hex!(
 					"0dfb492a83da711996d2d76b64604f9bca9dc08b6c13cf63b3be91742afe724b"
 				)
-				.into(),
+					.into(),
 				body_root: hex!("66fba38f7c8c2526f7ddfe09c1a54dd12ff93bdd4d0df6a0950e88e802228bfa")
 					.into(),
 			},
@@ -172,11 +166,11 @@ pub fn test_compute_signing_root_kiln() {
 				parent_root: hex!(
 					"b4c15cd79da1a4e645b0104fa66d226cb6dce0fae3522789cc4d0b3ae41d96f7"
 				)
-				.into(),
+					.into(),
 				state_root: hex!(
 					"6f711ef2e36decbc8f7037e73bbdace42c11f2896a43e44ab8a78dcb2ba66122"
 				)
-				.into(),
+					.into(),
 				body_root: hex!("963eaa01341c16dc8f288da47eedad0792978fdaab9f1f97ae0a1103494d1a10")
 					.into(),
 			},
@@ -201,11 +195,11 @@ pub fn test_compute_signing_root_kiln_head_update() {
 				parent_root: hex!(
 					"5d481a9721f0ecce9610eab51d400d223683d599b7fcebca7e4c4d10cdef6ebb"
 				)
-				.into(),
+					.into(),
 				state_root: hex!(
 					"14eb4575895f996a84528b789ff2e4d5148242e2983f03068353b2c37015507a"
 				)
-				.into(),
+					.into(),
 				body_root: hex!("7bb669c75b12e0781d6fa85d7fc2f32d64eafba89f39678815b084c156e46cac")
 					.into(),
 			},

--- a/parachain/primitives/beacon/src/lib.rs
+++ b/parachain/primitives/beacon/src/lib.rs
@@ -33,7 +33,7 @@ pub struct SigningData {
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct Header {
+pub struct ExecutionHeader {
 	pub parent_hash: H256,
 	pub fee_recipient: H160,
 	pub state_root: H256,
@@ -41,13 +41,13 @@ pub struct Header {
 	pub logs_bloom: Vec<u8>,
 	pub prev_randao: H256,
 	pub block_number: u64,
-	pub gas_used: U256,
-	pub gas_limit: U256,
+	pub gas_limit: u64,
+	pub gas_used: u64,
 	pub timestamp: u64,
 	pub extra_data: Vec<u8>,
-	pub base_fee_per_gas: Option<U256>,
+	pub base_fee_per_gas: U256,
 	pub block_hash: H256,
-	pub transactions: Vec<u8>,
+	pub transactions_root: H256,
 }
 
 /// Sync committee as it is stored in the runtime storage.
@@ -104,15 +104,15 @@ pub struct AttestationData {
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct IndexedAttestation {
-    pub attesting_indices: Vec<u64>,
-    pub data: AttestationData,
-    pub signature: Vec<u8>,
+	pub attesting_indices: Vec<u64>,
+	pub data: AttestationData,
+	pub signature: Vec<u8>,
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct SignedHeader {
 	pub message: crate::BeaconHeader,
-    pub signature: Vec<u8>,
+	pub signature: Vec<u8>,
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
@@ -131,7 +131,7 @@ pub struct AttesterSlashing {
 pub struct Attestation {
 	pub aggregation_bits: Vec<u8>,
 	pub data: AttestationData,
-    pub signature: Vec<u8>,
+	pub signature: Vec<u8>,
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
@@ -175,14 +175,14 @@ pub struct ExecutionPayload {
 pub struct Body {
 	pub randao_reveal: Vec<u8>,
 	pub eth1_data: Eth1Data,
-    pub graffiti: H256,
-    pub proposer_slashings: Vec<ProposerSlashing>,
-    pub attester_slashings: Vec<AttesterSlashing>,
-    pub attestations: Vec<Attestation>,
-    pub deposits: Vec<Deposit>,
-    pub voluntary_exits: Vec<VoluntaryExit>,
-    pub sync_aggregate: SyncAggregate,
-    pub execution_payload: ExecutionPayload,
+	pub graffiti: H256,
+	pub proposer_slashings: Vec<ProposerSlashing>,
+	pub attester_slashings: Vec<AttesterSlashing>,
+	pub attestations: Vec<Attestation>,
+	pub deposits: Vec<Deposit>,
+	pub voluntary_exits: Vec<VoluntaryExit>,
+	pub sync_aggregate: SyncAggregate,
+	pub execution_payload: ExecutionPayload,
 }
 
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]


### PR DESCRIPTION
- Adds a new extrinsic `import_execution_header` to store eth1 headers
- Some clean-up (Replace GenesisConfig with ValidatorsRoot)