### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/ethereum/contracts @musnit
+/parachain/pallets @musnit

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/ethereum/contracts @musnit
-/parachain/pallets @musnit
+/ethereum/contracts @snowbridge-onchain-code-owners
+/parachain/pallets @snowbridge-onchain-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/ethereum/contracts @snowbridge-onchain-code-owners
-/parachain/pallets @snowbridge-onchain-code-owners
+/ethereum/contracts @snowfork/snowbridge-onchain-code-owners
+/parachain/pallets @snowfork/snowbridge-onchain-code-owners


### PR DESCRIPTION
This is a Github feature that allows you to specify specific files/folders on which someone should be automatically tagged as a code reviewer.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

I'm assigning myself as a reviewer for all on-chain business logic code to test this feature out.