### PR TITLE
Misc fixes for RPC handler

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -10341,9 +10341,11 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "parity-scale-codec",
+ "parking_lot 0.11.2",
  "serde_json",
  "snowbridge-basic-channel-merkle-proof",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-offchain",
  "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 

--- a/parachain/pallets/basic-channel/merkle-proof/src/lib.rs
+++ b/parachain/pallets/basic-channel/merkle-proof/src/lib.rs
@@ -88,8 +88,7 @@ where
 /// A generated merkle proof.
 ///
 /// The structure contains all necessary data to later on verify the proof and the leaf itself.
-#[derive(Debug, PartialEq, Eq, Encode, Decode)]
-// #[derive(Debug, PartialEq, Eq)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq)]
 pub struct MerkleProof<T> {
 	/// Root hash of generated merkle tree.
 	pub root: H256,

--- a/parachain/pallets/basic-channel/rpc/Cargo.toml
+++ b/parachain/pallets/basic-channel/rpc/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Snowfork <contact@snowfork.com>" ]
 repository = "https://github.com/Snowfork/snowbridge"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
 codec = { version = "3.0.0", package = "parity-scale-codec", features = [ "derive" ] }
@@ -16,6 +16,8 @@ jsonrpc-derive = "18.0.0"
 
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
+sp-offchain = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.19' }
+parking_lot = "0.11.0"
 
 snowbridge-basic-channel-merkle-proof = { path = "../merkle-proof" }
 

--- a/parachain/pallets/basic-channel/rpc/src/lib.rs
+++ b/parachain/pallets/basic-channel/rpc/src/lib.rs
@@ -1,43 +1,66 @@
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 
-use codec::Encode;
-use sp_core::H256;
-use sp_runtime::{offchain::storage::StorageValueRef, traits::Keccak256};
+use codec::{Decode, Encode};
+use parking_lot::RwLock;
+use sp_core::{offchain::OffchainStorage, H256, Bytes};
+use sp_runtime::traits::Keccak256;
+
+use std::sync::Arc;
 
 use snowbridge_basic_channel_merkle_proof::merkle_proof;
 
-pub struct BasicChannel;
-impl BasicChannel {
-	pub fn new() -> Self {
-		Self {}
+pub struct BasicChannel<T: OffchainStorage> {
+	storage: Arc<RwLock<T>>,
+}
+
+impl<T: OffchainStorage> BasicChannel<T> {
+	pub fn new(storage: T) -> Self {
+		Self { storage: Arc::new(RwLock::new(storage)) }
 	}
 }
+
+#[derive(Decode)]
+struct Leaves(pub Vec<Vec<u8>>);
 
 #[rpc]
 pub trait BasicChannelApi {
 	#[rpc(name = "basicOutboundChannel_getMerkleProof")]
-	fn get_merkle_proof(&self, commitment_hash: H256, leaf_index: u64) -> Result<Vec<u8>>;
+	fn get_merkle_proof(&self, commitment_hash: H256, leaf_index: u64) -> Result<Bytes>;
 }
 
-impl BasicChannelApi for BasicChannel {
-	fn get_merkle_proof(&self, commitment_hash: H256, leaf_index: u64) -> Result<Vec<u8>> {
-		let oci_mem = StorageValueRef::persistent(&commitment_hash.as_bytes());
+impl<T> BasicChannelApi for BasicChannel<T>
+where
+	T: OffchainStorage + 'static,
+{
+	fn get_merkle_proof(&self, commitment_hash: H256, leaf_index: u64) -> Result<Bytes> {
+		let encoded_leaves = match self
+			.storage
+			.read()
+			.get(sp_offchain::STORAGE_PREFIX, commitment_hash.as_bytes())
+		{
+			Some(encoded_leaves) => encoded_leaves,
+			None => {
+				return Err(Error {
+					code: ErrorCode::InvalidParams,
+					message: "no leaves found for given commitment".into(),
+					data: None,
+				})
+			},
+		};
 
-		if let Ok(Some(leaves)) = oci_mem.get::<Vec<Vec<u8>>>() {
-			let proof =
-				merkle_proof::<Keccak256, Vec<Vec<u8>>, Vec<u8>>(leaves, leaf_index).encode();
+		let leaves = match Leaves::decode(&mut encoded_leaves.as_ref()) {
+			Ok(leaves) => leaves,
+			Err(_) => {
+				return Err(Error {
+					code: ErrorCode::InternalError,
+					message: "could not decode leaves from storage".into(),
+					data: None,
+				})
+			},
+		};
 
-			Ok(proof)
-		} else {
-			Err(Error {
-				code: ErrorCode::InternalError,
-				message: format!(
-					"Failed to retrieve leaves for commitment_hash {}",
-					commitment_hash
-				),
-				data: None,
-			})
-		}
+		let proof = merkle_proof::<Keccak256, Vec<Vec<u8>>, Vec<u8>>(leaves.0, leaf_index);
+		Ok(proof.encode().into())
 	}
 }

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -332,11 +332,13 @@ where
 		})?;
 
 	let rpc_extensions_builder = {
+		let backend = backend.clone();
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();
 
 		Box::new(move |deny_unsafe, _| {
 			let deps = crate::rpc::FullDeps {
+				backend: backend.clone(),
 				client: client.clone(),
 				pool: transaction_pool.clone(),
 				deny_unsafe,

--- a/relayer/cmd/basic_channel_leaf_proof.go
+++ b/relayer/cmd/basic_channel_leaf_proof.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	gsrpc "github.com/snowfork/go-substrate-rpc-client/v4"
+
+	"github.com/snowfork/go-substrate-rpc-client/v4/types"
+	"github.com/spf13/cobra"
+)
+
+func basicChannelLeafProofCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "basic-channel-leaf-proof",
+		Short: "fetch proof for leaf",
+		Args:  cobra.ExactArgs(0),
+		RunE:  BasicChannelLeafProofFn,
+	}
+
+	cmd.Flags().StringP("url", "u", "", "Parachain URL")
+	cmd.MarkFlagRequired("url")
+
+	cmd.Flags().BytesHex(
+		"commitment-hash",
+		[]byte{},
+		"Commitment Hash",
+	)
+
+	cmd.Flags().Uint64(
+		"leaf-index",
+		1,
+		"Leaf index",
+	)
+
+	return cmd
+}
+
+func BasicChannelLeafProofFn(cmd *cobra.Command, _ []string) error {
+	url, _ := cmd.Flags().GetString("url")
+	commitmentHashHex, _ := cmd.Flags().GetBytesHex("commitment-hash")
+	leafIndex, _ := cmd.Flags().GetUint64("leaf-index")
+
+	var commitmentHash types.Hash
+	copy(commitmentHash[:], commitmentHashHex[0:32])
+
+	api, err := gsrpc.NewSubstrateAPI(url)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	var proofHex string
+	err = api.Client.Call(&proofHex, "basicOutboundChannel_getMerkleProof", commitmentHash.Hex(), leafIndex)
+	if err != nil {
+		return fmt.Errorf("call rpc: %w", err)
+	}
+
+	var proof MerkleProof
+	err = types.DecodeFromHexString(proofHex, &proof)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+
+	fmt.Printf("%#+v", proof)
+
+	return nil
+}
+
+type MerkleProof struct {
+	Root           types.H256
+	Proof          []types.H256
+	NumberOfLeaves uint64
+	LeafIndex      uint64
+	Leaf           []byte
+}

--- a/relayer/cmd/root.go
+++ b/relayer/cmd/root.go
@@ -25,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(fetchMessagesCmd())
 	rootCmd.AddCommand(subBeefyCmd())
 	rootCmd.AddCommand(leafCmd())
-
+	rootCmd.AddCommand(basicChannelLeafProofCmd())
 }
 
 func Execute() {


### PR DESCRIPTION
Turns out the RPC handler wasn't accessing offchain storage properly. Calls to the RPC caused the node to panick with the following error in `test/11144.log`:
```
Thread '<unnamed>' panicked at '`local_storage_get_version_1` called outside of an Externalities-provided environment.', 
```

Luckily this example showed how to access offchain storage correctly: https://github.com/parami-protocol/parami-blockchain/blob/3c83123017ed5110eab8ab91dabaf6cc8963f704/pallets/did/rpc/src/lib.rs#L69

Other change was for the RPC handler to return `sp_core::Bytes` instead of `Vec<u8>`. This ensures the serialized result is hex-encoded for easier handling.

Testing
-------
I used polkadot-launch to test the parachain using the config at `/tmp/snowbridge/launch-config.json` (generated by calling `start-services.sh` once initially).

Added a command to the relayer binary which will call the RPC and parse the result:
Example: for commitment `0xb62a82b3220e87ff3cd7da30a3d59b36c9cffd6afcd29b77cd9091e4dc11c9cd`
```bash
mage build
build/snowbridge-relay basic-channel-leaf-proof --url ws://localhost:11144 --commitment-hash b62a82b3220e87ff3cd7da30a3d59b36c9cffd6afcd29b77cd9091e4dc11c9cd  --leaf-index 1
```

Useful for understanding how to call the RPC in the relayer.

Is equivalent to the curl command:
```bash
curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "basicOutboundChannel_getMerkleProof", "params":["0xb62a82b3220e87ff3cd7da30a3d59b36c9cffd6afcd29b77cd9091e4dc11c9cd", 1]}' http://localhost:8081
```

To generate a commitment in the basic channel, I called the `dotApp.lock` extrinsic using the //Alice account in the Polkadot-JS webui. Need to make sure to lockup at least 2 DOT (type in 2000000000000) or you will get [existential deposit](https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit-#:~:text=Print&text=On%20the%20Polkadot%20network%2C%20an,the%20Existential%20Deposit%20(ED).) / minimum deposit errors.

To test commitments with multiple leaves, I submitted a `Utility.BatchAll` extrinsic with multiple DOT lockups:
![Web capture_20-7-2022_225948_polkadot js org](https://user-images.githubusercontent.com/117534/180085213-f491ee10-cfe9-457b-8593-9d20ec0a86fe.jpeg)

After calling the RPC, I looked at `test/11144.log` for any any errors emitted by the parachain node.
