### PR TITLE
Update API endpoints and use public Lodestar Ropsten server for start-services

### DIFF
--- a/relayer/relays/beacon/main.go
+++ b/relayer/relays/beacon/main.go
@@ -136,7 +136,7 @@ func (r *Relay) Sync(ctx context.Context) error {
 }
 
 func (r *Relay) SyncCommitteePeriodUpdate(ctx context.Context, period uint64) error {
-	syncCommitteeUpdate, err := r.syncer.GetSyncCommitteePeriodUpdate(period, period)
+	syncCommitteeUpdate, err := r.syncer.GetSyncCommitteePeriodUpdate(period)
 
 	switch {
 	case errors.Is(err, syncer.ErrCommitteeUpdateHeaderInDifferentSyncPeriod):

--- a/relayer/relays/beacon/syncer/api.go
+++ b/relayer/relays/beacon/syncer/api.go
@@ -23,7 +23,7 @@ type BeaconClientTracker interface {
 	GetFinalizedHeader() (BeaconHeader, error)
 	GetHeadHeader() (BeaconHeader, error)
 	GetHeader(id string) (BeaconHeader, error)
-	GetSyncCommitteePeriodUpdate(from, to uint64) (SyncCommitteePeriodUpdateResponse, error)
+	GetSyncCommitteePeriodUpdate(from uint64) (SyncCommitteePeriodUpdateResponse, error)
 	GetHeadCheckpoint() (FinalizedCheckpointResponse, error)
 	GetBeaconBlock(slot uint64) (BeaconBlockResponse, error)
 	GetBeaconBlockBySlot(slot uint64) (BeaconBlockResponse, error)
@@ -359,8 +359,8 @@ type SyncCommitteePeriodUpdateResponse struct {
 	} `json:"data"`
 }
 
-func (b *BeaconClient) GetSyncCommitteePeriodUpdate(from, to uint64) (SyncCommitteePeriodUpdateResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/eth/v1/lightclient/committee_updates?from=%d&to=%d", b.endpoint, from, to), nil)
+func (b *BeaconClient) GetSyncCommitteePeriodUpdate(from uint64) (SyncCommitteePeriodUpdateResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/eth/v1/light_client/updates?start_period=%d&count=1", b.endpoint, from), nil)
 	if err != nil {
 		return SyncCommitteePeriodUpdateResponse{}, fmt.Errorf("%s: %w", ConstructRequestErrorMessage, err)
 	}
@@ -548,7 +548,7 @@ type LatestFinalisedUpdateResponse struct {
 }
 
 func (b *BeaconClient) GetLatestFinalizedUpdate() (LatestFinalisedUpdateResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/eth/v1/lightclient/latest_finalized_head_update/", b.endpoint), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/eth/v1/light_client/finality_update/", b.endpoint), nil)
 	if err != nil {
 		return LatestFinalisedUpdateResponse{}, fmt.Errorf("%s: %w", ConstructRequestErrorMessage, err)
 	}

--- a/relayer/relays/beacon/syncer/syncer.go
+++ b/relayer/relays/beacon/syncer/syncer.go
@@ -120,8 +120,8 @@ func (s *Syncer) GetSyncPeriodsToFetch(checkpointSyncPeriod uint64) ([]uint64, e
 	return syncPeriodsToFetch, nil
 }
 
-func (s *Syncer) GetSyncCommitteePeriodUpdate(from, to uint64) (SyncCommitteePeriodUpdate, error) {
-	committeeUpdates, err := s.Client.GetSyncCommitteePeriodUpdate(from, to)
+func (s *Syncer) GetSyncCommitteePeriodUpdate(from uint64) (SyncCommitteePeriodUpdate, error) {
+	committeeUpdates, err := s.Client.GetSyncCommitteePeriodUpdate(from)
 	if err != nil {
 		return SyncCommitteePeriodUpdate{}, fmt.Errorf("fetch sync committee period update: %w", err)
 	}

--- a/test/.envrc-example
+++ b/test/.envrc-example
@@ -26,6 +26,8 @@ export PARACHAIN_ID=1000
 # export ETH_RPC_ENDPOINT=https://ropsten.infura.io/v3
 # export ETH_WS_ENDPOINT=wss://ropsten.infura.io/ws/v3
 
+# export BEACON_HTTP_ENDPOINT=https://lodestar-ropsten.chainsafe.io
+
 # export ROPSTEN_PRIVATE_KEY=         # Your deployment account private key
 # export BEEFY_RELAY_ETH_KEY=         # Your Beefy relayer account private key
 # export PARACHAIN_RELAY_ETH_KEY=     # Your Parachain relayer account private key

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -218,10 +218,12 @@ start_relayer()
         --arg k1 "$(address_for BasicOutboundChannel)" \
         --arg k2 "$(address_for IncentivizedOutboundChannel)" \
         --arg infura_endpoint_ws $infura_endpoint_ws \
+        --arg beacon_endpoint_http $beacon_endpoint_http \
     '
       .source.contracts.BasicOutboundChannel = $k1
     | .source.contracts.IncentivizedOutboundChannel = $k2
     | .source.ethereum.endpoint = $infura_endpoint_ws
+    | .source.beacon.endpoint = $beacon_endpoint_http
     ' \
     config/beacon-relay.json > $output_dir/beacon-relay.json
 

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -101,8 +101,6 @@ start_polkadot_launch()
         initial_beacon_block=$(curl "$beacon_endpoint_http/eth/v1/beacon/states/head/finality_checkpoints" \
                 | jq -r '.data.finalized.root')
 
-        echo "$beacon_endpoint_http/eth/v1/light_client/bootstrap/$initial_beacon_block"
-
         curl "$beacon_endpoint_http/eth/v1/light_client/bootstrap/$initial_beacon_block" \
             | node scripts/helpers/transformInitialBeaconSync.js > "$output_dir/initialBeaconSync_tmp.json"
 


### PR DESCRIPTION
- Updates the Lodestar endpoints with the new light client spec version
- Uses the public Ropsten Lodestar server for start-services, instead of running own node

Resolves: [SNO-291](https://linear.app/snowfork/issue/SNO-291/update-endpoints-to-use-new-light-client-spec)