### PR TITLE
Check latest finalized header verification before syncing messages

### DIFF
--- a/relayer/relays/beacon/cache/cache.go
+++ b/relayer/relays/beacon/cache/cache.go
@@ -7,10 +7,14 @@ import (
 )
 
 type BeaconCache struct {
-	LastSyncedSyncCommitteePeriod          uint64
-	FinalizedHeaders                       []common.Hash
-	HeadersMap                             map[common.Hash]uint64
-	mu                                     sync.Mutex
+	LastSyncedSyncCommitteePeriod uint64
+	// Stores all successfully imported (in the parachain) finalized headers. 
+	// Used to determine the execution headers that needs to be backfilled.
+	FinalizedHeaders              []common.Hash
+	// Stores the last attempted finalized header, whether the import succeeded or not.
+	LastAttemptedFinalizedHeader  common.Hash
+	HeadersMap                    map[common.Hash]uint64
+	mu                            sync.Mutex
 }
 
 func New() *BeaconCache {

--- a/relayer/relays/beacon/header/header.go
+++ b/relayer/relays/beacon/header/header.go
@@ -195,7 +195,6 @@ func (h *Header) SyncFinalizedHeader(ctx context.Context) (syncer.FinalizedHeade
 	h.cache.FinalizedHeaders = append(h.cache.FinalizedHeaders, blockRoot)
 
 	lastStoredHeader, err := h.writer.GetLastStoredFinalizedHeader()
-
 	if lastStoredHeader != blockRoot {
 		return syncer.FinalizedHeaderUpdate{}, common.Hash{}, ErrFinalizedHeaderNotImported
 	}
@@ -247,7 +246,6 @@ func (h *Header) SyncHeaders(ctx context.Context) error {
 	}).Info("starting to back-fill headers")
 
 	blockRoot := common.HexToHash(finalizedHeader.FinalizedHeader.ParentRoot.Hex())
-
 	prevSyncAggregate := finalizedHeader.SyncAggregate
 
 	headerUpdate, err := h.SyncHeader(ctx, finalizedHeaderBlockRoot, prevSyncAggregate)

--- a/relayer/relays/beacon/header/header.go
+++ b/relayer/relays/beacon/header/header.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
-
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v4/types"
@@ -249,10 +248,7 @@ func (h *Header) SyncHeaders(ctx context.Context) error {
 
 	blockRoot := common.HexToHash(finalizedHeader.FinalizedHeader.ParentRoot.Hex())
 
-	prevSyncAggregate, err := h.syncer.GetSyncAggregateForSlot(uint64(finalizedHeader.FinalizedHeader.Slot + 1))
-	if err != nil {
-		return fmt.Errorf("get sync aggregate by slot: %w", err)
-	}
+	prevSyncAggregate := finalizedHeader.SyncAggregate
 
 	headerUpdate, err := h.SyncHeader(ctx, finalizedHeaderBlockRoot, prevSyncAggregate)
 	if err != nil {

--- a/relayer/relays/beacon/header/header.go
+++ b/relayer/relays/beacon/header/header.go
@@ -95,9 +95,9 @@ func (h *Header) Sync(ctx context.Context, eg *errgroup.Group) (<-chan uint64, <
 			err := h.SyncHeaders(ctx)
 			switch {
 			case errors.Is(err, ErrFinalizedHeaderUnchanged):
-				log.WithField("finalized_header", h.cache.LastAttemptedFinalizedHeader).Info(err.Error())
+				log.WithError(err).WithField("finalized_header", h.cache.LastAttemptedFinalizedHeader).Info("not importing unchanged header")
 			case errors.Is(err, ErrFinalizedHeaderNotImported):
-				log.Warn(err.Error())
+				log.WithError(err).Warn("Not importing header this cycle")
 			case err != nil:
 				return err
 			default:

--- a/relayer/relays/beacon/header/syncer/api.go
+++ b/relayer/relays/beacon/header/syncer/api.go
@@ -335,7 +335,7 @@ func (b *BeaconClient) GetBeaconBlockRoot(slot uint64) (common.Hash, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return common.Hash{}, fmt.Errorf("%s: %w", HTTPStatusNotOKErrorMessage, res.StatusCode)
+		return common.Hash{}, fmt.Errorf("fetch beacon block %d: %s", res.StatusCode, HTTPStatusNotOKErrorMessage)
 	}
 
 	bodyBytes, err := io.ReadAll(res.Body)

--- a/relayer/relays/beacon/header/syncer/api.go
+++ b/relayer/relays/beacon/header/syncer/api.go
@@ -27,7 +27,6 @@ type BeaconClientTracker interface {
 	GetSyncCommitteePeriodUpdate(from uint64) (SyncCommitteePeriodUpdateResponse, error)
 	GetHeadCheckpoint() (FinalizedCheckpointResponse, error)
 	GetBeaconBlock(slot uint64) (BeaconBlockResponse, error)
-	GetBeaconBlockBySlot(slot uint64) (BeaconBlockResponse, error)
 	GetCurrentForkVersion(slot uint64) (string, error)
 	GetLatestFinalizedUpdate() (LatestFinalisedUpdateResponse, error)
 }
@@ -269,41 +268,6 @@ func (b *BeaconClient) GetBeaconBlock(blockID common.Hash) (BeaconBlockResponse,
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return BeaconBlockResponse{}, fmt.Errorf("%s: %d", HTTPStatusNotOKErrorMessage, res.StatusCode)
-	}
-
-	bodyBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return BeaconBlockResponse{}, fmt.Errorf("%s: %w", ReadResponseBodyErrorMessage, err)
-	}
-
-	var response BeaconBlockResponse
-
-	err = json.Unmarshal(bodyBytes, &response)
-	if err != nil {
-		return BeaconBlockResponse{}, fmt.Errorf("%s: %w", UnmarshalBodyErrorMessage, err)
-	}
-
-	return response, nil
-}
-
-func (b *BeaconClient) GetBeaconBlockBySlot(slot uint64) (BeaconBlockResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", b.endpoint, slot), nil)
-	if err != nil {
-		return BeaconBlockResponse{}, fmt.Errorf("%s: %w", ConstructRequestErrorMessage, err)
-	}
-
-	req.Header.Set("accept", "application/json")
-	res, err := b.httpClient.Do(req)
-	if err != nil {
-		return BeaconBlockResponse{}, fmt.Errorf("%s: %w", DoHTTPRequestErrorMessage, err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		if res.StatusCode == 404 {
-			return BeaconBlockResponse{}, ErrNotFound
-		}
-
 		return BeaconBlockResponse{}, fmt.Errorf("%s: %d", HTTPStatusNotOKErrorMessage, res.StatusCode)
 	}
 

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -106,7 +106,7 @@ func (s *Syncer) GetSyncPeriodsToFetch(checkpointSyncPeriod uint64) ([]uint64, e
 
 	currentSyncPeriod := s.ComputeSyncPeriodAtSlot(slot)
 
-	//The current sync period's next sync committee should be synced too. So even
+	//The current sync period's next sync committee should be synced too. So even 
 	// if the syncing is up to date with the current period, we still need to sync the current
 	// period's next sync committee.
 	if checkpointSyncPeriod == currentSyncPeriod {

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -302,11 +302,14 @@ func (s *Syncer) GetSyncAggregateForSlot(slot uint64) (scale.SyncAggregate, erro
 		}).Info("fetching sync aggregate for slot")
 		block, err = s.Client.GetBeaconBlockBySlot(slot)
 		if err != nil {
-			return scale.SyncAggregate{}, fmt.Errorf("fetch block: %w", err)
+			log.Info("next slot didn't have a block, finding next slot")
 		}
 
 		tries = tries + 1
 		slot = slot + 1
+	}
+	if tries == maxSlotsMissed {
+		return scale.SyncAggregate{}, fmt.Errorf("next block to get sync aggregate by slot: %w", err)
 	}
 
 	blockScale, err := block.ToScale()

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ssz "github.com/ferranbt/fastssz"
+	log "github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v4/types"
 	"github.com/snowfork/snowbridge/relayer/relays/beacon/header/syncer/scale"
 )
@@ -106,7 +107,7 @@ func (s *Syncer) GetSyncPeriodsToFetch(checkpointSyncPeriod uint64) ([]uint64, e
 
 	currentSyncPeriod := s.ComputeSyncPeriodAtSlot(slot)
 
-	//The current sync period's next sync committee should be synced too. So even 
+	//The current sync period's next sync committee should be synced too. So even
 	// if the syncing is up to date with the current period, we still need to sync the current
 	// period's next sync committee.
 	if checkpointSyncPeriod == currentSyncPeriod {
@@ -290,9 +291,22 @@ func (s *Syncer) GetSyncAggregate(blockRoot common.Hash) (scale.SyncAggregate, e
 }
 
 func (s *Syncer) GetSyncAggregateForSlot(slot uint64) (scale.SyncAggregate, error) {
-	block, err := s.Client.GetBeaconBlockBySlot(slot)
-	if err != nil {
-		return scale.SyncAggregate{}, fmt.Errorf("fetch block: %w", err)
+	err := ErrNotFound
+	var block BeaconBlockResponse
+	tries := 0
+	maxSlotsMissed := 20
+	for errors.Is(err, ErrNotFound) && tries < maxSlotsMissed {
+		log.WithFields(log.Fields{
+			"try_number": tries,
+			"slot":       slot,
+		}).Info("fetching sync aggregate for slot")
+		block, err = s.Client.GetBeaconBlockBySlot(slot)
+		if err != nil {
+			return scale.SyncAggregate{}, fmt.Errorf("fetch block: %w", err)
+		}
+
+		tries = tries + 1
+		slot = slot + 1
 	}
 
 	blockScale, err := block.ToScale()

--- a/relayer/relays/beacon/message/message.go
+++ b/relayer/relays/beacon/message/message.go
@@ -191,7 +191,7 @@ func (m *Message) SyncIncentivized(ctx context.Context, eg *errgroup.Group, bloc
 
 func (m *Message) writeMessages(ctx context.Context, payload ParachainPayload) error {
 	for _, msg := range payload.Messages {
-		err := m.writer.WriteToParachain(ctx, msg.Call, msg.Args...)
+		_, err := m.writer.WriteToParachain(ctx, msg.Call, msg.Args...)
 		if err != nil {
 			return err
 		}

--- a/relayer/relays/beacon/writer/parachain-writer.go
+++ b/relayer/relays/beacon/writer/parachain-writer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	log "github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v4/rpc/author"
 	"github.com/snowfork/go-substrate-rpc-client/v4/types"
 	"github.com/snowfork/snowbridge/relayer/chain/parachain"

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -150,6 +150,15 @@ start_polkadot_launch()
     done 
 
     echo "Found initial finalized block: $initial_beacon_block"
+    bootstrap_header=""
+    while [ -z "$bootstrap_header" ] || [ "$bootstrap_header" == "" ] || [ "$bootstrap_header" == "null" ]
+    do 
+        echo "Waiting for beacon chain to finalize to get initial block..."
+        bootstrap_header=$(curl -s "$beacon_endpoint_http/eth/v1/beacon/light_client/bootstrap/$initial_beacon_block" \
+            | jq -r '.data.header')
+        sleep 3
+    done 
+    
     curl -s "$beacon_endpoint_http/eth/v1/beacon/light_client/bootstrap/$initial_beacon_block" \
         | node scripts/helpers/transformInitialBeaconSync.js > "$output_dir/initialBeaconSync_tmp.json"
 


### PR DESCRIPTION
Check that the latest finalized header verification succeeded before backfilling execution headers and verifying messages for any ancestor blocks.

Resolves [SNO-321](https://linear.app/snowfork/issue/SNO-321)

- [x] Test updated code against Goerli, where some finalized blocks are not signed by supermajority