### PR TITLE
Updates endpoint and adds more logs to the trie method.

### DIFF
--- a/relayer/chain/ethereum/header_cache_state.go
+++ b/relayer/chain/ethereum/header_cache_state.go
@@ -215,17 +215,17 @@ func (s *HeaderCache) GetReceiptTrie(ctx context.Context, hash gethCommon.Hash) 
 
 	block, err := s.blockLoader.GetBlock(ctx, hash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get block: %w", err)
 	}
 
 	receipts, err := s.blockLoader.GetAllReceipts(ctx, block)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get all receipts: %w", err)
 	}
 
 	receiptTrie, err = MakeTrie(receipts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("make trie: %w", err)
 	}
 
 	if receiptTrie.Hash() != block.ReceiptHash() {

--- a/relayer/relays/beacon/header/syncer/api.go
+++ b/relayer/relays/beacon/header/syncer/api.go
@@ -344,7 +344,9 @@ func (b *BeaconClient) GetBeaconBlockRoot(slot uint64) (common.Hash, error) {
 	}
 
 	var response struct {
-		Data string `json:"data"`
+		Data struct {
+			Root string `json:"root"`
+		} `json:"data"`
 	}
 
 	err = json.Unmarshal(bodyBytes, &response)
@@ -352,7 +354,7 @@ func (b *BeaconClient) GetBeaconBlockRoot(slot uint64) (common.Hash, error) {
 		return common.Hash{}, fmt.Errorf("%s: %w", UnmarshalBodyErrorMessage, err)
 	}
 
-	return common.HexToHash(response.Data), nil
+	return common.HexToHash(response.Data.Root), nil
 }
 
 type SyncCommitteePeriodUpdateResponse struct {


### PR DESCRIPTION
On Rococo-Goerli, I get this error when fetching a message trie:

```
{"@timestamp":"2022-09-27T06:07:32.268398525Z","blockHash":"0x23a4c19edbf780d783b13f88f006351901747c45811dfb5cf60416a90387715f","blockNumber":7627631,"error":"context canceled","level":"error","message":"Failed to get receipt trie for event","txHash":"0xb1d59c52fb229714e094fae97e5fafe30b4ee3811f0ff3d07c7953aa2bb38fc3"}
```

It doesn't give much more information and I wasn't able to reproduce it locally, so I have added extra logging to investigate.

I also update a Lodestar response struct, since that seems to have changed. To update Lodestar locally, run:

`yarn global upgrade @chainsafe/lodestar`

If you run lodestar --version, this should be the version:

`Version: v1.1.0/90a92dd`

I will paste this in the chat too, once merged.