### PR TITLE
Vault contract for ETH app.

### DIFF
--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -36,8 +36,6 @@ contract ETHApp is RewardController, AccessControl {
         Channel incentivized
     );
 
-    event VaultTransferred(address newOwner);
-
     bytes2 constant MINT_CALL = 0x4101;
 
     bytes32 public constant REWARD_ROLE = keccak256("REWARD_ROLE");
@@ -199,6 +197,5 @@ contract ETHApp is RewardController, AccessControl {
         address newOwner
     ) external onlyRole(CHANNEL_UPGRADE_ROLE) {
         vault.transferOwnership(newOwner);
-        emit VaultTransferred(newOwner);
     }
 }

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -193,4 +193,10 @@ contract ETHApp is RewardController, AccessControl {
         grantRole(INBOUND_CHANNEL_ROLE, _incentivized.inbound);
         emit Upgraded(msg.sender, c1, c2);
     }
+
+     function transferVaultOwnership(
+        address newOwner
+    ) external onlyRole(CHANNEL_UPGRADE_ROLE) {
+        vault.transferOwnership(newOwner);
+    }
 }

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -36,6 +36,8 @@ contract ETHApp is RewardController, AccessControl {
         Channel incentivized
     );
 
+    event VaultTransferred(address newOwner);
+
     bytes2 constant MINT_CALL = 0x4101;
 
     bytes32 public constant REWARD_ROLE = keccak256("REWARD_ROLE");
@@ -197,5 +199,6 @@ contract ETHApp is RewardController, AccessControl {
         address newOwner
     ) external onlyRole(CHANNEL_UPGRADE_ROLE) {
         vault.transferOwnership(newOwner);
+        emit VaultTransferred(newOwner);
     }
 }

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -92,7 +92,7 @@ contract ETHApp is RewardController, AccessControl {
 
         // revert in case of overflow.
         uint128 value = (msg.value).toUint128();
-        vault.deposit{value: msg.value}();
+        vault.deposit{value: msg.value}(msg.sender);
 
         emit Locked(msg.sender, _recipient, value, _paraId, _fee);
 

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -51,7 +51,6 @@ contract ETHApp is RewardController, AccessControl {
     bytes32 public constant CHANNEL_UPGRADE_ROLE =
         keccak256("CHANNEL_UPGRADE_ROLE");
 
-        
     ETHVault public vault;
 
     constructor(

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -77,10 +77,6 @@ contract ETHApp is RewardController, AccessControl {
         _setupRole(INBOUND_CHANNEL_ROLE, _incentivized.inbound);
     }
 
-    receive() external payable {
-        require(msg.sender == address(vault), "Only receive funds from vault");
-    }
-
     function lock(
         bytes32 _recipient,
         ChannelId _channelId,
@@ -96,7 +92,7 @@ contract ETHApp is RewardController, AccessControl {
 
         // revert in case of overflow.
         uint128 value = (msg.value).toUint128();
-        
+
         (bool success, ) = address(vault).call{value: msg.value}("");
         require(success, "Vault must accept funds");
 
@@ -120,11 +116,7 @@ contract ETHApp is RewardController, AccessControl {
         address payable _recipient,
         uint128 _amount
     ) public onlyRole(INBOUND_CHANNEL_ROLE) {
-        require(_amount > 0, "Must unlock a positive amount");
-
-        vault.unlock(_amount);
-        (bool success, ) = _recipient.call{value: _amount}("");
-        require(success, "Unable to send Ether");
+        vault.withdraw(_recipient, _amount);
         emit Unlocked(_sender, _recipient, _amount);
     }
 

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -92,7 +92,7 @@ contract ETHApp is RewardController, AccessControl {
 
         // revert in case of overflow.
         uint128 value = (msg.value).toUint128();
-        vault.deposit{value: msg.value}(tx.origin);
+        vault.deposit{value: msg.value}();
 
         emit Locked(msg.sender, _recipient, value, _paraId, _fee);
 

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -96,7 +96,9 @@ contract ETHApp is RewardController, AccessControl {
 
         // revert in case of overflow.
         uint128 value = (msg.value).toUint128();
-        vault.lock{value: msg.value}();
+        
+        (bool success, ) = address(vault).call{value: msg.value}("");
+        require(success, "Vault must accept funds");
 
         emit Locked(msg.sender, _recipient, value, _paraId, _fee);
 

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -51,7 +51,7 @@ contract ETHApp is RewardController, AccessControl {
     bytes32 public constant CHANNEL_UPGRADE_ROLE =
         keccak256("CHANNEL_UPGRADE_ROLE");
 
-    ETHVault public vault;
+    ETHVault public immutable vault;
 
     constructor(
         address rewarder,

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./RewardController.sol";
 import "./ScaleCodec.sol";
 import "./OutboundChannel.sol";
-import "./ETHVault.sol";
+import "./EtherVault.sol";
 
 enum ChannelId {
     Basic,
@@ -53,11 +53,11 @@ contract ETHApp is RewardController, AccessControl {
     bytes32 public constant CHANNEL_UPGRADE_ROLE =
         keccak256("CHANNEL_UPGRADE_ROLE");
 
-    ETHVault public immutable vault;
+    EtherVault public immutable vault;
 
     constructor(
         address rewarder,
-        ETHVault _vault,
+        EtherVault _vault,
         Channel memory _basic,
         Channel memory _incentivized
     ) {

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -92,9 +92,7 @@ contract ETHApp is RewardController, AccessControl {
 
         // revert in case of overflow.
         uint128 value = (msg.value).toUint128();
-
-        (bool success, ) = address(vault).call{value: msg.value}("");
-        require(success, "Vault must accept funds");
+        vault.deposit{value: msg.value}(tx.origin);
 
         emit Locked(msg.sender, _recipient, value, _paraId, _fee);
 

--- a/ethereum/contracts/ETHVault.sol
+++ b/ethereum/contracts/ETHVault.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract ETHVault is Ownable {
+    function lock() 
+        public
+        payable
+        onlyOwner
+    {
+        require(msg.value > 0, "Value of transaction must be positive");
+    }
+
+    function unlock(uint128 _amount)
+        public
+        onlyOwner
+    {
+        require(_amount > 0, "Must unlock a positive amount");
+        (bool success, ) = msg.sender.call{ value: _amount }("");
+        require(success, "Unable to send Ether");
+    }
+}

--- a/ethereum/contracts/ETHVault.sol
+++ b/ethereum/contracts/ETHVault.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+// Holds ETH on behalf of ETHApp
 contract ETHVault is Ownable {
+    // Accepts ETH from the caller.
     function lock() 
         public
         payable
@@ -12,6 +14,7 @@ contract ETHVault is Ownable {
         require(msg.value > 0, "Value of transaction must be positive");
     }
 
+    // Returns ETH to the caller.
     function unlock(uint128 _amount)
         public
         onlyOwner

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -13,12 +13,12 @@ contract EtherVault is Ownable {
     }
 
     // Accepts ETH from the caller.
-    function deposit(address sender) 
+    function deposit(address _sender) 
         external
         payable
         onlyOwner
     {
-        emit Deposit(msg.sender, sender, msg.value);
+        emit Deposit(msg.sender, _sender, msg.value);
     }
 
     // Returns ETH to the caller.

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -5,16 +5,22 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Holds ETH on behalf of ETHApp
 contract EtherVault is Ownable {
+    event Deposit(address account, uint256 amount);
+    event Withdraw(address account, address recipient, uint256 amount);
+
     // Accepts ETH from the caller.
-    receive() external payable {}
+    receive() external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
 
     // Returns ETH to the caller.
-    function withdraw(address payable _recipient, uint128 _amount)
+    function withdraw(address payable _recipient, uint256 _amount)
         external
         onlyOwner
     {
         require(_amount > 0, "Must unlock a positive amount");
         (bool success, ) = _recipient.call{ value: _amount }("");
         require(success, "Unable to send Ether");
+        emit Withdraw(msg.sender, _recipient, _amount);
     }
 }

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -13,12 +13,12 @@ contract EtherVault is Ownable {
     }
 
     // Accepts ETH from the caller.
-    function deposit() 
+    function deposit(address origin) 
         external
         payable
         onlyOwner
     {
-        emit Deposit(msg.sender, tx.origin, msg.value);
+        emit Deposit(msg.sender, origin, msg.value);
     }
 
     // Returns ETH to the caller.

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -6,13 +6,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 // Holds ETH on behalf of ETHApp
 contract EtherVault is Ownable {
     // Accepts ETH from the caller.
-    function lock() 
-        public
-        payable
-        onlyOwner
-    {
-        require(msg.value > 0, "Value of transaction must be positive");
-    }
+    receive() external payable {}
 
     // Returns ETH to the caller.
     function unlock(uint128 _amount)

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Holds ETH on behalf of ETHApp
 contract EtherVault is Ownable {
-    event Deposit(address account, address origin, uint256 amount);
+    event Deposit(address account, address sender, uint256 amount);
     event Withdraw(address account, address recipient, uint256 amount);
 
     receive() external payable {
@@ -13,12 +13,12 @@ contract EtherVault is Ownable {
     }
 
     // Accepts ETH from the caller.
-    function deposit(address origin) 
+    function deposit(address sender) 
         external
         payable
         onlyOwner
     {
-        emit Deposit(msg.sender, origin, msg.value);
+        emit Deposit(msg.sender, sender, msg.value);
     }
 
     // Returns ETH to the caller.

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -9,12 +9,12 @@ contract EtherVault is Ownable {
     receive() external payable {}
 
     // Returns ETH to the caller.
-    function unlock(uint128 _amount)
-        public
+    function withdraw(address payable _recipient, uint128 _amount)
+        external
         onlyOwner
     {
         require(_amount > 0, "Must unlock a positive amount");
-        (bool success, ) = msg.sender.call{ value: _amount }("");
+        (bool success, ) = _recipient.call{ value: _amount }("");
         require(success, "Unable to send Ether");
     }
 }

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -5,12 +5,20 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Holds ETH on behalf of ETHApp
 contract EtherVault is Ownable {
-    event Deposit(address account, uint256 amount);
+    event Deposit(address account, address owner, uint256 amount);
     event Withdraw(address account, address recipient, uint256 amount);
 
-    // Accepts ETH from the caller.
     receive() external payable {
-        emit Deposit(msg.sender, msg.value);
+        revert("Must use deposit function");
+    }
+
+    // Accepts ETH from the caller.
+    function deposit(address owner) 
+        external
+        payable
+        onlyOwner
+    {
+        emit Deposit(msg.sender, owner, msg.value);
     }
 
     // Returns ETH to the caller.

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Holds ETH on behalf of ETHApp
-contract ETHVault is Ownable {
+contract EtherVault is Ownable {
     // Accepts ETH from the caller.
     function lock() 
         public

--- a/ethereum/contracts/EtherVault.sol
+++ b/ethereum/contracts/EtherVault.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Holds ETH on behalf of ETHApp
 contract EtherVault is Ownable {
-    event Deposit(address account, address owner, uint256 amount);
+    event Deposit(address account, address origin, uint256 amount);
     event Withdraw(address account, address recipient, uint256 amount);
 
     receive() external payable {
@@ -13,12 +13,12 @@ contract EtherVault is Ownable {
     }
 
     // Accepts ETH from the caller.
-    function deposit(address owner) 
+    function deposit() 
         external
         payable
         onlyOwner
     {
-        emit Deposit(msg.sender, owner, msg.value);
+        emit Deposit(msg.sender, tx.origin, msg.value);
     }
 
     // Returns ETH to the caller.

--- a/ethereum/deploy/10-eth-app.ts
+++ b/ethereum/deploy/10-eth-app.ts
@@ -47,11 +47,11 @@ module.exports = async ({
     autoMine: true,
   });
 
-  console.log("Transferring EtherVault ownership to ETHApp")
   await deployments.execute(
     "EtherVault", 
     {
       from: deployer,
+      log: true,
       autoMine: true
     },
     "transferOwnership",

--- a/ethereum/deploy/10-eth-app.ts
+++ b/ethereum/deploy/10-eth-app.ts
@@ -20,10 +20,17 @@ module.exports = async ({
 
   let scaleCodecLibrary = await deployments.get("ScaleCodec")
 
-  await deployments.deploy("ETHApp", {
+  let vault = await deployments.deploy('EtherVault', {
+    from: deployer,
+    log: true,
+    autoMine: true
+  });
+
+  let app = await deployments.deploy("ETHApp", {
     from: deployer,
     args:[
       channels.incentivized.inbound.address,
+      vault.address,
       {
         inbound: channels.basic.inbound.address,
         outbound: channels.basic.outbound.address,
@@ -40,4 +47,14 @@ module.exports = async ({
     autoMine: true,
   });
 
+  console.log("Transferring EtherVault ownership to ETHApp")
+  await deployments.execute(
+    "EtherVault", 
+    {
+      from: deployer,
+      autoMine: true
+    },
+    "transferOwnership",
+    app.address
+  );
 };

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -73,7 +73,7 @@ describe("ETHApp", function () {
       );
 
       depositEvent.account.should.be.equal(this.app.address);
-      depositEvent.origin.should.be.equal(userOne);
+      depositEvent.sender.should.be.equal(userOne);
       depositEvent.amount.eq(ethers.BigNumber.from(amount.toString())).should.be.true;
 
       // Confirm app event emitted with expected values

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -73,7 +73,7 @@ describe("ETHApp", function () {
       );
 
       depositEvent.account.should.be.equal(this.app.address);
-      depositEvent.owner.should.be.equal(userOne);
+      depositEvent.origin.should.be.equal(userOne);
       depositEvent.amount.eq(ethers.BigNumber.from(amount.toString())).should.be.true;
 
       // Confirm app event emitted with expected values

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -186,13 +186,6 @@ describe("ETHApp", function () {
       this.app = await deployAppWithMockChannels(owner, [inboundChannel, outboundChannel.address], ETHApp, inboundChannel, this.vault.address);
     });
 
-    it("should not lock", async function () {
-      const amount = BigNumber(web3.utils.toWei("2", "ether"));
-
-      const tx = await lockupFunds(this.app, userOne, POLKADOT_ADDRESS, amount, ChannelId.Basic, 0, 0)
-        .should.be.rejectedWith(/Ownable: caller is not the owner/);
-    });
-
     it("should not unlock", async function () {
       const amount = BigNumber(web3.utils.toWei("2", "ether"));
       // recipient on the ethereum side

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -13,7 +13,7 @@ require("chai")
 const { ethers } = require("ethers");
 const { expect } = require("chai");
 
-const ETHVault = artifacts.require("ETHVault");
+const ETHVault = artifacts.require("EtherVault");
 const ETHApp = artifacts.require("ETHApp");
 const ScaleCodec = artifacts.require("ScaleCodec");
 

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -178,6 +178,7 @@ describe("ETHApp", function () {
         receipt.rawLogs[1].topics
       );
 
+      unlockEvent.sender.should.be.equal(POLKADOT_ADDRESS);
       unlockEvent.recipient.should.be.equal(recipient);
       unlockEvent.amount.eq(ethers.BigNumber.from(amount)).should.be.true;
 

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -231,6 +231,16 @@ describe("ETHApp", function () {
         }
       ).should.be.rejectedWith(/Ownable: caller is not the owner/);
     });
+
+    it("should not receive", async function () {
+      const amount = BigNumber(web3.utils.toWei("2", "ether"));
+      await this.vault.sendTransaction(
+        {
+          value: amount,
+          from: inboundChannel,
+        }
+      ).should.be.rejectedWith(/Must use deposit function/);
+    });
   });
 
   describe("upgradeability", function () {

--- a/test/scripts/poll-ethereum-events.ts
+++ b/test/scripts/poll-ethereum-events.ts
@@ -8,6 +8,7 @@ const main = async () => {
     const contracts = JSON.parse(await readFile('/tmp/snowbridge/contracts.json', 'utf8'));
 
     const interestingContracts = {
+        EtherVault: contracts.contracts.EtherVault,
         ETHApp: contracts.contracts.ETHApp,
         ERC20App: contracts.contracts.ERC20App,
         DOTApp: contracts.contracts.DOTApp,


### PR DESCRIPTION
Added a vault to store ether on behalf of EthApp.

* The vault is secured with `Ownable` openzeppelin contract.
* Only one version of EthApp can hold ownership of the vault at a time.
* EthApp controls transfer of vault ownership via messages from the inbound channel.
* Ownership transfer is assumed to be part of a consistent upgrade procedure. i.e. No new transfers across the bridge can be initiated and all pending transfers are complete.

