### PR TITLE
SNO-352: Rename nonces map to nonce in parachain -> eth basic channel

### DIFF
--- a/ethereum/contracts/BasicInboundChannel.sol
+++ b/ethereum/contracts/BasicInboundChannel.sol
@@ -10,7 +10,7 @@ contract BasicInboundChannel {
 
     uint8 public immutable sourceChannelID;
 
-    mapping(bytes32 => uint64) public nonces;
+    mapping(bytes32 => uint64) public nonce;
 
     ParachainClient public parachainClient;
 
@@ -45,12 +45,12 @@ contract BasicInboundChannel {
 
         require(parachainClient.verifyCommitment(commitment, proof), "Invalid proof");
         require(bundle.sourceChannelID == sourceChannelID, "Invalid source channel");
-        require(bundle.nonce == nonces[bundle.account] + 1, "Invalid nonce");
+        require(bundle.nonce == nonce[bundle.account] + 1, "Invalid nonce");
         require(
             gasleft() >= (bundle.messages.length * MAX_GAS_PER_MESSAGE) + GAS_BUFFER,
             "insufficient gas for delivery of all messages"
         );
-        nonces[bundle.account]++;
+        nonce[bundle.account]++;
         dispatch(bundle);
     }
 

--- a/ethereum/test/test_basic_inbound_channel.js
+++ b/ethereum/test/test_basic_inbound_channel.js
@@ -46,7 +46,7 @@ describe("BasicInboundChannel", function () {
     });
 
     it("should accept a valid commitment and dispatch messages", async function () {
-      const nonceBeforeSubmit = BigNumber(await this.channel.nonces(submitInput.params.bundle.account));
+      const nonceBeforeSubmit = BigNumber(await this.channel.nonce(submitInput.params.bundle.account));
 
       const { receipt } = await this.channel.submit(
         submitInput.params.bundle,
@@ -55,7 +55,7 @@ describe("BasicInboundChannel", function () {
         submitInput.params.proof,
       ).should.be.fulfilled
 
-      const nonceAfterSubmit = BigNumber(await this.channel.nonces(submitInput.params.bundle.account));
+      const nonceAfterSubmit = BigNumber(await this.channel.nonce(submitInput.params.bundle.account));
       nonceAfterSubmit.minus(nonceBeforeSubmit).should.be.bignumber.equal(1);
 
       const event = interface.decodeEventLog(

--- a/parachain/pallets/basic-channel/src/outbound/mod.rs
+++ b/parachain/pallets/basic-channel/src/outbound/mod.rs
@@ -163,7 +163,7 @@ pub mod pallet {
 		StorageValue<_, BoundedVec<EnqueuedMessageOf<T>, T::MaxMessagesPerCommit>, ValueQuery>;
 
 	#[pallet::storage]
-	pub type Nonces<T: Config> = StorageMap<_, Identity, T::AccountId, u64, ValueQuery>;
+	pub type Nonce<T: Config> = StorageMap<_, Identity, T::AccountId, u64, ValueQuery>;
 
 	#[pallet::storage]
 	pub type NextId<T: Config> = StorageValue<_, u64, ValueQuery>;
@@ -318,7 +318,7 @@ pub mod pallet {
 
 			let mut message_bundles: Vec<MessageBundleOf<T>> = Vec::new();
 			for (account, messages) in account_message_map {
-				let next_nonce = <Nonces<T>>::mutate(&account, |nonce| {
+				let next_nonce = <Nonce<T>>::mutate(&account, |nonce| {
 					*nonce = nonce.saturating_add(1);
 					*nonce
 				});

--- a/parachain/pallets/basic-channel/src/outbound/test.rs
+++ b/parachain/pallets/basic-channel/src/outbound/test.rs
@@ -106,7 +106,7 @@ fn test_submit() {
 		assert_ok!(BasicOutboundChannel::submit(who, target, &vec![0, 1, 2]));
 
 		assert_eq!(<NextId<Test>>::get(), 1);
-		assert_eq!(<Nonces<Test>>::get(who), 0);
+		assert_eq!(<Nonce<Test>>::get(who), 0);
 		assert_eq!(<MessageQueue<Test>>::get().len(), 1);
 	});
 }
@@ -154,7 +154,7 @@ fn test_commit_single_user() {
 		run_to_block(2);
 
 		assert_eq!(<NextId<Test>>::get(), 1);
-		assert_eq!(<Nonces<Test>>::get(who), 1);
+		assert_eq!(<Nonce<Test>>::get(who), 1);
 		assert_eq!(<MessageQueue<Test>>::get().len(), 0);
 	})
 }
@@ -171,8 +171,8 @@ fn test_commit_multi_user() {
 		run_to_block(2);
 
 		assert_eq!(<NextId<Test>>::get(), 2);
-		assert_eq!(<Nonces<Test>>::get(alice), 1);
-		assert_eq!(<Nonces<Test>>::get(bob), 1);
+		assert_eq!(<Nonce<Test>>::get(alice), 1);
+		assert_eq!(<Nonce<Test>>::get(bob), 1);
 		assert_eq!(<MessageQueue<Test>>::get().len(), 0);
 	})
 }

--- a/relayer/contracts/basic/inbound.go
+++ b/relayer/contracts/basic/inbound.go
@@ -45,7 +45,7 @@ type BasicInboundChannelMessageBundle struct {
 
 // BasicInboundChannelMetaData contains all meta data concerning the BasicInboundChannel contract.
 var BasicInboundChannelMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"_sourceChannelID\",\"type\":\"uint8\"},{\"internalType\":\"contractParachainClient\",\"name\":\"_parachainClient\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"result\",\"type\":\"bool\"}],\"name\":\"MessageDispatched\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"GAS_BUFFER\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MAX_GAS_PER_MESSAGE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"parachainClient\",\"outputs\":[{\"internalType\":\"contractParachainClient\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sourceChannelID\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint8\",\"name\":\"sourceChannelID\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"account\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"payload\",\"type\":\"bytes\"}],\"internalType\":\"structBasicInboundChannel.Message[]\",\"name\":\"messages\",\"type\":\"tuple[]\"}],\"internalType\":\"structBasicInboundChannel.MessageBundle\",\"name\":\"bundle\",\"type\":\"tuple\"},{\"internalType\":\"bytes32[]\",\"name\":\"leafProof\",\"type\":\"bytes32[]\"},{\"internalType\":\"bool[]\",\"name\":\"hashSides\",\"type\":\"bool[]\"},{\"internalType\":\"bytes\",\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"submit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"_sourceChannelID\",\"type\":\"uint8\"},{\"internalType\":\"contractParachainClient\",\"name\":\"_parachainClient\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"result\",\"type\":\"bool\"}],\"name\":\"MessageDispatched\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"GAS_BUFFER\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MAX_GAS_PER_MESSAGE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"parachainClient\",\"outputs\":[{\"internalType\":\"contractParachainClient\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sourceChannelID\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint8\",\"name\":\"sourceChannelID\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"account\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"payload\",\"type\":\"bytes\"}],\"internalType\":\"structBasicInboundChannel.Message[]\",\"name\":\"messages\",\"type\":\"tuple[]\"}],\"internalType\":\"structBasicInboundChannel.MessageBundle\",\"name\":\"bundle\",\"type\":\"tuple\"},{\"internalType\":\"bytes32[]\",\"name\":\"leafProof\",\"type\":\"bytes32[]\"},{\"internalType\":\"bool[]\",\"name\":\"hashSides\",\"type\":\"bool[]\"},{\"internalType\":\"bytes\",\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"submit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
 // BasicInboundChannelABI is the input ABI used to generate the binding from.
@@ -256,12 +256,12 @@ func (_BasicInboundChannel *BasicInboundChannelCallerSession) MAXGASPERMESSAGE()
 	return _BasicInboundChannel.Contract.MAXGASPERMESSAGE(&_BasicInboundChannel.CallOpts)
 }
 
-// Nonces is a free data retrieval call binding the contract method 0x9e317f12.
+// Nonce is a free data retrieval call binding the contract method 0x905da30f.
 //
-// Solidity: function nonces(bytes32 ) view returns(uint64)
-func (_BasicInboundChannel *BasicInboundChannelCaller) Nonces(opts *bind.CallOpts, arg0 [32]byte) (uint64, error) {
+// Solidity: function nonce(bytes32 ) view returns(uint64)
+func (_BasicInboundChannel *BasicInboundChannelCaller) Nonce(opts *bind.CallOpts, arg0 [32]byte) (uint64, error) {
 	var out []interface{}
-	err := _BasicInboundChannel.contract.Call(opts, &out, "nonces", arg0)
+	err := _BasicInboundChannel.contract.Call(opts, &out, "nonce", arg0)
 
 	if err != nil {
 		return *new(uint64), err
@@ -273,18 +273,18 @@ func (_BasicInboundChannel *BasicInboundChannelCaller) Nonces(opts *bind.CallOpt
 
 }
 
-// Nonces is a free data retrieval call binding the contract method 0x9e317f12.
+// Nonce is a free data retrieval call binding the contract method 0x905da30f.
 //
-// Solidity: function nonces(bytes32 ) view returns(uint64)
-func (_BasicInboundChannel *BasicInboundChannelSession) Nonces(arg0 [32]byte) (uint64, error) {
-	return _BasicInboundChannel.Contract.Nonces(&_BasicInboundChannel.CallOpts, arg0)
+// Solidity: function nonce(bytes32 ) view returns(uint64)
+func (_BasicInboundChannel *BasicInboundChannelSession) Nonce(arg0 [32]byte) (uint64, error) {
+	return _BasicInboundChannel.Contract.Nonce(&_BasicInboundChannel.CallOpts, arg0)
 }
 
-// Nonces is a free data retrieval call binding the contract method 0x9e317f12.
+// Nonce is a free data retrieval call binding the contract method 0x905da30f.
 //
-// Solidity: function nonces(bytes32 ) view returns(uint64)
-func (_BasicInboundChannel *BasicInboundChannelCallerSession) Nonces(arg0 [32]byte) (uint64, error) {
-	return _BasicInboundChannel.Contract.Nonces(&_BasicInboundChannel.CallOpts, arg0)
+// Solidity: function nonce(bytes32 ) view returns(uint64)
+func (_BasicInboundChannel *BasicInboundChannelCallerSession) Nonce(arg0 [32]byte) (uint64, error) {
+	return _BasicInboundChannel.Contract.Nonce(&_BasicInboundChannel.CallOpts, arg0)
 }
 
 // ParachainClient is a free data retrieval call binding the contract method 0x1674f9b7.

--- a/relayer/relays/beacon/writer/parachain-writer.go
+++ b/relayer/relays/beacon/writer/parachain-writer.go
@@ -250,7 +250,7 @@ func (wr *ParachainWriter) GetLastBasicChannelNoncesByAddresses(addresses []comm
 	addressNonceMap := make(map[common.Address]uint64, len(addresses))
 
 	for _, address := range addresses {
-		key, err := types.CreateStorageKey(wr.conn.Metadata(), "BasicOutboundChannel", "Nonces", address[:], nil)
+		key, err := types.CreateStorageKey(wr.conn.Metadata(), "BasicInboundChannel", "Nonce", address[:], nil)
 		if err != nil {
 			return addressNonceMap, fmt.Errorf("create storage key for basic channel nonces: %w", err)
 		}

--- a/relayer/relays/parachain/beefy-listener.go
+++ b/relayer/relays/parachain/beefy-listener.go
@@ -347,7 +347,7 @@ func (li *BeefyListener) discoverCatchupTasks(
 			"account": types.HexEncodeToString(account[:]),
 		}).Info("Checked latest nonce delivered to ethereum basic channel")
 
-		paraBasicNonceKey, err := types.CreateStorageKey(li.parachainConnection.Metadata(), "BasicOutboundChannel", "Nonces", account[:], nil)
+		paraBasicNonceKey, err := types.CreateStorageKey(li.parachainConnection.Metadata(), "BasicOutboundChannel", "Nonce", account[:], nil)
 		if err != nil {
 			return nil, fmt.Errorf("create storage key for account '%v': %w", types.HexEncodeToString(account[:]), err)
 		}

--- a/relayer/relays/parachain/beefy-listener.go
+++ b/relayer/relays/parachain/beefy-listener.go
@@ -338,7 +338,7 @@ func (li *BeefyListener) discoverCatchupTasks(
 
 	basicChannelAccountNoncesToFind := make(map[types.AccountID]uint64, len(li.accounts))
 	for _, account := range li.accounts {
-		ethBasicNonce, err := basicContract.Nonces(&options, account)
+		ethBasicNonce, err := basicContract.Nonce(&options, account)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Follow-on from a [previous comment](https://github.com/Snowfork/snowbridge/pull/699#discussion_r995597978) about renaming the nonce map.

This is another breaking change for the parachain & contracts, so might be a good opportunity for an upgradability exercise.