### PR TITLE
SNO-316: Switch to Twox64Concat hasher for Nonces map

### DIFF
--- a/parachain/pallets/basic-channel/src/outbound/mod.rs
+++ b/parachain/pallets/basic-channel/src/outbound/mod.rs
@@ -163,7 +163,7 @@ pub mod pallet {
 		StorageValue<_, BoundedVec<EnqueuedMessageOf<T>, T::MaxMessagesPerCommit>, ValueQuery>;
 
 	#[pallet::storage]
-	pub type Nonces<T: Config> = StorageMap<_, Identity, T::AccountId, u64, ValueQuery>;
+	pub type Nonces<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, u64, ValueQuery>;
 
 	#[pallet::storage]
 	pub type NextId<T: Config> = StorageValue<_, u64, ValueQuery>;


### PR DESCRIPTION
[Relevant article](https://www.shawntabrizi.com/substrate/transparent-keys-in-substrate)