### PR TITLE
SNO-369: Use Option for initial_sync in GenesisConfig

### DIFF
--- a/core/packages/test/src/ethclient/index.js
+++ b/core/packages/test/src/ethclient/index.js
@@ -14,7 +14,7 @@ const IncentivizedOutboundChannel = contracts.contracts.IncentivizedOutboundChan
 const BasicInboundChannel = contracts.contracts.BasicInboundChannel;
 const IncentivizedInboundChannel = contracts.contracts.IncentivizedInboundChannel;
 
-const IERC20 = require("../../../ethereum/artifacts/@openzeppelin/contracts/token/ERC20/IERC20.sol/IERC20.json")
+const IERC20 = require("../../../contracts/artifacts/@openzeppelin/contracts/token/ERC20/IERC20.sol/IERC20.json")
 /**
  * The Ethereum client for Bridge interaction
  */

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -154,13 +154,13 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub initial_sync: InitialSyncOf<T>,
+		pub initial_sync: Option<InitialSyncOf<T>>,
 	}
 
 	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self { GenesisConfig {
-			initial_sync: Default::default(),
+			initial_sync: None,
 		}}
 	}
 
@@ -173,9 +173,11 @@ pub mod pallet {
 				config::SYNC_COMMITTEE_SIZE
 			);
 
-			Pallet::<T>::initial_sync(
-				self.initial_sync.clone(),
-			).unwrap();
+			if let Some(initial_sync) = self.initial_sync.clone() {
+				Pallet::<T>::initial_sync(
+					initial_sync,
+				).unwrap();
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes the `benchmark` subcommand and makes it a bit clearer when there isn't any real InitialSync data in the GenesisConfig. Only the XCM tests are failing, but those are also failing on main iirc.