### PR TITLE
Adds ssz tests

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/Snowfork/ssz_rs?rev=8d497a949c320577aa1f741eb9f2958191df905b#8d497a949c320577aa1f741eb9f2958191df905b"
+source = "git+https://github.com/Snowfork/ssz_rs?rev=f55915f7f96943109345b164e89342eef1aeb6e3#f55915f7f96943109345b164e89342eef1aeb6e3"
 dependencies = [
  "bitvec",
  "hex",
@@ -11676,12 +11676,13 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "ssz-rs-derive",
+ "thiserror",
 ]
 
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/Snowfork/ssz_rs?rev=8d497a949c320577aa1f741eb9f2958191df905b#8d497a949c320577aa1f741eb9f2958191df905b"
+source = "git+https://github.com/Snowfork/ssz_rs?rev=f55915f7f96943109345b164e89342eef1aeb6e3#f55915f7f96943109345b164e89342eef1aeb6e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -15,8 +15,8 @@ serde = { version = "1.0.137", optional = true }
 codec = { version = "3.1.5", package = "parity-scale-codec", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.2.0", default-features = false, features = [ "derive" ] }
 milagro_bls = { git = "https://github.com/Snowfork/milagro_bls", default-features = false }
-ssz-rs = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="8d497a949c320577aa1f741eb9f2958191df905b" }
-ssz-rs-derive = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="8d497a949c320577aa1f741eb9f2958191df905b" }
+ssz-rs = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="f55915f7f96943109345b164e89342eef1aeb6e3" }
+ssz-rs-derive = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="f55915f7f96943109345b164e89342eef1aeb6e3" }
 byte-slice-cast = { version = "1.2.1", default-features = false }
 rlp = { version = "0.5", default-features = false }
 hex-literal = { version = "0.3.1", optional = true }

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -1,7 +1,7 @@
 mod beacon {
 	use crate as ethereum_beacon_client;
 	use crate::{
-		config, merkleization,
+		config, merkleization, merkleization::MerkleizationError,
 		mock::*,
 		BeaconHeader, Error, ExecutionHeaders, FinalizedBeaconHeaders, LatestFinalizedHeaderSlot,
 		PublicKey, SyncCommittees, ValidatorsRoot,
@@ -425,6 +425,24 @@ mod beacon {
 		assert_ok!(&sync_committee_bits);
 
 		assert_ok!(EthereumBeaconClient::sync_committee_participation_is_supermajority(sync_committee_bits.unwrap()));
+	}
+
+	#[test]
+	pub fn test_sync_committee_bits_too_short() {
+		let bits = hex!("bffffffff7f1ffdfcfeffeffbfdffffbfffffdffffefefffdffff7f7ffff77fffdf7bffff5f7fedfffdfb6ddff7bf7").to_vec();
+		
+		let sync_committee_bits =  merkleization::get_sync_committee_bits::<MaxSyncCommitteeSize>(bits.try_into().expect("invalid sync committee bits"));
+
+		assert_err!(sync_committee_bits, MerkleizationError::InputTooShort);
+	}
+
+	#[test]
+	pub fn test_sync_committee_bits_extra_input() {
+		let bits = hex!("bffffffff7f1ffdfcfeffeffbfdffffbfffffdffffefefffdffff7f7ffff77fffdf7bff77ffdf7fffafffffff77fefffeff7effffffff5f7fedfffdfb6ddff7bf7bffffffff7f1ffdfcfeffeffbfdffffbfffffdffffefefffdffff7f7ffff77fffdf7bff77ffdf7fffafffffff77fefffeff7effffffff5f7fedfffdfb6ddff7bf7").to_vec();
+		
+		let sync_committee_bits =  merkleization::get_sync_committee_bits::<MaxSyncCommitteeSize>(bits.try_into().expect("invalid sync committee bits"));
+
+		assert_err!(sync_committee_bits, MerkleizationError::ExtraInput);
 	}
 
 	#[test]


### PR DESCRIPTION
- Changes ssz-rs crate to use latest version of https://github.com/Snowfork/ssz_rs. This will be updated to the upstream crate once https://github.com/ralexstokes/ssz-rs/pull/25 is merged.
- Adds tests for deserializing sync committee bits, with too many bits and too few bits.
- The other usages of the ssz crate is for hash_tree_root, which is applied on a struct with size limits, so overflow cases are already handled on that level.