### PR TITLE
Clara/sno 367 check for extended gap between header imports

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -10347,6 +10347,7 @@ dependencies = [
  "frame-system",
  "hex-literal",
  "milagro_bls",
+ "pallet-timestamp",
  "parity-scale-codec",
  "rlp",
  "scale-info",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -38,6 +38,7 @@ sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "po
 snowbridge-testutils = { path = "../../primitives/testutils" }
 serde_json = "1.0.68"
 hex-literal = { version = "0.3.4" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", default-features = false }
 
 [features]
 default = ["std"]

--- a/parachain/pallets/ethereum-beacon-client/src/benchmarking/data.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/benchmarking/data.rs
@@ -600,7 +600,7 @@ pub fn initial_sync<SyncCommitteeSize: Get<u32>, ProofSize: Get<u32>>(
             hex!("b132c9711ec41fb5b14de2c9d06da61cd09f57da54ca5556e70824e4787a1e84").into()
         ].try_into().expect("too many branch proof items"),
         validators_root: hex!("043db0d9a83813551ee2f33450d23797757d430911a9320530ad8a0eabc43efb").into()   
-    }
+    };
 }
 
 pub fn sync_committee_update<
@@ -3634,5 +3634,5 @@ pub fn block_update<
             sync_committee_signature: hex!("802cbd03fec8b80a253aa8327cb66fe04684495742a0ef68bae487055f5bd71f00b082b1a1e10a7405e0a518bf06886817bad957aece07f119c66212422b5ce9d09c7c2eebf98a4f04a6bbec1a1fff31568380af32e26fcebc6cb2fbd423ca45").to_vec().try_into().expect("signature too long"),
         },
         signature_slot: 4485186
-    }
+    };
 }

--- a/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
@@ -49,7 +49,11 @@ benchmarks! {
 
 		let block_update = data::block_update();
 
-		LatestFinalizedHeaderSlot::<T>::set(block_update.block.slot);
+		LatestFinalizedHeaderState::<T>::set(FinalizedHeaderState{
+			beacon_block_root: H256::default(),
+			beacon_slot: block_update.block.slot,
+			import_time: 0,
+		});
 	}: _(RawOrigin::Signed(caller.clone()), block_update.clone())
 	verify {
 		let block_hash: H256 = block_update.block.body.execution_payload.block_hash;

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -17,7 +17,7 @@ mod benchmarking;
 pub use weights::WeightInfo;
 
 use crate::merkleization::get_sync_committee_bits;
-use frame_support::{dispatch::DispatchResult, log, transactional, traits::UnixTime};
+use frame_support::{dispatch::DispatchResult, log, traits::UnixTime, transactional};
 use frame_system::ensure_signed;
 use snowbridge_beacon_primitives::{
 	BeaconHeader, BlockUpdate, Domain, ExecutionHeader, ExecutionHeaderState,
@@ -178,8 +178,7 @@ pub mod pallet {
 	pub(super) type LatestFinalizedHeaderSlot<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::storage]
-	pub(super) type LatestFinalizedHeaderImportTime<T: Config> =
-		StorageValue<_, u64, ValueQuery>;
+	pub(super) type LatestFinalizedHeaderImportTime<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::storage]
 	pub(super) type LatestExecutionHeaderState<T: Config> =
@@ -333,9 +332,7 @@ pub mod pallet {
 
 		#[pallet::weight(1000)]
 		#[transactional]
-		pub fn unblock_bridge(
-			origin: OriginFor<T>,
-		) -> DispatchResult {
+		pub fn unblock_bridge(origin: OriginFor<T>) -> DispatchResult {
 			let _sender = ensure_root(origin)?;
 
 			log::info!(target: "ethereum-beacon-client","💫 Unblocking bridge.");
@@ -431,7 +428,7 @@ pub mod pallet {
 			if time > weak_subjectivity_period_check {
 				log::info!(target: "ethereum-beacon-client","💫 Weak subjectivity period exceeded, blocking bridge.",);
 				<Blocked<T>>::set(true);
-				return Err(Error::<T>::BridgeBlocked.into());
+				return Err(Error::<T>::BridgeBlocked.into())
 			}
 
 			let sync_committee_bits =

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -176,7 +176,8 @@ pub mod pallet {
 	pub(super) type LatestFinalizedHeaderSlot<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::storage]
-	pub(super) type LatestFinalizedHeaderImportBlockNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+	pub(super) type LatestFinalizedHeaderImportBlockNumber<T: Config> =
+		StorageValue<_, T::BlockNumber, ValueQuery>;
 
 	#[pallet::storage]
 	pub(super) type LatestExecutionHeaderState<T: Config> =
@@ -393,7 +394,8 @@ pub mod pallet {
 		fn process_finalized_header(update: FinalizedHeaderUpdateOf<T>) -> DispatchResult {
 			let current_block_number = <frame_system::Pallet<T>>::block_number();
 			let last_finalized_block_number = <LatestFinalizedHeaderImportBlockNumber<T>>::get();
-			let weak_subjectivity_period_check = last_finalized_block_number + T::WeakSubjectivityPeriod::get().into();
+			let weak_subjectivity_period_check =
+				last_finalized_block_number + T::WeakSubjectivityPeriod::get().into();
 
 			log::info!(
 				target: "ethereum-beacon-client",

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -190,9 +190,6 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type Blocked<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-	#[pallet::storage]
-	pub(super) type GovernanceResync<T: Config> = StorageValue<_, bool, ValueQuery>;
-
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub initial_sync: Option<InitialSyncOf<T>>,
@@ -338,7 +335,7 @@ pub mod pallet {
 		pub fn unblock_bridge(origin: OriginFor<T>) -> DispatchResult {
 			let _sender = ensure_root(origin)?;
 
-			<GovernanceResync<T>>::set(true);
+			<Blocked<T>>::set(false);
 
 			log::info!(target: "ethereum-beacon-client","💫 syncing bridge from governance provided checkpoint.");
 

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -20,9 +20,9 @@ use crate::merkleization::get_sync_committee_bits;
 use frame_support::{dispatch::DispatchResult, log, traits::UnixTime, transactional};
 use frame_system::ensure_signed;
 use snowbridge_beacon_primitives::{
-	BeaconHeader, BlockUpdate, Domain, ExecutionHeader, ExecutionHeaderState,
+	BeaconHeader, BlockUpdate, Domain, ExecutionHeader, ExecutionHeaderState, FinalizedHeaderState,
 	FinalizedHeaderUpdate, ForkData, ForkVersion, InitialSync, PublicKey, Root, SigningData,
-	SyncCommittee, SyncCommitteePeriodUpdate, FinalizedHeaderState
+	SyncCommittee, SyncCommitteePeriodUpdate,
 };
 use snowbridge_core::{Message, Verifier};
 use sp_core::H256;
@@ -173,7 +173,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	pub(super) type LatestFinalizedHeaderState<T: Config> =
-	StorageValue<_, FinalizedHeaderState, ValueQuery>;
+		StorageValue<_, FinalizedHeaderState, ValueQuery>;
 
 	#[pallet::storage]
 	pub(super) type LatestExecutionHeaderState<T: Config> =
@@ -411,7 +411,8 @@ pub mod pallet {
 		fn process_finalized_header(update: FinalizedHeaderUpdateOf<T>) -> DispatchResult {
 			let last_finalized_header = <LatestFinalizedHeaderState<T>>::get();
 			let import_time = last_finalized_header.import_time;
-			let weak_subjectivity_period_check = import_time + T::WeakSubjectivityPeriodSeconds::get() as u64;
+			let weak_subjectivity_period_check =
+				import_time + T::WeakSubjectivityPeriodSeconds::get() as u64;
 			let time: u64 = T::TimeProvider::now().as_secs();
 
 			log::info!(

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -190,6 +190,9 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type Blocked<T: Config> = StorageValue<_, bool, ValueQuery>;
 
+	#[pallet::storage]
+	pub(super) type GovernanceResync<T: Config> = StorageValue<_, bool, ValueQuery>;
+
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub initial_sync: Option<InitialSyncOf<T>>,
@@ -335,9 +338,9 @@ pub mod pallet {
 		pub fn unblock_bridge(origin: OriginFor<T>) -> DispatchResult {
 			let _sender = ensure_root(origin)?;
 
-			log::info!(target: "ethereum-beacon-client","💫 Unblocking bridge.");
+			<GovernanceResync<T>>::set(true);
 
-			<Blocked<T>>::set(false); // TODO add denylist headers
+			log::info!(target: "ethereum-beacon-client","💫 syncing bridge from governance provided checkpoint.");
 
 			Ok(())
 		}

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -23,6 +23,7 @@ pub mod mock_minimal {
 			UncheckedExtrinsic = UncheckedExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Storage, Event<T>},
+			Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 			EthereumBeaconClient: ethereum_beacon_client::{Pallet, Call, Config<T>, Storage, Event<T>},
 		}
 	);
@@ -73,7 +74,7 @@ pub mod mock_minimal {
 		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
-		pub const WeakSubjectivityPeriod: u32 = 300;
+		pub const WeakSubjectivityPeriodHours: u32 = 27;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
 				version: [0, 0, 0, 1], // 0x00000001
@@ -91,6 +92,7 @@ pub mod mock_minimal {
 	}
 
 	impl ethereum_beacon_client::Config for Test {
+		type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 		type RuntimeEvent = RuntimeEvent;
 		type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 		type MaxProofBranchSize = MaxProofBranchSize;
@@ -106,7 +108,7 @@ pub mod mock_minimal {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
-		type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
+		type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
 		type WeightInfo = ();
 	}
 }
@@ -124,6 +126,7 @@ pub mod mock_mainnet {
 			UncheckedExtrinsic = UncheckedExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Storage, Event<T>},
+			Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 			EthereumBeaconClient: ethereum_beacon_client::{Pallet, Call, Config<T>, Storage, Event<T>},
 		}
 	);
@@ -174,7 +177,7 @@ pub mod mock_mainnet {
 		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
-		pub const WeakSubjectivityPeriod: u32 = 300;
+		pub const WeakSubjectivityPeriodHours: u32 = 27;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
 				version: [0, 0, 16, 32], // 0x00001020
@@ -193,6 +196,7 @@ pub mod mock_mainnet {
 
 	impl ethereum_beacon_client::Config for Test {
 		type RuntimeEvent = RuntimeEvent;
+		type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 		type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 		type MaxProofBranchSize = MaxProofBranchSize;
 		type MaxExtraDataSize = MaxExtraDataSize;
@@ -207,7 +211,7 @@ pub mod mock_mainnet {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
-		type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
+		type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
 		type WeightInfo = ();
 	}
 }

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate as ethereum_beacon_client;
 use frame_support::parameter_types;
 use frame_system as system;
+use pallet_timestamp;
 use snowbridge_beacon_primitives::{AttesterSlashing, BeaconHeader, Body, Fork, ForkVersions};
 use sp_core::H256;
 use sp_runtime::{
@@ -60,6 +61,13 @@ pub mod mock_minimal {
 		type MaxConsumers = frame_support::traits::ConstU32<16>;
 	}
 
+	impl pallet_timestamp::Config for Test {
+		type Moment = u64;
+		type OnTimestampSet = ();
+		type MinimumPeriod = ();
+		type WeightInfo = ();
+	}
+
 	parameter_types! {
 		pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
 		pub const MaxProofBranchSize: u32 = 6;
@@ -92,7 +100,7 @@ pub mod mock_minimal {
 	}
 
 	impl ethereum_beacon_client::Config for Test {
-		type TimeProvider = pallet_timestamp::Pallet<Runtime>;
+		type TimeProvider = pallet_timestamp::Pallet<Test>;
 		type RuntimeEvent = RuntimeEvent;
 		type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 		type MaxProofBranchSize = MaxProofBranchSize;
@@ -163,6 +171,13 @@ pub mod mock_mainnet {
 		type MaxConsumers = frame_support::traits::ConstU32<16>;
 	}
 
+	impl pallet_timestamp::Config for Test {
+		type Moment = u64;
+		type OnTimestampSet = ();
+		type MinimumPeriod = ();
+		type WeightInfo = ();
+	}
+
 	parameter_types! {
 		pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
 		pub const MaxProofBranchSize: u32 = 6;
@@ -196,7 +211,7 @@ pub mod mock_mainnet {
 
 	impl ethereum_beacon_client::Config for Test {
 		type RuntimeEvent = RuntimeEvent;
-		type TimeProvider = pallet_timestamp::Pallet<Runtime>;
+		type TimeProvider = pallet_timestamp::Pallet<Test>;
 		type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 		type MaxProofBranchSize = MaxProofBranchSize;
 		type MaxExtraDataSize = MaxExtraDataSize;

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -161,34 +161,34 @@ pub mod mock_mainnet {
 	}
 
 	parameter_types! {
-			pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
-			pub const MaxProofBranchSize: u32 = 6;
-			pub const MaxExtraDataSize: u32 = config::MAX_EXTRA_DATA_BYTES as u32;
-			pub const MaxLogsBloomSize: u32 = config::MAX_LOGS_BLOOM_SIZE as u32;
-			pub const MaxFeeRecipientSize: u32 = config::MAX_FEE_RECIPIENT_SIZE as u32;
-			pub const MaxDepositDataSize: u32 = config::MAX_DEPOSITS as u32;
-			pub const MaxPublicKeySize: u32 = config::PUBKEY_SIZE as u32;
-			pub const MaxSignatureSize: u32 = config::SIGNATURE_SIZE as u32;
-			pub const MaxProposerSlashingSize: u32 = config::MAX_PROPOSER_SLASHINGS as u32;
-			pub const MaxAttesterSlashingSize: u32 = config::MAX_ATTESTER_SLASHINGS as u32;
-			pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
-			pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
-			pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
-			pub const WeakSubjectivityPeriod: u32 = 300;
-			pub const ChainForkVersions: ForkVersions = ForkVersions{
-				genesis: Fork {
-					version: [0, 0, 16, 32], // 0x00001020
-					epoch: 0,
-				},
-				altair: Fork {
-					version: [1, 0, 16, 32], // 0x01001020
-					epoch: 36660,
-				},
-				bellatrix: Fork {
-					version: [2, 0, 16, 32], // 0x02001020
-					epoch: 112260,
-				},
-			};
+		pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
+		pub const MaxProofBranchSize: u32 = 6;
+		pub const MaxExtraDataSize: u32 = config::MAX_EXTRA_DATA_BYTES as u32;
+		pub const MaxLogsBloomSize: u32 = config::MAX_LOGS_BLOOM_SIZE as u32;
+		pub const MaxFeeRecipientSize: u32 = config::MAX_FEE_RECIPIENT_SIZE as u32;
+		pub const MaxDepositDataSize: u32 = config::MAX_DEPOSITS as u32;
+		pub const MaxPublicKeySize: u32 = config::PUBKEY_SIZE as u32;
+		pub const MaxSignatureSize: u32 = config::SIGNATURE_SIZE as u32;
+		pub const MaxProposerSlashingSize: u32 = config::MAX_PROPOSER_SLASHINGS as u32;
+		pub const MaxAttesterSlashingSize: u32 = config::MAX_ATTESTER_SLASHINGS as u32;
+		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
+		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
+		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
+		pub const WeakSubjectivityPeriod: u32 = 300;
+		pub const ChainForkVersions: ForkVersions = ForkVersions{
+			genesis: Fork {
+				version: [0, 0, 16, 32], // 0x00001020
+				epoch: 0,
+			},
+			altair: Fork {
+				version: [1, 0, 16, 32], // 0x01001020
+				epoch: 36660,
+			},
+			bellatrix: Fork {
+				version: [2, 0, 16, 32], // 0x02001020
+				epoch: 112260,
+			},
+		};
 	}
 
 	impl ethereum_beacon_client::Config for Test {

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -73,6 +73,7 @@ pub mod mock_minimal {
 		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
+		pub const WeakSubjectivityPeriod: u32 = 300;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
 				version: [0, 0, 0, 1], // 0x00000001
@@ -105,6 +106,7 @@ pub mod mock_minimal {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
+		type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
 		type WeightInfo = ();
 	}
 }
@@ -172,6 +174,7 @@ pub mod mock_mainnet {
 			pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 			pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 			pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
+			pub const WeakSubjectivityPeriod: u32 = 300;
 			pub const ChainForkVersions: ForkVersions = ForkVersions{
 				genesis: Fork {
 					version: [0, 0, 16, 32], // 0x00001020
@@ -204,6 +207,7 @@ pub mod mock_mainnet {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
+		type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
 		type WeightInfo = ();
 	}
 }

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -82,7 +82,7 @@ pub mod mock_minimal {
 		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
-		pub const WeakSubjectivityPeriodHours: u32 = 27;
+		pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
 				version: [0, 0, 0, 1], // 0x00000001
@@ -116,7 +116,7 @@ pub mod mock_minimal {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
-		type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
+		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}
 }
@@ -192,7 +192,7 @@ pub mod mock_mainnet {
 		pub const MaxVoluntaryExitSize: u32 = config::MAX_VOLUNTARY_EXITS as u32;
 		pub const MaxAttestationSize: u32 = config::MAX_ATTESTATIONS as u32;
 		pub const MaxValidatorsPerCommittee: u32 = config::MAX_VALIDATORS_PER_COMMITTEE as u32;
-		pub const WeakSubjectivityPeriodHours: u32 = 27;
+		pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
 				version: [0, 0, 16, 32], // 0x00001020
@@ -226,7 +226,7 @@ pub mod mock_mainnet {
 		type MaxAttestationSize = MaxAttestationSize;
 		type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 		type ForkVersions = ChainForkVersions;
-		type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
+		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}
 }

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -655,8 +655,8 @@ mod beacon_tests {
 mod beacon_minimal_tests {
 	use crate::{
 		merkleization, merkleization::MerkleizationError, mock::*, ssz::SSZBeaconBlockBody, Error,
-		ExecutionHeaders, FinalizedBeaconHeaders, LatestFinalizedHeaderSlot, SyncCommittees,
-		ValidatorsRoot,
+		ExecutionHeaders, FinalizedBeaconHeaders, FinalizedHeaderState, LatestFinalizedHeaderState,
+		SyncCommittees, ValidatorsRoot,
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
@@ -749,7 +749,11 @@ mod beacon_minimal_tests {
 		new_tester::<mock_minimal::Test>().execute_with(|| {
 			SyncCommittees::<mock_minimal::Test>::insert(current_period, current_sync_committee);
 			ValidatorsRoot::<mock_minimal::Test>::set(get_validators_root::<mock_minimal::Test>());
-			LatestFinalizedHeaderSlot::<mock_minimal::Test>::set(update.block.slot);
+			LatestFinalizedHeaderState::<mock_minimal::Test>::set(FinalizedHeaderState {
+				beacon_block_root: H256::default(),
+				beacon_slot: update.block.slot,
+				import_time: 0,
+			});
 
 			assert_ok!(mock_minimal::EthereumBeaconClient::import_execution_header(
 				mock_minimal::RuntimeOrigin::signed(1),
@@ -839,8 +843,7 @@ mod beacon_minimal_tests {
 mod beacon_mainnet_tests {
 	use crate::{
 		merkleization, merkleization::MerkleizationError, mock::*, ssz::SSZBeaconBlockBody,
-		ExecutionHeaders, FinalizedBeaconHeaders, LatestFinalizedHeaderSlot, SyncCommittees,
-		ValidatorsRoot,
+		ExecutionHeaders, FinalizedBeaconHeaders, SyncCommittees, ValidatorsRoot,
 	};
 	use frame_support::assert_ok;
 	use hex_literal::hex;
@@ -933,7 +936,11 @@ mod beacon_mainnet_tests {
 		new_tester::<mock_mainnet::Test>().execute_with(|| {
 			SyncCommittees::<mock_mainnet::Test>::insert(current_period, current_sync_committee);
 			ValidatorsRoot::<mock_mainnet::Test>::set(get_validators_root::<mock_mainnet::Test>());
-			LatestFinalizedHeaderSlot::<mock_mainnet::Test>::set(update.block.slot);
+			LatestFinalizedHeaderState::<mock_mainnet::Test>::set(FinalizedHeaderState {
+				beacon_block_root: H256::default(),
+				beacon_slot: update.block.slot,
+				import_time: 0,
+			});
 
 			assert_ok!(mock_mainnet::EthereumBeaconClient::import_execution_header(
 				mock_mainnet::RuntimeOrigin::signed(1),

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -843,7 +843,8 @@ mod beacon_minimal_tests {
 mod beacon_mainnet_tests {
 	use crate::{
 		merkleization, merkleization::MerkleizationError, mock::*, ssz::SSZBeaconBlockBody,
-		ExecutionHeaders, FinalizedBeaconHeaders, SyncCommittees, ValidatorsRoot,
+		ExecutionHeaders, FinalizedBeaconHeaders, FinalizedHeaderState, LatestFinalizedHeaderState,
+		SyncCommittees, ValidatorsRoot,
 	};
 	use frame_support::assert_ok;
 	use hex_literal::hex;

--- a/parachain/primitives/beacon/src/lib.rs
+++ b/parachain/primitives/beacon/src/lib.rs
@@ -129,6 +129,13 @@ pub struct ExecutionHeaderState {
 	pub block_number: u64,
 }
 
+#[derive(Default, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct FinalizedHeaderState {
+	pub beacon_block_root: H256,
+	pub beacon_slot: u64,
+	pub import_time: u64,
+}
+
 #[derive(
 	Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen,
 )]

--- a/parachain/runtime/snowbase/src/lib.rs
+++ b/parachain/runtime/snowbase/src/lib.rs
@@ -628,7 +628,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriodHours: u32 = 27;
+	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 1], // 0x00000001
@@ -662,7 +662,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
+	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = weights::ethereum_beacon_client::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowbase/src/lib.rs
+++ b/parachain/runtime/snowbase/src/lib.rs
@@ -153,7 +153,7 @@ impl frame_system::Config for Runtime {
 	type BlockHashCount = BlockHashCount;
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
-	/// Version of the runtime.
+	/// Version of the runtime. 
 	type Version = Version;
 	/// Converts a module to the index of the module in `construct_runtime!`.
 	///
@@ -628,6 +628,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
+	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 1], // 0x00000001
@@ -660,6 +661,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
+	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
 	type WeightInfo = weights::ethereum_beacon_client::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowbase/src/lib.rs
+++ b/parachain/runtime/snowbase/src/lib.rs
@@ -153,7 +153,7 @@ impl frame_system::Config for Runtime {
 	type BlockHashCount = BlockHashCount;
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
-	/// Version of the runtime. 
+	/// Version of the runtime.
 	type Version = Version;
 	/// Converts a module to the index of the module in `construct_runtime!`.
 	///

--- a/parachain/runtime/snowbase/src/lib.rs
+++ b/parachain/runtime/snowbase/src/lib.rs
@@ -628,7 +628,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
+	pub const WeakSubjectivityPeriodHours: u32 = 27;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 1], // 0x00000001
@@ -647,6 +647,7 @@ parameter_types! {
 
 impl ethereum_beacon_client::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 	type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 	type MaxProofBranchSize = MaxProofBranchSize;
 	type MaxExtraDataSize = MaxExtraDataSize;
@@ -661,7 +662,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
+	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
 	type WeightInfo = weights::ethereum_beacon_client::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowblink/src/lib.rs
+++ b/parachain/runtime/snowblink/src/lib.rs
@@ -626,6 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
+	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 16, 32], // 0x00001020
@@ -658,6 +659,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
+	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowblink/src/lib.rs
+++ b/parachain/runtime/snowblink/src/lib.rs
@@ -626,7 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
+	pub const WeakSubjectivityPeriodHours: u32 = 27;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 16, 32], // 0x00001020
@@ -645,6 +645,7 @@ parameter_types! {
 
 impl ethereum_beacon_client::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 	type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 	type MaxProofBranchSize = MaxProofBranchSize;
 	type MaxExtraDataSize = MaxExtraDataSize;
@@ -659,7 +660,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
+	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowblink/src/lib.rs
+++ b/parachain/runtime/snowblink/src/lib.rs
@@ -626,7 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriodHours: u32 = 27;
+	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 16, 32], // 0x00001020
@@ -660,7 +660,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
+	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -626,6 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
+	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 0], // 0x00000000
@@ -658,6 +659,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
+	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -626,7 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriod: u32 = 27 * HOURS;
+	pub const WeakSubjectivityPeriodHours: u32 = 27;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 0], // 0x00000000
@@ -645,6 +645,7 @@ parameter_types! {
 
 impl ethereum_beacon_client::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 	type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
 	type MaxProofBranchSize = MaxProofBranchSize;
 	type MaxExtraDataSize = MaxExtraDataSize;
@@ -659,7 +660,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriod = WeakSubjectivityPeriod;
+	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -626,7 +626,7 @@ parameter_types! {
 	pub const MaxVoluntaryExitSize: u32 = 16;
 	pub const MaxAttestationSize: u32 = 128;
 	pub const MaxValidatorsPerCommittee: u32 = 2048;
-	pub const WeakSubjectivityPeriodHours: u32 = 27;
+	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
 		genesis: Fork {
 			version: [0, 0, 0, 0], // 0x00000000
@@ -660,7 +660,7 @@ impl ethereum_beacon_client::Config for Runtime {
 	type MaxAttestationSize = MaxAttestationSize;
 	type MaxValidatorsPerCommittee = MaxValidatorsPerCommittee;
 	type ForkVersions = ChainForkVersions;
-	type WeakSubjectivityPeriodHours = WeakSubjectivityPeriodHours;
+	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
 }
 

--- a/relayer/chain/parachain/writer.go
+++ b/relayer/chain/parachain/writer.go
@@ -191,14 +191,6 @@ func (wr *ParachainWriter) GetLastSyncedSyncCommitteePeriod() (uint64, error) {
 	return wr.getNumberFromParachain("EthereumBeaconClient", "LatestSyncCommitteePeriod")
 }
 
-func (wr *ParachainWriter) GetLastStoredFinalizedHeader() (common.Hash, error) {
-	return wr.getHashFromParachain("EthereumBeaconClient", "LatestFinalizedHeaderHash")
-}
-
-func (wr *ParachainWriter) GetLastStoredFinalizedHeaderSlot() (uint64, error) {
-	return wr.getNumberFromParachain("EthereumBeaconClient", "LatestFinalizedHeaderSlot")
-}
-
 func (wr *ParachainWriter) GetLastBasicChannelBlockNumber() (uint64, error) {
 	return wr.getNumberFromParachain("BasicInboundChannel", "LatestVerifiedBlockNumber")
 }
@@ -263,6 +255,29 @@ func (wr *ParachainWriter) GetLastExecutionHeaderState() (state.ExecutionHeader,
 		BeaconSlot:      uint64(storageState.BeaconSlot),
 		BlockHash:       common.Hash(storageState.BlockHash),
 		BlockNumber:     uint64(storageState.BlockNumber),
+	}, nil
+}
+
+func (wr *ParachainWriter) GetLastFinalizedHeaderState() (state.FinalizedHeader, error) {
+	key, err := types.CreateStorageKey(wr.conn.Metadata(), "EthereumBeaconClient", "LatestFinalizedHeaderState", nil, nil)
+	if err != nil {
+		return state.FinalizedHeader{}, fmt.Errorf("create storage key for GetLastFinalizedHeaderState: %w", err)
+	}
+
+	var storageState struct {
+		BeaconBlockRoot types.H256
+		BeaconSlot      types.U64
+		ImportTime      types.U64
+	}
+	_, err = wr.conn.API().RPC.State.GetStorageLatest(key, &storageState)
+	if err != nil {
+		return state.FinalizedHeader{}, fmt.Errorf("get storage for GetLastFinalizedHeaderState (err): %w", err)
+	}
+
+	return state.FinalizedHeader{
+		BeaconBlockRoot: common.Hash(storageState.BeaconBlockRoot),
+		BeaconSlot:      uint64(storageState.BeaconSlot),
+		ImportTime:      uint64(storageState.ImportTime),
 	}, nil
 }
 

--- a/relayer/relays/beacon/cache/cache.go
+++ b/relayer/relays/beacon/cache/cache.go
@@ -4,12 +4,20 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/snowfork/snowbridge/relayer/relays/beacon/state"
 )
+
+type FinalizedHeader struct {
+	// Used to determine the execution headers that need to be backfilled.
+	Headers []common.Hash
+	// Stores the last attempted finalized header, whether the import succeeded or not.
+	LastAttemptedSyncHash common.Hash
+	// Stores the slot number of the above header
+	LastAttemptedSyncSlot uint64
+}
 
 type BeaconCache struct {
 	LastSyncedSyncCommitteePeriod uint64
-	Finalized                     state.FinalizedHeader
+	Finalized                     FinalizedHeader
 	mu                            sync.Mutex
 }
 

--- a/relayer/relays/beacon/header/header.go
+++ b/relayer/relays/beacon/header/header.go
@@ -53,15 +53,13 @@ func (h *Header) Sync(ctx context.Context, eg *errgroup.Group) error {
 		return fmt.Errorf("sync lagging sync committee periods: %w", err)
 	}
 
-	lastFinalizedHeader, err := h.writer.GetLastStoredFinalizedHeader()
+	lastFinalizedHeaderState, err := h.writer.GetLastFinalizedHeaderState()
 	if err != nil {
-		return fmt.Errorf("fetch last finalized header: %w", err)
+		return fmt.Errorf("fetch last finalized header state: %w", err)
 	}
 
-	lastFinalizedSlot, err := h.writer.GetLastStoredFinalizedHeaderSlot()
-	if err != nil {
-		return fmt.Errorf("fetch last finalized header slot: %w", err)
-	}
+	lastFinalizedHeader := lastFinalizedHeaderState.BeaconBlockRoot
+	lastFinalizedSlot := lastFinalizedHeaderState.BeaconSlot
 
 	h.cache.Finalized.Headers = append(h.cache.Finalized.Headers, lastFinalizedHeader)
 	h.cache.Finalized.LastAttemptedSyncHash = lastFinalizedHeader
@@ -198,10 +196,12 @@ func (h *Header) SyncFinalizedHeader(ctx context.Context) (syncer.FinalizedHeade
 	h.cache.Finalized.LastAttemptedSyncHash = blockRoot
 	h.cache.Finalized.LastAttemptedSyncSlot = uint64(finalizedHeaderUpdate.FinalizedHeader.Slot)
 
-	lastStoredHeader, err := h.writer.GetLastStoredFinalizedHeader()
+	lastFinalizedHeaderState, err := h.writer.GetLastFinalizedHeaderState()
 	if err != nil {
-		return syncer.FinalizedHeaderUpdate{}, common.Hash{}, fmt.Errorf("fetch last finalized header from parachain: %w", err)
+		return syncer.FinalizedHeaderUpdate{}, common.Hash{}, fmt.Errorf("fetch last finalized header state: %w", err)
 	}
+
+	lastStoredHeader := lastFinalizedHeaderState.BeaconBlockRoot
 
 	// If the finalized header import succeeded, we add it to this cache. This cache is used to determine
 	// from which last finalized header needs to imported (i.e. start and end finalized blocks, to backfill execution

--- a/relayer/relays/beacon/state/state.go
+++ b/relayer/relays/beacon/state/state.go
@@ -12,10 +12,7 @@ type ExecutionHeader struct {
 }
 
 type FinalizedHeader struct {
-	// Used to determine the execution headers that need to be backfilled.
-	Headers []common.Hash
-	// Stores the last attempted finalized header, whether the import succeeded or not.
-	LastAttemptedSyncHash common.Hash
-	// Stores the slot number of the above header
-	LastAttemptedSyncSlot uint64
+	BeaconBlockRoot common.Hash
+	BeaconSlot      uint64
+	ImportTime      uint64
 }


### PR DESCRIPTION
Adds weak subjectivity check to prevent long range attacks. Set to 27 hours, as it is the [minimum recommended weak](https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2#:~:text=The%20maximum%20safe%20weak%20subjectivity%20period%20is%20always%20at%20least%2027%20hours.) subjectivity period.

When the weak subjectivity threshold period is exceeded, the light client panics and will have to be reinitialized.