### PR TITLE
Refactor type conversions using TryFrom impls

### DIFF
--- a/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
@@ -24,52 +24,58 @@ pub enum MerkleizationError {
 }
 
 impl<
-	FeeRecipientSize: Get<u32>,
-	LogsBloomSize: Get<u32>,
-	ExtraDataSize: Get<u32>,
-	DepositDataSize: Get<u32>,
-	PublicKeySize: Get<u32>,
-	SignatureSize: Get<u32>,
-	ProofSize: Get<u32>,
-	ProposerSlashingSize: Get<u32>,
-	AttesterSlashingSize: Get<u32>,
-	VoluntaryExitSize: Get<u32>,
-	AttestationSize: Get<u32>,
-	AggregationBitsSize: Get<u32>,
-	ValidatorCommitteeSize: Get<u32>,
-> TryFrom<Body<
-		FeeRecipientSize,
-		LogsBloomSize,
-		ExtraDataSize,
-		DepositDataSize,
-		PublicKeySize,
-		SignatureSize,
-		ProofSize,
-		ProposerSlashingSize,
-		AttesterSlashingSize,
-		VoluntaryExitSize,
-		AttestationSize,
-		AggregationBitsSize,
-		ValidatorCommitteeSize,
-	>> for SSZBeaconBlockBody {
-    type Error = MerkleizationError;
-	
-    fn try_from(body: Body<
-		FeeRecipientSize,
-		LogsBloomSize,
-		ExtraDataSize,
-		DepositDataSize,
-		PublicKeySize,
-		SignatureSize,
-		ProofSize,
-		ProposerSlashingSize,
-		AttesterSlashingSize,
-		VoluntaryExitSize,
-		AttestationSize,
-		AggregationBitsSize,
-		ValidatorCommitteeSize,
-	>) -> Result<Self, Self::Error> {
-        Ok(SSZBeaconBlockBody {
+		FeeRecipientSize: Get<u32>,
+		LogsBloomSize: Get<u32>,
+		ExtraDataSize: Get<u32>,
+		DepositDataSize: Get<u32>,
+		PublicKeySize: Get<u32>,
+		SignatureSize: Get<u32>,
+		ProofSize: Get<u32>,
+		ProposerSlashingSize: Get<u32>,
+		AttesterSlashingSize: Get<u32>,
+		VoluntaryExitSize: Get<u32>,
+		AttestationSize: Get<u32>,
+		AggregationBitsSize: Get<u32>,
+		ValidatorCommitteeSize: Get<u32>,
+	>
+	TryFrom<
+		Body<
+			FeeRecipientSize,
+			LogsBloomSize,
+			ExtraDataSize,
+			DepositDataSize,
+			PublicKeySize,
+			SignatureSize,
+			ProofSize,
+			ProposerSlashingSize,
+			AttesterSlashingSize,
+			VoluntaryExitSize,
+			AttestationSize,
+			AggregationBitsSize,
+			ValidatorCommitteeSize,
+		>,
+	> for SSZBeaconBlockBody
+{
+	type Error = MerkleizationError;
+
+	fn try_from(
+		body: Body<
+			FeeRecipientSize,
+			LogsBloomSize,
+			ExtraDataSize,
+			DepositDataSize,
+			PublicKeySize,
+			SignatureSize,
+			ProofSize,
+			ProposerSlashingSize,
+			AttesterSlashingSize,
+			VoluntaryExitSize,
+			AttestationSize,
+			AggregationBitsSize,
+			ValidatorCommitteeSize,
+		>,
+	) -> Result<Self, Self::Error> {
+		Ok(SSZBeaconBlockBody {
 			randao_reveal: Vector::<u8, 96>::from_iter(body.randao_reveal),
 			eth1_data: body.eth1_data.try_into()?,
 			graffiti: body
@@ -85,14 +91,18 @@ impl<
 			sync_aggregate: body.sync_aggregate.try_into()?,
 			execution_payload: body.execution_payload.try_into()?,
 		})
-    }
+	}
 }
 
-impl<FeeRecipientSize: Get<u32>, LogsBloomSize: Get<u32>, ExtraDataSize: Get<u32>> TryFrom<ExecutionPayload<FeeRecipientSize, LogsBloomSize, ExtraDataSize>> for SSZExecutionPayload {
+impl<FeeRecipientSize: Get<u32>, LogsBloomSize: Get<u32>, ExtraDataSize: Get<u32>>
+	TryFrom<ExecutionPayload<FeeRecipientSize, LogsBloomSize, ExtraDataSize>> for SSZExecutionPayload
+{
 	type Error = MerkleizationError;
 
-	fn try_from(execution_payload: ExecutionPayload<FeeRecipientSize, LogsBloomSize, ExtraDataSize>) -> Result<Self, Self::Error> {
-		Ok( SSZExecutionPayload {
+	fn try_from(
+		execution_payload: ExecutionPayload<FeeRecipientSize, LogsBloomSize, ExtraDataSize>,
+	) -> Result<Self, Self::Error> {
+		Ok(SSZExecutionPayload {
 			parent_hash: execution_payload
 				.parent_hash
 				.as_bytes()
@@ -141,10 +151,14 @@ impl<FeeRecipientSize: Get<u32>, LogsBloomSize: Get<u32>, ExtraDataSize: Get<u32
 	}
 }
 
-impl<AttestionBitsSize: Get<u32>, SignatureSize: Get<u32>> TryFrom<Attestation<AttestionBitsSize, SignatureSize>> for SSZAttestation {
+impl<AttestionBitsSize: Get<u32>, SignatureSize: Get<u32>>
+	TryFrom<Attestation<AttestionBitsSize, SignatureSize>> for SSZAttestation
+{
 	type Error = MerkleizationError;
 
-	fn try_from(attestation: Attestation<AttestionBitsSize, SignatureSize>) -> Result<Self, Self::Error> {
+	fn try_from(
+		attestation: Attestation<AttestionBitsSize, SignatureSize>,
+	) -> Result<Self, Self::Error> {
 		let signature = Vector::<u8, 96>::from_iter(attestation.signature.clone());
 
 		Ok(SSZAttestation {
@@ -162,7 +176,7 @@ impl TryFrom<AttestationData> for SSZAttestationData {
 	type Error = MerkleizationError;
 
 	fn try_from(attestation_data: AttestationData) -> Result<Self, Self::Error> {
-        Ok(SSZAttestationData {
+		Ok(SSZAttestationData {
 			slot: attestation_data.slot,
 			index: attestation_data.index,
 			beacon_block_root: attestation_data
@@ -173,15 +187,21 @@ impl TryFrom<AttestationData> for SSZAttestationData {
 			source: attestation_data.source.try_into()?,
 			target: attestation_data.target.try_into()?,
 		})
-    }
+	}
 }
 
-impl<AttestingIndicesSize: Get<u32>, SignatureSize: Get<u32>> TryFrom<AttesterSlashing<AttestingIndicesSize, SignatureSize>> for SSZAttesterSlashing {
+impl<AttestingIndicesSize: Get<u32>, SignatureSize: Get<u32>>
+	TryFrom<AttesterSlashing<AttestingIndicesSize, SignatureSize>> for SSZAttesterSlashing
+{
 	type Error = MerkleizationError;
 
-	fn try_from(attester_slashing: AttesterSlashing<AttestingIndicesSize, SignatureSize>) -> Result<Self, Self::Error> {
-        let signature1 = Vector::<u8, 96>::from_iter(attester_slashing.attestation_1.signature.clone());
-		let signature2 = Vector::<u8, 96>::from_iter(attester_slashing.attestation_2.signature.clone());
+	fn try_from(
+		attester_slashing: AttesterSlashing<AttestingIndicesSize, SignatureSize>,
+	) -> Result<Self, Self::Error> {
+		let signature1 =
+			Vector::<u8, 96>::from_iter(attester_slashing.attestation_1.signature.clone());
+		let signature2 =
+			Vector::<u8, 96>::from_iter(attester_slashing.attestation_2.signature.clone());
 
 		let attesting_indices1 = List::<u64, { config::MAX_VALIDATORS_PER_COMMITTEE }>::from_iter(
 			attester_slashing.attestation_1.attesting_indices.clone(),
@@ -202,14 +222,14 @@ impl<AttestingIndicesSize: Get<u32>, SignatureSize: Get<u32>> TryFrom<AttesterSl
 				signature: signature2,
 			},
 		})
-    }
+	}
 }
 
 impl TryFrom<Checkpoint> for SSZCheckpoint {
 	type Error = MerkleizationError;
 
 	fn try_from(checkpoint: Checkpoint) -> Result<Self, Self::Error> {
-        Ok(SSZCheckpoint {
+		Ok(SSZCheckpoint {
 			epoch: checkpoint.epoch,
 			root: checkpoint
 				.root
@@ -217,14 +237,14 @@ impl TryFrom<Checkpoint> for SSZCheckpoint {
 				.try_into()
 				.map_err(|_| MerkleizationError::InvalidLength)?,
 		})
-    }
+	}
 }
 
 impl TryFrom<BeaconHeader> for SSZBeaconBlockHeader {
 	type Error = MerkleizationError;
 
 	fn try_from(beacon_header: BeaconHeader) -> Result<Self, Self::Error> {
-       	Ok(SSZBeaconBlockHeader {
+		Ok(SSZBeaconBlockHeader {
 			slot: beacon_header.slot,
 			proposer_index: beacon_header.proposer_index,
 			parent_root: beacon_header
@@ -243,14 +263,18 @@ impl TryFrom<BeaconHeader> for SSZBeaconBlockHeader {
 				.try_into()
 				.map_err(|_| MerkleizationError::InvalidLength)?,
 		})
-    }
+	}
 }
 
-impl<SyncCommitteeBitsSize: Get<u32>, SignatureSize: Get<u32>> TryFrom<SyncAggregate<SyncCommitteeBitsSize, SignatureSize>> for SSZSyncAggregate {
+impl<SyncCommitteeBitsSize: Get<u32>, SignatureSize: Get<u32>>
+	TryFrom<SyncAggregate<SyncCommitteeBitsSize, SignatureSize>> for SSZSyncAggregate
+{
 	type Error = MerkleizationError;
 
-	fn try_from(sync_aggregate: SyncAggregate<SyncCommitteeBitsSize, SignatureSize>) -> Result<Self, Self::Error> {
-        Ok(SSZSyncAggregate {
+	fn try_from(
+		sync_aggregate: SyncAggregate<SyncCommitteeBitsSize, SignatureSize>,
+	) -> Result<Self, Self::Error> {
+		Ok(SSZSyncAggregate {
 			sync_committee_bits: Bitvector::<{ config::SYNC_COMMITTEE_SIZE }>::deserialize(
 				&sync_aggregate.sync_committee_bits,
 			)
@@ -259,14 +283,14 @@ impl<SyncCommitteeBitsSize: Get<u32>, SignatureSize: Get<u32>> TryFrom<SyncAggre
 				sync_aggregate.sync_committee_signature,
 			),
 		})
-    }
+	}
 }
 
 impl TryFrom<Eth1Data> for SSZEth1Data {
 	type Error = MerkleizationError;
 
 	fn try_from(eth1_data: Eth1Data) -> Result<Self, Self::Error> {
-        Ok(SSZEth1Data {
+		Ok(SSZEth1Data {
 			deposit_root: eth1_data
 				.deposit_root
 				.as_bytes()
@@ -279,7 +303,7 @@ impl TryFrom<Eth1Data> for SSZEth1Data {
 				.try_into()
 				.map_err(|_| MerkleizationError::InvalidLength)?,
 		})
-    }
+	}
 }
 
 pub fn get_ssz_deposits<

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -1,8 +1,14 @@
 mod beacon_tests {
 	use crate as ethereum_beacon_client;
 	use crate::{
-		config, merkleization, merkleization::MerkleizationError, mock::*, BeaconHeader, Error,
-		PublicKey, ssz::{SSZEth1Data, SSZSyncAggregate, SSZExecutionPayload, SSZAttestation, SSZAttestationData, SSZCheckpoint, SSZAttesterSlashing}
+		config, merkleization,
+		merkleization::MerkleizationError,
+		mock::*,
+		ssz::{
+			SSZAttestation, SSZAttestationData, SSZAttesterSlashing, SSZCheckpoint, SSZEth1Data,
+			SSZExecutionPayload, SSZSyncAggregate,
+		},
+		BeaconHeader, Error, PublicKey,
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
@@ -466,7 +472,8 @@ mod beacon_tests {
 			deposit_count: 0,
 			block_hash: hex!("0000000000000000000000000000000000000000000000000000000000000000")
 				.into(),
-		}.try_into();
+		}
+		.try_into();
 		assert_ok!(&payload);
 
 		let hash_root = merkleization::hash_tree_root(payload.unwrap());
@@ -518,7 +525,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_execution_payload() {
-		let payload: Result<SSZExecutionPayload, MerkleizationError> = 
+		let payload: Result<SSZExecutionPayload, MerkleizationError> =
             ExecutionPayload::<mock_minimal::MaxFeeRecipientSize, mock_minimal::MaxLogsBloomSize, mock_minimal::MaxExtraDataSize>{
                 parent_hash: hex!("eadee5ab098dde64e9fd02ae5858064bad67064070679625b09f8d82dec183f7").into(),
                 fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").to_vec().try_into().expect("fee recipient bits are too long"),
@@ -546,7 +553,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_attestation() {
-		let payload: Result<SSZAttestation, MerkleizationError> = 
+		let payload: Result<SSZAttestation, MerkleizationError> =
             Attestation::<mock_minimal::MaxValidatorsPerCommittee, mock_minimal::MaxSignatureSize>{
                 aggregation_bits: hex!("ffcffeff7ffffffffefbf7ffffffdff73e").to_vec().try_into().expect("aggregation bits are too long"),
                 data: AttestationData{
@@ -595,7 +602,8 @@ mod beacon_tests {
 				root: hex!("3a667c20c78352228169181f19757c774ca93d81047a6c121a0e88b2c385c7f7")
 					.into(),
 			},
-		}.try_into();
+		}
+		.try_into();
 
 		assert_ok!(&payload);
 
@@ -613,7 +621,8 @@ mod beacon_tests {
 		let payload: Result<SSZCheckpoint, MerkleizationError> = Checkpoint {
 			epoch: 15127,
 			root: hex!("e665df84b5f1b4db9112b5c3876f5c10063347bfaf1025732137cf9abca28b75").into(),
-		}.try_into();
+		}
+		.try_into();
 
 		assert_ok!(&payload);
 
@@ -628,7 +637,8 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_attester_slashing() {
-		let payload: Result<SSZAttesterSlashing, MerkleizationError> = get_attester_slashing::<mock_minimal::Test>().try_into();
+		let payload: Result<SSZAttesterSlashing, MerkleizationError> =
+			get_attester_slashing::<mock_minimal::Test>().try_into();
 
 		assert_ok!(&payload);
 
@@ -644,8 +654,9 @@ mod beacon_tests {
 #[cfg(feature = "minimal")]
 mod beacon_minimal_tests {
 	use crate::{
-		merkleization, merkleization::MerkleizationError, mock::*, Error, ExecutionHeaders, FinalizedBeaconHeaders,
-		LatestFinalizedHeaderSlot, SyncCommittees, ValidatorsRoot, ssz::SSZBeaconBlockBody
+		merkleization, merkleization::MerkleizationError, mock::*, ssz::SSZBeaconBlockBody, Error,
+		ExecutionHeaders, FinalizedBeaconHeaders, LatestFinalizedHeaderSlot, SyncCommittees,
+		ValidatorsRoot,
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
@@ -788,7 +799,8 @@ mod beacon_minimal_tests {
 	#[test]
 	pub fn test_hash_block_body() {
 		let block_update = get_header_update::<mock_minimal::Test>();
-		let payload: Result<SSZBeaconBlockBody, MerkleizationError> = block_update.block.body.try_into();
+		let payload: Result<SSZBeaconBlockBody, MerkleizationError> =
+			block_update.block.body.try_into();
 		assert_ok!(&payload);
 
 		let hash_root_result = merkleization::hash_tree_root(payload.unwrap());
@@ -826,8 +838,9 @@ mod beacon_minimal_tests {
 #[cfg(not(feature = "minimal"))]
 mod beacon_mainnet_tests {
 	use crate::{
-		merkleization, mock::*, ExecutionHeaders, FinalizedBeaconHeaders,
-		LatestFinalizedHeaderSlot, SyncCommittees, ValidatorsRoot,
+		merkleization, merkleization::MerkleizationError, mock::*, ssz::SSZBeaconBlockBody,
+		ExecutionHeaders, FinalizedBeaconHeaders, LatestFinalizedHeaderSlot, SyncCommittees,
+		ValidatorsRoot,
 	};
 	use frame_support::assert_ok;
 	use hex_literal::hex;
@@ -951,7 +964,8 @@ mod beacon_mainnet_tests {
 	#[test]
 	pub fn test_hash_block_body() {
 		let block_update = get_header_update::<mock_minimal::Test>();
-		let payload = merkleization::get_ssz_beacon_block_body(block_update.block.body);
+		let payload: Result<SSZBeaconBlockBody, MerkleizationError> =
+			block_update.block.body.try_into();
 		assert_ok!(&payload);
 
 		let hash_root_result = merkleization::hash_tree_root(payload.unwrap());

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -2,7 +2,7 @@ mod beacon_tests {
 	use crate as ethereum_beacon_client;
 	use crate::{
 		config, merkleization, merkleization::MerkleizationError, mock::*, BeaconHeader, Error,
-		PublicKey,
+		PublicKey, ssz::{SSZEth1Data, SSZSyncAggregate, SSZExecutionPayload, SSZAttestation, SSZAttestationData, SSZCheckpoint, SSZAttesterSlashing}
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
@@ -460,13 +460,13 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_eth1_data() {
-		let payload = merkleization::get_ssz_eth1_data(Eth1Data {
+		let payload: Result<SSZEth1Data, MerkleizationError> = Eth1Data {
 			deposit_root: hex!("d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e")
 				.into(),
 			deposit_count: 0,
 			block_hash: hex!("0000000000000000000000000000000000000000000000000000000000000000")
 				.into(),
-		});
+		}.try_into();
 		assert_ok!(&payload);
 
 		let hash_root = merkleization::hash_tree_root(payload.unwrap());
@@ -494,7 +494,7 @@ mod beacon_tests {
 				hex!("e6dcad4f60ce9ff8a587b110facbaf94721f06cd810b6d8bf6cffa641272808d").into(),
 		};
 
-		let payload = merkleization::get_ssz_sync_aggregate(sync_aggregate);
+		let payload: Result<SSZSyncAggregate, MerkleizationError> = sync_aggregate.try_into();
 		assert_ok!(&payload);
 
 		let hash_root_result = merkleization::hash_tree_root(payload.unwrap());
@@ -518,7 +518,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_execution_payload() {
-		let payload = merkleization::get_ssz_execution_payload(
+		let payload: Result<SSZExecutionPayload, MerkleizationError> = 
             ExecutionPayload::<mock_minimal::MaxFeeRecipientSize, mock_minimal::MaxLogsBloomSize, mock_minimal::MaxExtraDataSize>{
                 parent_hash: hex!("eadee5ab098dde64e9fd02ae5858064bad67064070679625b09f8d82dec183f7").into(),
                 fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").to_vec().try_into().expect("fee recipient bits are too long"),
@@ -534,8 +534,7 @@ mod beacon_tests {
                 base_fee_per_gas: U256::from(7 as i16),
                 block_hash: hex!("cd8df91b4503adb8f2f1c7a4f60e07a1f1a2cbdfa2a95bceba581f3ff65c1968").into(),
                 transactions_root: hex!("7ffe241ea60187fdb0187bfa22de35d1f9bed7ab061d9401fd47e34a54fbede1").into(),
-            }
-        );
+            }.try_into();
 		assert_ok!(&payload);
 
 		let hash_root = merkleization::hash_tree_root(payload.unwrap());
@@ -547,7 +546,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_attestation() {
-		let payload = merkleization::get_ssz_attestation(
+		let payload: Result<SSZAttestation, MerkleizationError> = 
             Attestation::<mock_minimal::MaxValidatorsPerCommittee, mock_minimal::MaxSignatureSize>{
                 aggregation_bits: hex!("ffcffeff7ffffffffefbf7ffffffdff73e").to_vec().try_into().expect("aggregation bits are too long"),
                 data: AttestationData{
@@ -564,8 +563,7 @@ mod beacon_tests {
                     }
                 },
                 signature: hex!("af8e57aadf092443bd6675927ca84875419233fb7a5eb3ae626621d3339fe738b00af4a0edcc55efbe1198a815600784074388d366c4add789aa6126bb1ec5ed63ad8d8f22b5f158ae4c25d46b08d46d1188f7ed7e8f99d96ff6c3c69a240c18").to_vec().try_into().expect("signature is too long"),
-            },
-        );
+            }.try_into();
 
 		assert_ok!(&payload);
 
@@ -580,7 +578,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_attestation_data() {
-		let payload = merkleization::get_ssz_attestation_data(AttestationData {
+		let payload: Result<SSZAttestationData, MerkleizationError> = AttestationData {
 			slot: 484119,
 			index: 25,
 			beacon_block_root: hex!(
@@ -597,7 +595,7 @@ mod beacon_tests {
 				root: hex!("3a667c20c78352228169181f19757c774ca93d81047a6c121a0e88b2c385c7f7")
 					.into(),
 			},
-		});
+		}.try_into();
 
 		assert_ok!(&payload);
 
@@ -612,10 +610,10 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_checkpoint() {
-		let payload = merkleization::get_ssz_checkpoint(Checkpoint {
+		let payload: Result<SSZCheckpoint, MerkleizationError> = Checkpoint {
 			epoch: 15127,
 			root: hex!("e665df84b5f1b4db9112b5c3876f5c10063347bfaf1025732137cf9abca28b75").into(),
-		});
+		}.try_into();
 
 		assert_ok!(&payload);
 
@@ -630,8 +628,7 @@ mod beacon_tests {
 
 	#[test]
 	pub fn test_hash_tree_root_attester_slashing() {
-		let payload =
-			merkleization::get_ssz_attester_slashing(get_attester_slashing::<mock_minimal::Test>());
+		let payload: Result<SSZAttesterSlashing, MerkleizationError> = get_attester_slashing::<mock_minimal::Test>().try_into();
 
 		assert_ok!(&payload);
 
@@ -647,8 +644,8 @@ mod beacon_tests {
 #[cfg(feature = "minimal")]
 mod beacon_minimal_tests {
 	use crate::{
-		merkleization, mock::*, Error, ExecutionHeaders, FinalizedBeaconHeaders,
-		LatestFinalizedHeaderSlot, SyncCommittees, ValidatorsRoot,
+		merkleization, merkleization::MerkleizationError, mock::*, Error, ExecutionHeaders, FinalizedBeaconHeaders,
+		LatestFinalizedHeaderSlot, SyncCommittees, ValidatorsRoot, ssz::SSZBeaconBlockBody
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
@@ -791,7 +788,7 @@ mod beacon_minimal_tests {
 	#[test]
 	pub fn test_hash_block_body() {
 		let block_update = get_header_update::<mock_minimal::Test>();
-		let payload = merkleization::get_ssz_beacon_block_body(block_update.block.body);
+		let payload: Result<SSZBeaconBlockBody, MerkleizationError> = block_update.block.body.try_into();
 		assert_ok!(&payload);
 
 		let hash_root_result = merkleization::hash_tree_root(payload.unwrap());


### PR DESCRIPTION
Refactor of SSZ conversion types to use `TryFrom` impls instead of manual conversions.

Also adds error type conversions so manual `map_err` isn't necessary anymore.