### PR TITLE
Minor improvements to speeding up E2E tests

### DIFF
--- a/core/packages/test/scripts/start-relayer.sh
+++ b/core/packages/test/scripts/start-relayer.sh
@@ -134,13 +134,6 @@ start_relayer()
             sleep 20
         done
     ) &
-
-    # waiting sync headers 
-    until grep "starting to sync finalized headers" beacon-relay.log > /dev/null; do
-        echo "Waiting for beacon relay to sync headers..."
-        sleep 5
-    done
-    echo "Ready for beacon relayer to sync headers"
 }
 
 if [ -z "${from_start_services:-}" ]; then

--- a/core/packages/test/scripts/start-services.sh
+++ b/core/packages/test/scripts/start-services.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -eu
 
+start=$(date +%s)
+
 source scripts/set-env.sh
 source scripts/build-binary.sh
 from_start_services=true
 
 trap kill_all SIGINT SIGTERM EXIT
 kill_all && cleanup
-# 0. check required tools 
+# 0. check required tools
 echo "Check building tools"
 check_tool
 
@@ -26,5 +28,11 @@ source scripts/start-relayer.sh
 start_relayer
 
 echo "Testnet has been initialized"
+
+end=$(date +%s)
+runtime=$((end-start))
+minutes=$(( (runtime % 3600) / 60 ));
+seconds=$(( (runtime % 3600) % 60 ));
+echo "Took $minutes minutes $seconds seconds"
 
 wait


### PR DESCRIPTION
- Removes unnecessary beacon relay check. 
- Adds total time printout for start-services at the end of the script.