### PR TITLE
fix benchark params

### DIFF
--- a/parachain/pallets/basic-channel/src/outbound/test.rs
+++ b/parachain/pallets/basic-channel/src/outbound/test.rs
@@ -64,8 +64,10 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxMessagePayloadSize: u32 = 128;
-	pub const MaxMessagesPerCommit: u32 = 5;
+	// more than 256 in runtime to leave some margin
+	pub const MaxMessagePayloadSize: u32 = 300;
+	// more than 20 in runtime to leave some margin
+	pub const MaxMessagesPerCommit: u32 = 24;
 }
 
 impl basic_outbound_channel::Config for Test {


### PR DESCRIPTION
then we need to re-benchark based on it to update the weight required
https://github.com/Snowfork/snowbridge/blob/09404845e0fb34783576a9513b59043b8bff6349/parachain/pallets/basic-channel/src/outbound/weights.rs#L49-L55
