### PR TITLE
Use ralexstokes ssz-rs crate after it has been no-std enabled.

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3704,9 +3704,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -11501,13 +11498,10 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/Snowfork/ssz_rs?rev=f55915f7f96943109345b164e89342eef1aeb6e3#f55915f7f96943109345b164e89342eef1aeb6e3"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=d18af912abacbf84219be37ab3b42a9abcf10d2a#d18af912abacbf84219be37ab3b42a9abcf10d2a"
 dependencies = [
  "bitvec",
- "hex",
- "lazy_static",
  "num-bigint 0.4.3",
- "serde",
  "sha2 0.9.9",
  "ssz-rs-derive",
  "thiserror",
@@ -11516,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/Snowfork/ssz_rs?rev=f55915f7f96943109345b164e89342eef1aeb6e3#f55915f7f96943109345b164e89342eef1aeb6e3"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=d18af912abacbf84219be37ab3b42a9abcf10d2a#d18af912abacbf84219be37ab3b42a9abcf10d2a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -15,8 +15,8 @@ serde = { version = "1.0.137", optional = true }
 codec = { version = "3.1.5", package = "parity-scale-codec", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.2.0", default-features = false, features = [ "derive" ] }
 milagro_bls = { git = "https://github.com/Snowfork/milagro_bls", default-features = false }
-ssz-rs = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="f55915f7f96943109345b164e89342eef1aeb6e3" }
-ssz-rs-derive = { git = "https://github.com/Snowfork/ssz_rs", default-features = false, rev="f55915f7f96943109345b164e89342eef1aeb6e3" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev="d18af912abacbf84219be37ab3b42a9abcf10d2a" }
+ssz-rs-derive = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev="d18af912abacbf84219be37ab3b42a9abcf10d2a" }
 byte-slice-cast = { version = "1.2.1", default-features = false }
 rlp = { version = "0.5", default-features = false }
 hex-literal = { version = "0.3.1", optional = true }

--- a/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
@@ -20,8 +20,8 @@ pub enum MerkleizationError {
 	HashTreeRootError,
 	HashTreeRootInvalidBytes,
 	InvalidLength,
-	InputTooShort,
-	ExtraInput,
+	ExpectedFurtherInput { provided: u64, expected: u64 },
+	AdditionalInput { provided: u64, expected: u64 },
 	InvalidInput,
 	DeserializeError,
 	ListError,
@@ -483,10 +483,19 @@ pub fn get_sync_committee_bits<SyncCommitteeBitsSize: Get<u32>>(
 	bits_hex: BoundedVec<u8, SyncCommitteeBitsSize>,
 ) -> Result<Vec<u8>, MerkleizationError> {
 	let bitv = Bitvector::<{ config::SYNC_COMMITTEE_SIZE }>::deserialize(&bits_hex).map_err(
+		//|_| MerkleizationError::InvalidInput
 		|e| -> MerkleizationError {
 			match e {
-				DeserializeError::InputTooShort => MerkleizationError::InputTooShort,
-				DeserializeError::ExtraInput => MerkleizationError::ExtraInput,
+				DeserializeError::ExpectedFurtherInput { provided, expected } =>
+					MerkleizationError::ExpectedFurtherInput {
+						provided: provided as u64,
+						expected: expected as u64,
+					},
+				DeserializeError::AdditionalInput { provided, expected } =>
+					MerkleizationError::AdditionalInput {
+						provided: provided as u64,
+						expected: expected as u64,
+					},
 				_ => MerkleizationError::InvalidInput,
 			}
 		},

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -327,7 +327,10 @@ mod beacon_tests {
 			mock_minimal::MaxSyncCommitteeSize,
 		>(bits.try_into().expect("invalid sync committee bits"));
 
-		assert_err!(sync_committee_bits, MerkleizationError::InputTooShort);
+		assert_err!(
+			sync_committee_bits,
+			MerkleizationError::ExpectedFurtherInput { provided: 47, expected: 64 }
+		);
 	}
 
 	#[test]
@@ -341,7 +344,10 @@ mod beacon_tests {
 			mock_minimal::MaxSyncCommitteeSize,
 		>(bits.try_into().expect("invalid sync committee bits"));
 
-		assert_err!(sync_committee_bits, MerkleizationError::ExtraInput);
+		assert_err!(
+			sync_committee_bits,
+			MerkleizationError::AdditionalInput { provided: 130, expected: 64 }
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Uses the original ssz-rs crate after https://github.com/ralexstokes/ssz-rs/pull/25 has been merged.