### PR TITLE
Remove target param from BasicOutboundChannel.submit

### DIFF
--- a/core/packages/test/scripts/deploy-ethereum.sh
+++ b/core/packages/test/scripts/deploy-ethereum.sh
@@ -82,9 +82,8 @@ deploy_ethereum()
     # 2. deploy consensus client
     echo "Starting beacon node"
     start_lodestar
-    
+
     # 3. deploy bridge contracts
     echo "Deploying contracts"
     deploy_contracts
 }
-

--- a/parachain/pallets/basic-channel/src/outbound/mod.rs
+++ b/parachain/pallets/basic-channel/src/outbound/mod.rs
@@ -13,7 +13,7 @@ use frame_support::{
 	BoundedVec, CloneNoBound, Parameter, PartialEqNoBound, RuntimeDebugNoBound,
 };
 use scale_info::TypeInfo;
-use sp_core::{H160, H256};
+use sp_core::H256;
 use sp_runtime::traits::Hash;
 
 use sp_std::prelude::*;
@@ -171,8 +171,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		/// Submit message on the outbound channel
-		// TODO: Remove target once incentivized channel & app removal are done
-		pub fn submit(source_id: &T::SourceId, _target: H160, payload: &[u8]) -> DispatchResult {
+		pub fn submit(source_id: &T::SourceId, payload: &[u8]) -> DispatchResult {
 			ensure!(
 				<MessageQueue<T>>::decode_len().unwrap_or(0) <
 					T::MaxMessagesPerCommit::get() as usize,

--- a/parachain/pallets/basic-channel/src/outbound/test.rs
+++ b/parachain/pallets/basic-channel/src/outbound/test.rs
@@ -4,7 +4,7 @@ use frame_support::{
 	assert_noop, assert_ok, parameter_types,
 	traits::{Everything, GenesisBuild, OnInitialize},
 };
-use sp_core::{H160, H256};
+use sp_core::H256;
 use sp_keyring::AccountKeyring as Keyring;
 use sp_runtime::{
 	testing::Header,
@@ -101,10 +101,9 @@ fn run_to_block(n: u64) {
 #[test]
 fn test_submit() {
 	new_tester().execute_with(|| {
-		let target = H160::zero();
 		let source_id: &AccountId = &Keyring::Bob.into();
 
-		assert_ok!(BasicOutboundChannel::submit(source_id, target, &vec![0, 1, 2]));
+		assert_ok!(BasicOutboundChannel::submit(source_id, &vec![0, 1, 2]));
 
 		assert_eq!(<Nonce<Test>>::get(source_id), 1);
 		assert_eq!(<MessageQueue<Test>>::get().len(), 1);
@@ -114,15 +113,14 @@ fn test_submit() {
 #[test]
 fn test_submit_exceeds_queue_limit() {
 	new_tester().execute_with(|| {
-		let target = H160::zero();
 		let source_id: &AccountId = &Keyring::Bob.into();
 
 		let max_messages = MaxMessagesPerCommit::get();
 		(0..max_messages)
-			.for_each(|_| BasicOutboundChannel::submit(source_id, target, &vec![0, 1, 2]).unwrap());
+			.for_each(|_| BasicOutboundChannel::submit(source_id, &vec![0, 1, 2]).unwrap());
 
 		assert_noop!(
-			BasicOutboundChannel::submit(source_id, target, &vec![0, 1, 2]),
+			BasicOutboundChannel::submit(source_id, &vec![0, 1, 2]),
 			Error::<Test>::QueueSizeLimitReached,
 		);
 	})
@@ -131,7 +129,6 @@ fn test_submit_exceeds_queue_limit() {
 #[test]
 fn test_submit_exceeds_payload_limit() {
 	new_tester().execute_with(|| {
-		let target = H160::zero();
 		let source_id: &AccountId = &Keyring::Bob.into();
 
 		let max_payload_bytes = MaxMessagePayloadSize::get() - 1;
@@ -142,7 +139,7 @@ fn test_submit_exceeds_payload_limit() {
 		payload.push(10);
 
 		assert_noop!(
-			BasicOutboundChannel::submit(source_id, target, payload.as_slice()),
+			BasicOutboundChannel::submit(source_id, payload.as_slice()),
 			Error::<Test>::PayloadTooLarge,
 		);
 	})
@@ -151,10 +148,9 @@ fn test_submit_exceeds_payload_limit() {
 #[test]
 fn test_commit_single_user() {
 	new_tester().execute_with(|| {
-		let target = H160::zero();
 		let source_id: &AccountId = &Keyring::Bob.into();
 
-		assert_ok!(BasicOutboundChannel::submit(source_id, target, &vec![0, 1, 2]));
+		assert_ok!(BasicOutboundChannel::submit(source_id, &vec![0, 1, 2]));
 		run_to_block(2);
 		BasicOutboundChannel::commit(Weight::MAX);
 
@@ -166,12 +162,11 @@ fn test_commit_single_user() {
 #[test]
 fn test_commit_multi_user() {
 	new_tester().execute_with(|| {
-		let target = H160::zero();
 		let alice: &AccountId = &Keyring::Alice.into();
 		let bob: &AccountId = &Keyring::Bob.into();
 
-		assert_ok!(BasicOutboundChannel::submit(alice, target, &vec![0, 1, 2]));
-		assert_ok!(BasicOutboundChannel::submit(bob, target, &vec![0, 1, 2]));
+		assert_ok!(BasicOutboundChannel::submit(alice, &vec![0, 1, 2]));
+		assert_ok!(BasicOutboundChannel::submit(bob, &vec![0, 1, 2]));
 		run_to_block(2);
 		BasicOutboundChannel::commit(Weight::MAX);
 


### PR DESCRIPTION
Found a TODO after merging the [Basic channel v3 PR](https://github.com/Snowfork/snowbridge/pull/770).