### PR TITLE
Use rust version from parachain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
     flake-utils.lib.eachSystem supportedSystems (system:
         let
             pkgs = import nixpkgs { inherit system overlays; };
+            cwd = builtins.toString ./.;
+            rust =
+              pkgs.rust-bin.fromRustupToolchainFile "${cwd}/parachain/rust-toolchain.toml";
         in
         with pkgs;
         {
@@ -51,7 +54,7 @@
                     gcc
                     libiconv
                     protobuf
-                    rustup
+                    rust
 
                     cowsay
                 ];

--- a/parachain/rust-toolchain.toml
+++ b/parachain/rust-toolchain.toml
@@ -6,8 +6,7 @@
 #   - update `channel = "nightly-OLD_DATE"` below
 #   - update nightly-OLD_DATE in .github/workflows/parachain.yml
 
-# channel = "1.62.1" # matching polkadot v0.9.30
-channel = "nightly-2022-07-24" # 1.64.0 nightly for unstable features, matching polkadot v0.9.30
+channel = "nightly-2022-11-15" # 1.67.0 nightly for unstable features, matching polkadot v0.9.38
 targets = [
     "wasm32-unknown-unknown",
 ]


### PR DESCRIPTION
Thanks for catching this @vgeddes!

Two gotchas to keep in mind are that `rustup` isn't aware of the overlay:
```
$ rustup show
Default host: aarch64-apple-darwin
rustup home:  /Users/daviddunn/.rustup

installed toolchains
--------------------

stable-aarch64-apple-darwin (default)
nightly-2022-07-24-aarch64-apple-darwin
nightly-2023-02-09-aarch64-apple-darwin
nightly-aarch64-apple-darwin

active toolchain
----------------

stable-aarch64-apple-darwin (default)
rustc 1.67.1 (d5a82bbd2 2023-02-07)
```

But the toolchain file's version is actually used by the overlay:

```
$ rustc --version
rustc 1.64.0-nightly (93ffde6f0 2022-07-23)
$ command -v rustc
/nix/store/nq5w4kdq1kkjlkhr4bp5j498a31cz8ns-rust-default-1.64.0-nightly-2022-07-24/bin/rustc
```

Tools like editor extensions might be affected by this if they use `rustup` to check versions.
___
Also running `rustup show` in the `parachain/` directory will start installing the toolchain in `parachain/rust-toolchain.toml`, which could be annoying.