### PR TITLE
Make `snowbridge-ethereum-beacon-client` generic over the network it is built for

### DIFF
--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -67,4 +67,5 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "hex-literal"
 ]
+# Feature only used for testing and benchmarking
 minimal = []

--- a/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
@@ -15,6 +15,7 @@ mod data_mainnet;
 use data_mainnet::*;
 
 benchmarks! {
+	where_clause { where [(); T::SYNC_COMMITTEE_SIZE]: Sized }
 	sync_committee_period_update {
 		let caller: T::AccountId = whitelisted_caller();
 

--- a/parachain/pallets/ethereum-beacon-client/src/config.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/config.rs
@@ -1,14 +1,5 @@
-#[cfg(feature = "minimal")]
-mod minimal;
-
-#[cfg(not(feature = "minimal"))]
-mod mainnet;
-
-#[cfg(feature = "minimal")]
-pub use minimal::*;
-
-#[cfg(not(feature = "minimal"))]
-pub use mainnet::*;
+pub mod mainnet;
+pub mod minimal;
 
 pub const CURRENT_SYNC_COMMITTEE_INDEX: u64 = 22;
 pub const CURRENT_SYNC_COMMITTEE_DEPTH: u64 = 5;

--- a/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/merkleization.rs
@@ -127,15 +127,17 @@ pub fn hash_tree_root_sync_committee<S: Get<u32>>(
 	let mut pubkeys_vec = Vec::new();
 
 	for pubkey in sync_committee.pubkeys.iter() {
-		let conv_pubkey = Vector::<u8, 48>::from_iter(pubkey.0);
+		let conv_pubkey = Vector::<u8, { config::PUBKEY_SIZE }>::from_iter(pubkey.0);
 
 		pubkeys_vec.push(conv_pubkey);
 	}
 
 	let pubkeys =
-		Vector::<Vector<u8, 48>, { config::SYNC_COMMITTEE_SIZE }>::from_iter(pubkeys_vec.clone());
+		Vector::<Vector<u8, { config::PUBKEY_SIZE }>, { config::SYNC_COMMITTEE_SIZE }>::from_iter(
+			pubkeys_vec.clone(),
+		);
 
-	let agg = Vector::<u8, 48>::from_iter(sync_committee.aggregate_pubkey.0);
+	let agg = Vector::<u8, { config::PUBKEY_SIZE }>::from_iter(sync_committee.aggregate_pubkey.0);
 
 	hash_tree_root(SSZSyncCommittee { pubkeys, aggregate_pubkey: agg })
 }

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -13,7 +13,7 @@ use std::{fs::File, path::PathBuf};
 
 pub mod mock_minimal {
 	use super::*;
-
+	use crate::config::minimal;
 	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -69,7 +69,7 @@ pub mod mock_minimal {
 	}
 
 	parameter_types! {
-		pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
+		pub const MaxSyncCommitteeSize: u32 = minimal::SYNC_COMMITTEE_SIZE as u32;
 		pub const MaxProofBranchSize: u32 = 20;
 		pub const MaxExtraDataSize: u32 = config::MAX_EXTRA_DATA_BYTES as u32;
 		pub const MaxLogsBloomSize: u32 = config::MAX_LOGS_BLOOM_SIZE as u32;
@@ -110,11 +110,17 @@ pub mod mock_minimal {
 		type ForkVersions = ChainForkVersions;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
+
+		const SLOTS_PER_EPOCH: u64 = minimal::SLOTS_PER_EPOCH;
+		const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = minimal::EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+		const SYNC_COMMITTEE_SIZE: usize = minimal::SYNC_COMMITTEE_SIZE;
+		const BLOCK_ROOT_AT_INDEX_PROOF_DEPTH: u64 = minimal::BLOCK_ROOT_AT_INDEX_PROOF_DEPTH;
 	}
 }
 
 pub mod mock_mainnet {
 	use super::*;
+	use crate::config::mainnet;
 
 	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
@@ -171,7 +177,7 @@ pub mod mock_mainnet {
 	}
 
 	parameter_types! {
-		pub const MaxSyncCommitteeSize: u32 = config::SYNC_COMMITTEE_SIZE as u32;
+		pub const MaxSyncCommitteeSize: u32 = mainnet::SYNC_COMMITTEE_SIZE as u32;
 		pub const MaxProofBranchSize: u32 = 20;
 		pub const MaxExtraDataSize: u32 = config::MAX_EXTRA_DATA_BYTES as u32;
 		pub const MaxLogsBloomSize: u32 = config::MAX_LOGS_BLOOM_SIZE as u32;
@@ -212,6 +218,11 @@ pub mod mock_mainnet {
 		type ForkVersions = ChainForkVersions;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
+
+		const SLOTS_PER_EPOCH: u64 = mainnet::SLOTS_PER_EPOCH;
+		const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = mainnet::EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+		const SYNC_COMMITTEE_SIZE: usize = mainnet::SYNC_COMMITTEE_SIZE;
+		const BLOCK_ROOT_AT_INDEX_PROOF_DEPTH: u64 = mainnet::BLOCK_ROOT_AT_INDEX_PROOF_DEPTH;
 	}
 }
 
@@ -276,11 +287,13 @@ fn header_update_from_file<T: crate::Config>(
 	serde_json::from_reader(File::open(&filepath).unwrap()).unwrap()
 }
 
-fn get_config_setting() -> String {
-	return match config::IS_MINIMAL {
-		true => "minimal".to_owned(),
-		false => "mainnet".to_owned(),
-	}
+#[cfg(feature = "minimal")]
+fn get_config_setting() -> &'static str {
+	"minimal"
+}
+#[cfg(not(feature = "minimal"))]
+fn get_config_setting() -> &'static str {
+	"mainnet"
 }
 
 fn add_file_prefix(name: &str) -> String {

--- a/parachain/pallets/ethereum-beacon-client/src/ssz.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/ssz.rs
@@ -16,14 +16,14 @@ pub struct SSZBeaconBlockHeader {
 }
 
 #[derive(Default, SimpleSerialize)]
-pub struct SSZSyncCommittee {
-	pub pubkeys: Vector<Vector<u8, { config::PUBKEY_SIZE }>, { config::SYNC_COMMITTEE_SIZE }>,
+pub struct SSZSyncCommittee<const SYNC_COMMITTEE_SIZE: usize> {
+	pub pubkeys: Vector<Vector<u8, { config::PUBKEY_SIZE }>, SYNC_COMMITTEE_SIZE>,
 	pub aggregate_pubkey: Vector<u8, { config::PUBKEY_SIZE }>,
 }
 
 #[derive(Default, Debug, SimpleSerialize, Clone)]
-pub struct SSZSyncAggregate {
-	pub sync_committee_bits: Bitvector<{ config::SYNC_COMMITTEE_SIZE }>,
+pub struct SSZSyncAggregate<const SYNC_COMMITTEE_SIZE: usize> {
+	pub sync_committee_bits: Bitvector<SYNC_COMMITTEE_SIZE>,
 	pub sync_committee_signature: Vector<u8, { config::SIGNATURE_SIZE }>,
 }
 

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -1,7 +1,7 @@
 mod beacon_tests {
 	use crate as ethereum_beacon_client;
 	use crate::{
-		config, merkleization,
+		merkleization,
 		merkleization::MerkleizationError,
 		mock::*,
 		ssz::{SSZExecutionPayload, SSZSyncAggregate},
@@ -12,6 +12,13 @@ mod beacon_tests {
 	use snowbridge_beacon_primitives::{ExecutionPayload, SyncAggregate};
 	use sp_core::{H256, U256};
 	use ssz_rs::prelude::Vector;
+
+	pub(crate) mod config {
+		#[cfg(not(feature = "minimal"))]
+		pub(crate) use crate::config::mainnet::*;
+		#[cfg(feature = "minimal")]
+		pub(crate) use crate::config::minimal::*;
+	}
 
 	#[test]
 	pub fn test_get_sync_committee_sum() {
@@ -300,6 +307,7 @@ mod beacon_tests {
 
 		let sync_committee_bits = merkleization::get_sync_committee_bits::<
 			mock_minimal::MaxSyncCommitteeSize,
+			{ config::SYNC_COMMITTEE_SIZE },
 		>(bits.try_into().expect("too many sync committee bits"));
 
 		assert_ok!(&sync_committee_bits);
@@ -328,6 +336,7 @@ mod beacon_tests {
 
 		let sync_committee_bits = merkleization::get_sync_committee_bits::<
 			mock_minimal::MaxSyncCommitteeSize,
+			{ config::SYNC_COMMITTEE_SIZE },
 		>(bits.try_into().expect("invalid sync committee bits"));
 
 		assert_err!(
@@ -353,6 +362,7 @@ mod beacon_tests {
 
 		let sync_committee_bits = merkleization::get_sync_committee_bits::<
 			mock_minimal::MaxSyncCommitteeSize,
+			{ config::SYNC_COMMITTEE_SIZE },
 		>(bits.try_into().expect("invalid sync committee bits"));
 
 		assert_err!(
@@ -499,7 +509,8 @@ mod beacon_tests {
 				hex!("e6dcad4f60ce9ff8a587b110facbaf94721f06cd810b6d8bf6cffa641272808d").into(),
 		};
 
-		let payload: Result<SSZSyncAggregate, MerkleizationError> = sync_aggregate.try_into();
+		let payload: Result<SSZSyncAggregate<{ config::SYNC_COMMITTEE_SIZE }>, MerkleizationError> =
+			sync_aggregate.try_into();
 		assert_ok!(&payload);
 
 		let hash_root_result = merkleization::hash_tree_root(payload.unwrap());

--- a/parachain/pallets/ethereum-beacon-client/src/tests_mainnet.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests_mainnet.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "minimal"))]
 mod beacon_mainnet_tests {
 	use crate::{
-		config, merkleization, mock::*, Error, ExecutionHeaders, FinalizedBeaconHeaders,
+		config::mainnet, merkleization, mock::*, Error, ExecutionHeaders, FinalizedBeaconHeaders,
 		FinalizedBeaconHeadersBlockRoot, FinalizedHeaderState, LatestFinalizedHeaderState,
 		LatestSyncCommitteePeriod, SyncCommittees, ValidatorsRoot,
 	};
@@ -66,7 +66,7 @@ mod beacon_mainnet_tests {
 		);
 
 		let slot = update.finalized_header.slot;
-		let import_time = 1616508000u64 + (slot * config::SECONDS_PER_SLOT); // Goerli genesis time + finalized header update time
+		let import_time = 1616508000u64 + (slot * mainnet::SECONDS_PER_SLOT); // Goerli genesis time + finalized header update time
 		let mock_pallet_time = import_time + 3600; // plus one hour
 
 		new_tester::<mock_mainnet::Test>().execute_with(|| {
@@ -104,7 +104,7 @@ mod beacon_mainnet_tests {
 		);
 
 		let slot = update.finalized_header.slot;
-		let import_time = 1616508000u64 + (slot * config::SECONDS_PER_SLOT);
+		let import_time = 1616508000u64 + (slot * mainnet::SECONDS_PER_SLOT);
 		let mock_pallet_time = import_time + 100800; // plus 28 hours
 
 		new_tester::<mock_mainnet::Test>().execute_with(|| {
@@ -172,7 +172,10 @@ mod beacon_mainnet_tests {
 	#[test]
 	pub fn test_hash_tree_root_sync_committee() {
 		let sync_committee = get_committee_sync_ssz_test_data::<mock_mainnet::Test>();
-		let hash_root_result = merkleization::hash_tree_root_sync_committee(sync_committee);
+		let hash_root_result = merkleization::hash_tree_root_sync_committee::<
+			_,
+			{ mainnet::SYNC_COMMITTEE_SIZE },
+		>(sync_committee);
 		assert_ok!(&hash_root_result);
 
 		let hash_root: H256 = hash_root_result.unwrap().into();
@@ -187,9 +190,10 @@ mod beacon_mainnet_tests {
 		let test_data = get_bls_signature_verify_test_data::<mock_mainnet::Test>();
 
 		let sync_committee_bits =
-			merkleization::get_sync_committee_bits::<mock_mainnet::MaxSyncCommitteeSize>(
-				test_data.sync_committee_bits.try_into().expect("too many sync committee bits"),
-			);
+			merkleization::get_sync_committee_bits::<
+				mock_mainnet::MaxSyncCommitteeSize,
+				{ mainnet::SYNC_COMMITTEE_SIZE },
+			>(test_data.sync_committee_bits.try_into().expect("too many sync committee bits"));
 
 		assert_ok!(&sync_committee_bits);
 

--- a/parachain/pallets/ethereum-beacon-client/src/tests_minimal.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests_minimal.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "minimal")]
 mod beacon_minimal_tests {
 	use crate::{
-		config, merkleization, mock::*, pallet::FinalizedBeaconHeadersBlockRoot, Error,
+		config::minimal, merkleization, mock::*, pallet::FinalizedBeaconHeadersBlockRoot, Error,
 		ExecutionHeaderState, ExecutionHeaders, FinalizedBeaconHeaders, FinalizedHeaderState,
 		LatestExecutionHeaderState, LatestFinalizedHeaderState, LatestSyncCommitteePeriod,
 		SyncCommittees, ValidatorsRoot,
@@ -163,7 +163,7 @@ mod beacon_minimal_tests {
 			.expect("Time went backwards")
 			.as_secs();
 
-		let import_time = time_now + (update.finalized_header.slot * config::SECONDS_PER_SLOT); // Goerli genesis time + finalized header update time
+		let import_time = time_now + (update.finalized_header.slot * minimal::SECONDS_PER_SLOT); // Goerli genesis time + finalized header update time
 		let mock_pallet_time = import_time + 3600; // plus one hour
 
 		new_tester::<mock_minimal::Test>().execute_with(|| {
@@ -364,7 +364,10 @@ mod beacon_minimal_tests {
 	#[test]
 	pub fn test_hash_tree_root_sync_committee() {
 		let sync_committee = get_committee_sync_ssz_test_data::<mock_mainnet::Test>();
-		let hash_root_result = merkleization::hash_tree_root_sync_committee(sync_committee);
+		let hash_root_result = merkleization::hash_tree_root_sync_committee::<
+			_,
+			{ minimal::SYNC_COMMITTEE_SIZE },
+		>(sync_committee);
 		assert_ok!(&hash_root_result);
 
 		let hash_root: H256 = hash_root_result.unwrap().into();
@@ -379,9 +382,10 @@ mod beacon_minimal_tests {
 		let test_data = get_bls_signature_verify_test_data::<mock_minimal::Test>();
 
 		let sync_committee_bits =
-			merkleization::get_sync_committee_bits::<mock_minimal::MaxSyncCommitteeSize>(
-				test_data.sync_committee_bits.try_into().expect("too many sync committee bits"),
-			);
+			merkleization::get_sync_committee_bits::<
+				mock_minimal::MaxSyncCommitteeSize,
+				{ minimal::SYNC_COMMITTEE_SIZE },
+			>(test_data.sync_committee_bits.try_into().expect("too many sync committee bits"));
 
 		assert_ok!(&sync_committee_bits);
 

--- a/parachain/runtime/snowbase/Cargo.toml
+++ b/parachain/runtime/snowbase/Cargo.toml
@@ -72,7 +72,7 @@ runtime-primitives = { path = "../../primitives/runtime", default-features = fal
 
 snowbridge-basic-channel = { path = "../../pallets/basic-channel", default-features = false }
 dispatch = { path = "../../pallets/dispatch", package = "snowbridge-dispatch", default-features = false }
-ethereum-beacon-client = { path = "../../pallets/ethereum-beacon-client", package = "snowbridge-ethereum-beacon-client", default-features = false, features=["minimal"]}
+ethereum-beacon-client = { path = "../../pallets/ethereum-beacon-client", package = "snowbridge-ethereum-beacon-client", default-features = false }
 runtime-common = { path = "../common", package = "snowbridge-runtime-common", default-features = false }
 snowbridge-beacon-primitives = { path = "../../primitives/beacon", default-features = false }
 

--- a/parachain/runtime/snowbase/src/lib.rs
+++ b/parachain/runtime/snowbase/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -10,6 +12,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 mod weights;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use ethereum_beacon_client::config::minimal;
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU32, OpaqueMetadata};
@@ -599,14 +602,14 @@ impl basic_channel_outbound::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxSyncCommitteeSize: u32 = 32;
+	pub const MaxSyncCommitteeSize: u32 = minimal::SYNC_COMMITTEE_SIZE as u32;
 	pub const MaxProofBranchSize: u32 = 20;
 	pub const MaxExtraDataSize: u32 = 32;
 	pub const MaxLogsBloomSize: u32 = 256;
 	pub const MaxFeeRecipientSize: u32 = 20;
 	pub const MaxPublicKeySize: u32 = 48;
 	pub const MaxSignatureSize: u32 = 96;
-	pub const MaxSlotsPerHistoricalRoot: u64 = 64;
+	pub const MaxSlotsPerHistoricalRoot: u64 = minimal::SLOTS_PER_HISTORICAL_ROOT as u64;
 	pub const MaxFinalizedHeaderSlotArray: u32 = 1000;
 	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
@@ -640,6 +643,11 @@ impl ethereum_beacon_client::Config for Runtime {
 	type ForkVersions = ChainForkVersions;
 	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = weights::ethereum_beacon_client::SnowbridgeWeight<Self>;
+
+	const SLOTS_PER_EPOCH: u64 = minimal::SLOTS_PER_EPOCH;
+	const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = minimal::EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+	const SYNC_COMMITTEE_SIZE: usize = minimal::SYNC_COMMITTEE_SIZE;
+	const BLOCK_ROOT_AT_INDEX_PROOF_DEPTH: u64 = minimal::BLOCK_ROOT_AT_INDEX_PROOF_DEPTH;
 }
 
 parameter_types! {

--- a/parachain/runtime/snowblink/src/lib.rs
+++ b/parachain/runtime/snowblink/src/lib.rs
@@ -2,12 +2,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use ethereum_beacon_client::config::mainnet;
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU32, OpaqueMetadata};
@@ -597,14 +600,14 @@ impl basic_channel_outbound::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxSyncCommitteeSize: u32 = 512;
+	pub const MaxSyncCommitteeSize: u32 = mainnet::SYNC_COMMITTEE_SIZE as u32;
 	pub const MaxProofBranchSize: u32 = 20;
 	pub const MaxExtraDataSize: u32 = 32;
 	pub const MaxLogsBloomSize: u32 = 256;
 	pub const MaxFeeRecipientSize: u32 = 20;
 	pub const MaxPublicKeySize: u32 = 48;
 	pub const MaxSignatureSize: u32 = 96;
-	pub const MaxSlotsPerHistoricalRoot: u64 = 8192;
+	pub const MaxSlotsPerHistoricalRoot: u64 = mainnet::SLOTS_PER_HISTORICAL_ROOT as u64;
 	pub const MaxFinalizedHeaderSlotArray: u32 = 1000;
 	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
@@ -638,6 +641,11 @@ impl ethereum_beacon_client::Config for Runtime {
 	type ForkVersions = ChainForkVersions;
 	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
+
+	const SLOTS_PER_EPOCH: u64 = mainnet::SLOTS_PER_EPOCH;
+	const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = mainnet::EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+	const SYNC_COMMITTEE_SIZE: usize = mainnet::SYNC_COMMITTEE_SIZE;
+	const BLOCK_ROOT_AT_INDEX_PROOF_DEPTH: u64 = mainnet::BLOCK_ROOT_AT_INDEX_PROOF_DEPTH;
 }
 
 parameter_types! {

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -65,6 +67,7 @@ use xcm_builder::{
 	UsingComponents,
 };
 
+use ethereum_beacon_client::config::mainnet;
 use xcm_executor::{traits::JustTry, Config, XcmExecutor};
 
 use runtime_common::{fee::WeightToFee, MaxMessagePayloadSize, MaxMessagesPerCommit};
@@ -597,14 +600,14 @@ impl basic_channel_outbound::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxSyncCommitteeSize: u32 = 512;
+	pub const MaxSyncCommitteeSize: u32 = mainnet::SYNC_COMMITTEE_SIZE as u32;
 	pub const MaxProofBranchSize: u32 = 20;
 	pub const MaxExtraDataSize: u32 = 32;
 	pub const MaxLogsBloomSize: u32 = 256;
 	pub const MaxFeeRecipientSize: u32 = 20;
 	pub const MaxPublicKeySize: u32 = 48;
 	pub const MaxSignatureSize: u32 = 96;
-	pub const MaxSlotsPerHistoricalRoot: u64 = 8192;
+	pub const MaxSlotsPerHistoricalRoot: u64 = mainnet::SLOTS_PER_HISTORICAL_ROOT as u64;
 	pub const MaxFinalizedHeaderSlotArray: u32 = 1000;
 	pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 	pub const ChainForkVersions: ForkVersions = ForkVersions{
@@ -638,6 +641,11 @@ impl ethereum_beacon_client::Config for Runtime {
 	type ForkVersions = ChainForkVersions;
 	type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 	type WeightInfo = ethereum_beacon_client::weights::SnowbridgeWeight<Self>;
+
+	const SLOTS_PER_EPOCH: u64 = mainnet::SLOTS_PER_EPOCH;
+	const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = mainnet::EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+	const SYNC_COMMITTEE_SIZE: usize = mainnet::SYNC_COMMITTEE_SIZE;
+	const BLOCK_ROOT_AT_INDEX_PROOF_DEPTH: u64 = mainnet::BLOCK_ROOT_AT_INDEX_PROOF_DEPTH;
 }
 
 parameter_types! {


### PR DESCRIPTION
We wanted to use this at Subspace, but turned out there was a mix of constants and generic configuration parameters that were:
1) Somewhat confusing
2) Didn't allow to build both "minimal" and "mainnet" version of the crate in the same workspace

I resolved this by making a few data structures generic and adding constants to `Config` trait. If pallet is made instantiable (I didn't implement it in this PR as it might be more controversial) then it would be possible to have this pallet included multiple times in the same runtime with different configurations, which wasn't possible before.

It required using unstable feature, but since Substrate uses them too and nightly is already required, this seemed like a decent compromise.

Note: `minimal` feature is still there, but it is now only used for benchmaking and testing and has no effect otherwise.