### PR TITLE
Add support for contract upgrades

### DIFF
--- a/core/packages/contracts/src/IUpgradeTask.sol
+++ b/core/packages/contracts/src/IUpgradeTask.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+interface IUpgradeTask {
+    function run() external;
+}

--- a/core/packages/contracts/src/NativeTokens.sol
+++ b/core/packages/contracts/src/NativeTokens.sol
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.19;
 
-import {Ownable} from "openzeppelin/access/Ownable.sol";
-import {AccessControl} from "openzeppelin/access/AccessControl.sol";
-import {IERC20Metadata} from "openzeppelin/token/ERC20/extensions/IERC20Metadata.sol";
+import { Ownable } from "openzeppelin/access/Ownable.sol";
+import { AccessControl } from "openzeppelin/access/AccessControl.sol";
+import { IERC20Metadata } from "openzeppelin/token/ERC20/extensions/IERC20Metadata.sol";
 
-import {TokenVault} from "./TokenVault.sol";
-import {SubstrateTypes} from "./SubstrateTypes.sol";
-import {NativeTokensTypes} from "./NativeTokensTypes.sol";
-import {IOutboundQueue} from "./OutboundQueue.sol";
-import {ParaID} from "./Types.sol";
+import { TokenVault } from "./TokenVault.sol";
+import { SubstrateTypes } from "./SubstrateTypes.sol";
+import { NativeTokensTypes } from "./NativeTokensTypes.sol";
+import { IOutboundQueue } from "./OutboundQueue.sol";
+import { ParaID } from "./Types.sol";
 
 /// @title Native Tokens
 /// @dev Manages locking, unlocking ERC20 tokens in the vault. Initializes ethereum native
 /// tokens on the substrate side via create.
 contract NativeTokens is AccessControl {
     /// @dev Describes the type of message.
-    enum Action {Unlock}
+    enum Action {
+        Unlock
+    }
 
     /// @dev Message format.
     struct Message {
@@ -67,7 +69,12 @@ contract NativeTokens is AccessControl {
     error Unauthorized();
     error NoFundsforCreateToken();
 
-    constructor(TokenVault _vault, IOutboundQueue _outboundQueue, ParaID _assetHubParaID, uint256 _createTokenFee) {
+    constructor(
+        TokenVault _vault,
+        IOutboundQueue _outboundQueue,
+        ParaID _assetHubParaID,
+        uint256 _createTokenFee
+    ) {
         _grantRole(ADMIN_ROLE, msg.sender);
         _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(SENDER_ROLE, ADMIN_ROLE);
@@ -82,7 +89,12 @@ contract NativeTokens is AccessControl {
     /// @param token The token to lock.
     /// @param recipient The recipient on the substrate side.
     /// @param amount The amount to lock.
-    function lock(address token, ParaID dest, bytes calldata recipient, uint128 amount) external payable {
+    function lock(
+        address token,
+        ParaID dest,
+        bytes calldata recipient,
+        uint128 amount
+    ) external payable {
         if (amount == 0) {
             revert InvalidAmount();
         }
@@ -90,7 +102,7 @@ contract NativeTokens is AccessControl {
         vault.deposit(msg.sender, token, amount);
 
         bytes memory payload = NativeTokensTypes.Mint(token, dest, recipient, amount);
-        outboundQueue.submit{value: msg.value}(assetHubParaID, payload);
+        outboundQueue.submit{ value: msg.value }(assetHubParaID, payload);
 
         emit Locked(recipient, token, amount);
     }
@@ -115,7 +127,7 @@ contract NativeTokens is AccessControl {
         uint8 decimals = metadata.decimals();
 
         bytes memory payload = NativeTokensTypes.Create(token, name, symbol, decimals);
-        outboundQueue.submit{value: msg.value}(assetHubParaID, payload);
+        outboundQueue.submit{ value: msg.value }(assetHubParaID, payload);
 
         emit Created(token);
     }

--- a/core/packages/contracts/src/OutboundQueue.sol
+++ b/core/packages/contracts/src/OutboundQueue.sol
@@ -21,6 +21,7 @@ contract OutboundQueue is IOutboundQueue, AccessControl {
 
     constructor(IVault _vault, uint256 _fee) {
         _grantRole(ADMIN_ROLE, msg.sender);
+        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(SUBMIT_ROLE, ADMIN_ROLE);
         vault = _vault;
         fee = _fee;

--- a/core/packages/contracts/src/TokenVault.sol
+++ b/core/packages/contracts/src/TokenVault.sol
@@ -28,6 +28,7 @@ contract TokenVault is AccessControl {
 
     constructor() {
         _grantRole(ADMIN_ROLE, msg.sender);
+        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(WITHDRAW_ROLE, ADMIN_ROLE);
         _setRoleAdmin(DEPOSIT_ROLE, ADMIN_ROLE);
     }

--- a/core/packages/contracts/src/UpgradeProxy.sol
+++ b/core/packages/contracts/src/UpgradeProxy.sol
@@ -15,13 +15,12 @@ contract UpgradeProxy is AccessControl {
         bytes payload;
     }
 
-    enum Action
-    // Withdraw from sovereign account and transfer to recipient.
-    // Parachain teams will occasionally send this message to retrieve collected fees.
-    {Upgrade}
+    enum Action {
+        Upgrade
+    }
 
     struct UpgradePayload {
-        address upgrader;
+        address task;
     }
 
     error InvalidMessage();
@@ -49,7 +48,7 @@ contract UpgradeProxy is AccessControl {
 
         UpgradePayload memory payload = abi.decode(decoded.payload, (UpgradePayload));
 
-        (bool success,) = payload.upgrader.delegatecall(abi.encodeCall(IUpgradeTask.run, ()));
+        (bool success,) = payload.task.delegatecall(abi.encodeCall(IUpgradeTask.run, ()));
         if (!success) {
             revert UpgradeFailed();
         }

--- a/core/packages/contracts/src/UpgradeProxy.sol
+++ b/core/packages/contracts/src/UpgradeProxy.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.19;
 
 import {AccessControl} from "openzeppelin/access/AccessControl.sol";
 import {IVault} from "./IVault.sol";
+import {IUpgradeTask} from "./IUpgradeTask.sol";
 import {ParaID} from "./Types.sol";
 
-contract SovereignTreasury is AccessControl {
+contract UpgradeProxy is AccessControl {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant SENDER_ROLE = keccak256("SENDER_ROLE");
-
-    IVault public vault;
 
     struct Message {
         Action action;
@@ -19,26 +18,40 @@ contract SovereignTreasury is AccessControl {
     enum Action
     // Withdraw from sovereign account and transfer to recipient.
     // Parachain teams will occasionally send this message to retrieve collected fees.
-    {Withdraw}
+    {Upgrade}
 
-    struct WithdrawPayload {
-        address payable recipient;
-        uint256 amount;
+    struct UpgradePayload {
+        address upgrader;
     }
 
-    constructor(IVault _vault) {
+    error InvalidMessage();
+    error Unauthorized();
+    error UpgradeFailed();
+
+    // Parachain ID of BridgeHub
+    ParaID public immutable bridgeHubParaID;
+
+    constructor(ParaID _bridgeHubParaID) {
         _grantRole(ADMIN_ROLE, msg.sender);
-        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(SENDER_ROLE, ADMIN_ROLE);
-        vault = _vault;
+        bridgeHubParaID = _bridgeHubParaID;
     }
 
-    // Handle a message from the bridge.
     function handle(ParaID origin, bytes calldata message) external onlyRole(SENDER_ROLE) {
+        if (origin != bridgeHubParaID) {
+            revert Unauthorized();
+        }
+
         Message memory decoded = abi.decode(message, (Message));
-        if (decoded.action == Action.Withdraw) {
-            WithdrawPayload memory payload = abi.decode(decoded.payload, (WithdrawPayload));
-            vault.withdraw(origin, payload.recipient, payload.amount);
+        if (decoded.action != Action.Upgrade) {
+            revert InvalidMessage();
+        }
+
+        UpgradePayload memory payload = abi.decode(decoded.payload, (UpgradePayload));
+
+        (bool success,) = payload.upgrader.delegatecall(abi.encodeCall(IUpgradeTask.run, ()));
+        if (!success) {
+            revert UpgradeFailed();
         }
     }
 }

--- a/core/packages/contracts/src/Vault.sol
+++ b/core/packages/contracts/src/Vault.sol
@@ -21,6 +21,7 @@ contract Vault is IVault, AccessControl {
 
     constructor() {
         _grantRole(ADMIN_ROLE, msg.sender);
+        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
         _setRoleAdmin(WITHDRAW_ROLE, ADMIN_ROLE);
     }
 

--- a/core/packages/contracts/test/UpgradeProxy.t.sol
+++ b/core/packages/contracts/test/UpgradeProxy.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {AccessControl} from "openzeppelin/access/AccessControl.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+import {UpgradeProxy} from "../src/UpgradeProxy.sol";
+import {IUpgradeTask} from "../src/IUpgradeTask.sol";
+
+import {IVault, Vault} from "../src/Vault.sol";
+import {OutboundQueue} from "../src/OutboundQueue.sol";
+
+import {ParaID} from "../src/Types.sol";
+
+contract UpgradeTask is IUpgradeTask, AccessControl {
+    OutboundQueue public immutable outboundQueue;
+
+    constructor(OutboundQueue _outboundQueue) {
+        outboundQueue = _outboundQueue;
+    }
+
+    // In this simple upgrade we just update a fee parameter
+    function run() external {
+        outboundQueue.updateFee(2 ether);
+    }
+}
+
+contract FailingUpgradeTask is IUpgradeTask, AccessControl {
+    function run() pure external {
+        revert("failed");
+    }
+}
+
+contract UpgradeProxyTest is Test {
+    UpgradeProxy public upgradeProxy;
+    IUpgradeTask public upgrader;
+    IUpgradeTask public failingUpgrader;
+
+    OutboundQueue public outboundQueue;
+
+    ParaID origin = ParaID.wrap(1001);
+
+    function setUp() public {
+        upgradeProxy = new UpgradeProxy(origin);
+        outboundQueue = new OutboundQueue(new Vault(), 1 ether);
+
+        outboundQueue.grantRole(outboundQueue.ADMIN_ROLE(), address(upgradeProxy));
+        outboundQueue.revokeRole(outboundQueue.ADMIN_ROLE(), address(this));
+
+        upgradeProxy.grantRole(upgradeProxy.SENDER_ROLE(), address(this));
+
+        // create upgrader instances
+        upgrader = new UpgradeTask(outboundQueue);
+        failingUpgrader = new FailingUpgradeTask();
+    }
+
+    function testUpgrade() public {
+        // execute upgrader
+        bytes memory message = abi.encode(
+            UpgradeProxy.Message(
+                UpgradeProxy.Action.Upgrade,
+                abi.encode(UpgradeProxy.UpgradePayload(address(upgrader)))));
+        upgradeProxy.handle(origin, message);
+
+        assertEq(outboundQueue.fee(), 2 ether);
+    }
+
+    function testUpgradeFailBadOrigin() public {
+        vm.expectRevert(UpgradeProxy.Unauthorized.selector);
+        upgradeProxy.handle(ParaID.wrap(3), hex"deadbeef");
+    }
+
+    function testUpgradeUpgraderFail() public {
+        bytes memory message = abi.encode(
+            UpgradeProxy.Message(
+                UpgradeProxy.Action.Upgrade,
+                abi.encode(UpgradeProxy.UpgradePayload(address(failingUpgrader)))));
+        vm.expectRevert(UpgradeProxy.UpgradeFailed.selector);
+        upgradeProxy.handle(origin, message);
+    }
+}


### PR DESCRIPTION
Design:

There is a new message handler called `UpgradeProxy`. It can receive upgrade instructions from Polkadot governance, and execute them with elevated privileges.

Steps:
1. Polkadot governance manually deploys a contract that implements `IUpgradeTask`, and which contains the necessary upgrade logic.
2. When `UpgradeProxy` receives a message from governance, it will execute the upgrade logic in the task using `delegatecall`.

I've updated the forge deployment script so that `UpgradeProxy` has admin privileges for all upgradable contracts.