### PR TITLE
Bound finalized header, execution header and sync committee by pruning older data beyond threshold

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3561,6 +3561,7 @@ dependencies = [
  "milagro_bls",
  "pallet-timestamp",
  "parity-scale-codec",
+ "rand 0.8.5",
  "rlp",
  "scale-info",
  "serde",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -34,6 +34,7 @@ snowbridge-ethereum = { path = "../../primitives/ethereum", default-features = f
 snowbridge-beacon-primitives = { path = "../../primitives/beacon", default-features = false }
 
 [dev-dependencies]
+rand = "0.8.5"
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 snowbridge-testutils = { path = "../../primitives/testutils" }
 serde_json = "1.0.96"

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -181,12 +181,12 @@ pub mod pallet {
 	/// latest value.
 	#[pallet::storage]
 	pub(super) type ExecutionHeadersOldestMapping<T: Config> =
-	StorageValue<_, (u64, u64), OptionQuery>;
+		StorageValue<_, (u64, u64), OptionQuery>;
 
 	/// Mapping of count -> Execution header hash. Used to prune older headers
 	#[pallet::storage]
 	pub(super) type ExecutionHeadersMapping<T: Config> =
-	StorageMap<_, Identity, u64, H256, ValueQuery>;
+		StorageMap<_, Identity, u64, H256, ValueQuery>;
 
 	#[pallet::storage]
 	pub(super) type ExecutionHeaders<T: Config> =
@@ -905,13 +905,15 @@ pub mod pallet {
 				let highest_period_to_remove = latest_sync_committee_period - threshold;
 
 				let mut current_sync_committee_to_remove = highest_period_to_remove;
-				let mut number_of_sync_committees_to_remove = stored_sync_committees as u64 - threshold;
+				let mut number_of_sync_committees_to_remove =
+					stored_sync_committees as u64 - threshold;
 
-				while number_of_sync_committees_to_remove > 0
-				{
+				while number_of_sync_committees_to_remove > 0 {
 					<SyncCommittees<T>>::remove(current_sync_committee_to_remove);
-                    number_of_sync_committees_to_remove = number_of_sync_committees_to_remove.saturating_sub(1);
-					current_sync_committee_to_remove = current_sync_committee_to_remove.saturating_sub(1);
+					number_of_sync_committees_to_remove =
+						number_of_sync_committees_to_remove.saturating_sub(1);
+					current_sync_committee_to_remove =
+						current_sync_committee_to_remove.saturating_sub(1);
 				}
 			}
 		}
@@ -940,10 +942,13 @@ pub mod pallet {
 			Ok(())
 		}
 
-		pub(super) fn add_finalized_header_slot(slot: u64, finalized_header_hash: H256) -> DispatchResult {
+		pub(super) fn add_finalized_header_slot(
+			slot: u64,
+			finalized_header_hash: H256,
+		) -> DispatchResult {
 			<FinalizedBeaconHeaderSlots<T>>::try_mutate(|b_vec| {
 				if b_vec.len() as u32 == T::MaxFinalizedHeaderSlotArray::get() {
-					let (_slot, finalized_header_hash) =  b_vec.remove(0);
+					let (_slot, finalized_header_hash) = b_vec.remove(0);
 					// Removing corresponding finalized header data of popped slot
 					// as that data will not be used by relayer anyway.
 					<FinalizedBeaconHeadersBlockRoot<T>>::remove(finalized_header_hash);
@@ -966,10 +971,7 @@ pub mod pallet {
 			let block_number = header.block_number;
 
 			let (_, latest_mapping_to_insert) = Self::get_mapping_bound();
-			<ExecutionHeadersMapping<T>>::insert(
-				latest_mapping_to_insert,
-				block_hash,
-			);
+			<ExecutionHeadersMapping<T>>::insert(latest_mapping_to_insert, block_hash);
 			Self::update_mapping_bound(None, Some(latest_mapping_to_insert + 1));
 			<ExecutionHeaders<T>>::insert(block_hash, header);
 			Self::prune_older_execution_headers();
@@ -996,7 +998,8 @@ pub mod pallet {
 		}
 
 		fn update_mapping_bound(oldest: Option<u64>, latest: Option<u64>) {
-			let (previous_oldest, previous_latest) = <ExecutionHeadersOldestMapping<T>>::get().unwrap_or((1, 1));
+			let (previous_oldest, previous_latest) =
+				<ExecutionHeadersOldestMapping<T>>::get().unwrap_or((1, 1));
 			let new_oldest = oldest.unwrap_or(previous_oldest);
 			let new_latest = latest.unwrap_or(previous_latest);
 			<ExecutionHeadersOldestMapping<T>>::put((new_oldest, new_latest));
@@ -1008,7 +1011,8 @@ pub mod pallet {
 
 			if stored_execution_headers > threshold {
 				let (mut oldest_mapping_to_delete, _) = Self::get_mapping_bound();
-				let execution_headers_to_delete = stored_execution_headers.saturating_sub(threshold);
+				let execution_headers_to_delete =
+					stored_execution_headers.saturating_sub(threshold);
 				for _i in 0..execution_headers_to_delete {
 					let execution_header_hash =
 						<ExecutionHeadersMapping<T>>::get(oldest_mapping_to_delete);

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -77,7 +77,9 @@ pub mod mock_minimal {
 		pub const MaxPublicKeySize: u32 = config::PUBKEY_SIZE as u32;
 		pub const MaxSignatureSize: u32 = config::SIGNATURE_SIZE as u32;
 		pub const MaxSlotsPerHistoricalRoot: u64 = 64;
-		pub const MaxFinalizedHeaderSlotArray: u32 = 1000;
+		pub const MaxFinalizedHeaderSlotArray: u32 = 12;
+		pub const SyncCommitteePruneThreshold: u64 = 4;
+		pub const ExecutionHeadersPruneThreshold: u64 = 10;
 		pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
@@ -112,6 +114,8 @@ pub mod mock_minimal {
 		type MaxSlotsPerHistoricalRoot = MaxSlotsPerHistoricalRoot;
 		type MaxFinalizedHeaderSlotArray = MaxFinalizedHeaderSlotArray;
 		type ForkVersions = ChainForkVersions;
+		type SyncCommitteePruneThreshold = SyncCommitteePruneThreshold;
+		type ExecutionHeadersPruneThreshold = ExecutionHeadersPruneThreshold;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}
@@ -203,6 +207,8 @@ pub mod mock_mainnet {
 				epoch: 162304,
 			},
 		};
+		pub const SyncCommitteePruneThreshold: u64 = 4;
+		pub const ExecutionHeadersPruneThreshold: u64 = 10;
 	}
 
 	impl ethereum_beacon_client::Config for Test {
@@ -218,6 +224,8 @@ pub mod mock_mainnet {
 		type MaxSlotsPerHistoricalRoot = MaxSlotsPerHistoricalRoot;
 		type MaxFinalizedHeaderSlotArray = MaxFinalizedHeaderSlotArray;
 		type ForkVersions = ChainForkVersions;
+		type SyncCommitteePruneThreshold = SyncCommitteePruneThreshold;
+		type ExecutionHeadersPruneThreshold = ExecutionHeadersPruneThreshold;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -5,14 +5,14 @@ mod beacon_tests {
 		merkleization::MerkleizationError,
 		mock::*,
 		ssz::{SSZExecutionPayloadHeader, SSZSyncAggregate},
-		BeaconHeader, Error, PublicKey, ExecutionHeader, SyncCommittee
+		BeaconHeader, Error, ExecutionHeader, PublicKey, SyncCommittee,
 	};
 	use frame_support::{assert_err, assert_ok};
 	use hex_literal::hex;
+	use rand::{thread_rng, Rng};
 	use snowbridge_beacon_primitives::{ExecutionPayloadHeader, SyncAggregate};
 	use sp_core::{H256, U256};
 	use ssz_rs::prelude::Vector;
-	use rand::{thread_rng, Rng};
 
 	#[test]
 	pub fn test_get_sync_committee_sum() {

--- a/relayer/chain/parachain/writer.go
+++ b/relayer/chain/parachain/writer.go
@@ -231,7 +231,7 @@ func (wr *ParachainWriter) GetFinalizedSlots() ([]uint64, error) {
 		return nil, fmt.Errorf("create storage key for basic channel nonces: %w", err)
 	}
 
-	var slots []types.U64
+	var slots []state.FinalizedHeaderSlots
 	_, err = wr.conn.API().RPC.State.GetStorageLatest(key, &slots)
 	if err != nil {
 		return nil, fmt.Errorf("get storage for latest basic channel nonces (err): %w", err)
@@ -239,7 +239,7 @@ func (wr *ParachainWriter) GetFinalizedSlots() ([]uint64, error) {
 
 	result := []uint64{}
 	for _, slot := range slots {
-		result = append(result, uint64(slot))
+		result = append(result, slot.Slot)
 	}
 
 	return result, nil

--- a/relayer/relays/beacon/state/state.go
+++ b/relayer/relays/beacon/state/state.go
@@ -16,3 +16,8 @@ type FinalizedHeader struct {
 	BeaconSlot      uint64
 	ImportTime      uint64
 }
+
+type FinalizedHeaderSlots struct {
+	Slot uint64
+	FinalizedHeaderHash common.Hash
+}


### PR DESCRIPTION
### Description
This PR enables pruning older `FinalizedHeader`, `ExecutionHeader` and `SyncCommittee`. This is required to put bounds on the storage of the pallet. As left unchecked it could be huge amount of data.

First three PR adds support for pruning of `FinalizedHeader`, `ExecutionHeader` and `SyncCommittee` respectively. Fourth commit adds comprehensive tests for the same. Fifth commit is just cargo fmt changes. And last commit introduces relayer changes.

### How it works?

#### ExecutionHeader
For `ExecutionHeader` there is a queue like simulated data maintained that allows pruning of older data as the new data gets added. 

Since execution headers are not contiguous, to maintain the queue, we need to maintain a mapping of `u64 -> ExecutionHeader` and also keep track of front and back of the queue. While we push new data to back, we remove data from front this is supported by `(oldest_bound, latest_bound)` storage.

#### FinalizedHeader
For `FinalizedHeader` we are pruning it as per `MaxFinalizedHeaderSlotArray`. As, `FinalizedHeader` and its associated data with slot less than `0`th element of the vector will not be used by relayer in anycase.

#### SyncCommittee
Since `SyncCommittee` is stored in an order, we can rely on it to prune oldest sync committee. 


### Configuration changes
Both `ExecutionHeader` and `SyncCommittee`'s pruning threshold is defined in pallet configuration. 

### Relayer changes
Due to change in `FinalizedSlotArray` storage, there is a change in relayer to maintain compatibility. 

