### PR TITLE
Bound finalized header, execution header and sync committee by RingBuffer and BoundedVec

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3561,6 +3561,7 @@ dependencies = [
  "milagro_bls",
  "pallet-timestamp",
  "parity-scale-codec",
+ "rand 0.8.5",
  "rlp",
  "scale-info",
  "serde",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -34,6 +34,7 @@ snowbridge-ethereum = { path = "../../primitives/ethereum", default-features = f
 snowbridge-beacon-primitives = { path = "../../primitives/beacon", default-features = false }
 
 [dev-dependencies]
+rand = "0.8.5"
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 snowbridge-testutils = { path = "../../primitives/testutils" }
 serde_json = "1.0.96"

--- a/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -77,7 +77,9 @@ pub mod mock_minimal {
 		pub const MaxPublicKeySize: u32 = config::PUBKEY_SIZE as u32;
 		pub const MaxSignatureSize: u32 = config::SIGNATURE_SIZE as u32;
 		pub const MaxSlotsPerHistoricalRoot: u64 = 64;
-		pub const MaxFinalizedHeaderSlotArray: u32 = 1000;
+		pub const MaxFinalizedHeaderSlotArray: u32 = 12;
+		pub const SyncCommitteePruneThreshold: u64 = 4;
+		pub const ExecutionHeadersPruneThreshold: u64 = 10;
 		pub const WeakSubjectivityPeriodSeconds: u32 = 97200;
 		pub const ChainForkVersions: ForkVersions = ForkVersions{
 			genesis: Fork {
@@ -112,6 +114,8 @@ pub mod mock_minimal {
 		type MaxSlotsPerHistoricalRoot = MaxSlotsPerHistoricalRoot;
 		type MaxFinalizedHeaderSlotArray = MaxFinalizedHeaderSlotArray;
 		type ForkVersions = ChainForkVersions;
+		type SyncCommitteePruneThreshold = SyncCommitteePruneThreshold;
+		type ExecutionHeadersPruneThreshold = ExecutionHeadersPruneThreshold;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}
@@ -203,6 +207,8 @@ pub mod mock_mainnet {
 				epoch: 162304,
 			},
 		};
+		pub const SyncCommitteePruneThreshold: u64 = 4;
+		pub const ExecutionHeadersPruneThreshold: u64 = 10;
 	}
 
 	impl ethereum_beacon_client::Config for Test {
@@ -218,6 +224,8 @@ pub mod mock_mainnet {
 		type MaxSlotsPerHistoricalRoot = MaxSlotsPerHistoricalRoot;
 		type MaxFinalizedHeaderSlotArray = MaxFinalizedHeaderSlotArray;
 		type ForkVersions = ChainForkVersions;
+		type SyncCommitteePruneThreshold = SyncCommitteePruneThreshold;
+		type ExecutionHeadersPruneThreshold = ExecutionHeadersPruneThreshold;
 		type WeakSubjectivityPeriodSeconds = WeakSubjectivityPeriodSeconds;
 		type WeightInfo = ();
 	}

--- a/parachain/pallets/ethereum-beacon-client/src/ringbuffer.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/ringbuffer.rs
@@ -1,0 +1,74 @@
+use codec::FullCodec;
+use core::{cmp::Ord, marker::PhantomData, ops::Add};
+use frame_support::storage::{types::QueryKindTrait, StorageMap, StorageValue};
+use sp_core::{Get, GetDefault};
+use sp_runtime::traits::{One, Zero};
+
+/// Trait object presenting the ringbuffer interface.
+pub trait RingBufferMap<Key, Value, QueryKind>
+where
+	Key: FullCodec,
+	Value: FullCodec,
+	QueryKind: QueryKindTrait<Value, GetDefault>,
+{
+	/// Insert a map entry.
+	fn insert(k: Key, v: Value);
+
+	/// Check if map contains a key
+	fn contains_key(k: Key) -> bool;
+
+	/// Get the value of the key
+	fn get(k: Key) -> QueryKind::Query;
+}
+
+pub struct RingBufferMapImpl<Index, B, CurrentIndex, Intermediate, M, QueryKind>(
+	PhantomData<(Index, B, CurrentIndex, Intermediate, M, QueryKind)>,
+);
+
+/// Ringbuffer implementation based on `RingBufferTransient`
+impl<Key, Value, Index, B, CurrentIndex, Intermediate, M, QueryKind>
+	RingBufferMap<Key, Value, QueryKind>
+	for RingBufferMapImpl<Index, B, CurrentIndex, Intermediate, M, QueryKind>
+where
+	Key: FullCodec + Clone,
+	Value: FullCodec,
+	Index: Ord + One + Zero + Add<Output = Index> + Copy + FullCodec + Eq,
+	B: Get<Index>,
+	CurrentIndex: StorageValue<Index, Query = Index>,
+	Intermediate: StorageMap<Index, Key, Query = Key>,
+	M: StorageMap<Key, Value, Query = QueryKind::Query>,
+	QueryKind: QueryKindTrait<Value, GetDefault>,
+{
+	/// Insert a map entry.
+	fn insert(k: Key, v: Value) {
+		let bound = B::get();
+		let mut current_index = CurrentIndex::get();
+
+		// Adding one here as bound denotes number of items but our index starts with zero.
+		if (current_index + Index::one()) >= bound {
+			current_index = Index::zero();
+		} else {
+			current_index = current_index + Index::one();
+		}
+
+		// Deleting earlier entry if it exists
+		if Intermediate::contains_key(current_index) {
+			let older_key = Intermediate::get(current_index);
+			M::remove(older_key);
+		}
+
+		Intermediate::insert(current_index, k.clone());
+		CurrentIndex::set(current_index);
+		M::insert(k, v);
+	}
+
+	/// Check if map contains a key
+	fn contains_key(k: Key) -> bool {
+		M::contains_key(k)
+	}
+
+	/// Get the value associated with key
+	fn get(k: Key) -> M::Query {
+		M::get(k)
+	}
+}


### PR DESCRIPTION
### Description
This PR is improvement over https://github.com/Snowfork/snowbridge/pull/810 as suggested by @yrong.  Instead of using Pruning, now we are using modified version of RingBuffer to limit the runtime storage. 

### How `RingBuffer` works?
If number of items go beyond some threshold, the `RingBuffer::insert` will remove oldest entry. 

### Advantage of `RingBuffer`
There is no while loop. The complexity is `O(1)`. And since it is abstracted, there is no clutter in application logic.