### PR TITLE
Solmate proofs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/snowfork/canonical-weth
 [submodule "core/packages/contracts/lib/solmate"]
 	path = core/packages/contracts/lib/solmate
-	url = https://github.com/doubledup/solmate
+	url = https://github.com/Snowfork/solmate

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "core/packages/contracts/lib/canonical-weth"]
 	path = core/packages/contracts/lib/canonical-weth
 	url = https://github.com/snowfork/canonical-weth
+[submodule "core/packages/contracts/lib/solmate"]
+	path = core/packages/contracts/lib/solmate
+	url = https://github.com/doubledup/solmate

--- a/core/packages/contracts/foundry.toml
+++ b/core/packages/contracts/foundry.toml
@@ -12,6 +12,7 @@ remappings = [
     'solmate=lib/solmate/src/',
 ]
 ffi = true
+fuzz.runs = 1_000
 
 
 ignored_error_codes = [

--- a/core/packages/contracts/foundry.toml
+++ b/core/packages/contracts/foundry.toml
@@ -9,6 +9,7 @@ remappings = [
     'ds-test=lib/ds-test/src/',
     'forge-std=lib/forge-std/src/',
     'openzeppelin=lib/openzeppelin-contracts/contracts/',
+    'solmate=lib/solmate/src/',
 ]
 ffi = true
 

--- a/core/packages/contracts/src/BeefyClient.sol
+++ b/core/packages/contracts/src/BeefyClient.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import "openzeppelin/utils/cryptography/ECDSA.sol";
-import "openzeppelin/utils/cryptography/MerkleProof.sol";
+import "solmate/utils/MerkleProofLib.sol";
 import "openzeppelin/access/Ownable.sol";
 import "./utils/Bitfield.sol";
 import "./utils/MMRProof.sol";
@@ -511,7 +511,7 @@ contract BeefyClient is Ownable {
         bytes32[] calldata proof
     ) internal pure returns (bool) {
         bytes32 hashedLeaf = keccak256(abi.encodePacked(addr));
-        return MerkleProof.verify(proof, vset.root, hashedLeaf);
+        return MerkleProofLib.verify(proof, vset.root, hashedLeaf);
     }
 
     /**

--- a/core/packages/contracts/src/IParachainClient.sol
+++ b/core/packages/contracts/src/IParachainClient.sol
@@ -2,8 +2,32 @@
 pragma solidity ^0.8.19;
 
 interface IParachainClient {
+    struct HeadProof {
+        uint256 pos;
+        uint256 width;
+        bytes32[] proof;
+    }
+
+    struct MMRLeafPartial {
+        uint8 version;
+        uint32 parentNumber;
+        bytes32 parentHash;
+        uint64 nextAuthoritySetID;
+        uint32 nextAuthoritySetLen;
+        bytes32 nextAuthoritySetRoot;
+    }
+
+    struct Proof {
+        bytes headPrefix;
+        bytes headSuffix;
+        HeadProof headProof;
+        MMRLeafPartial leafPartial;
+        bytes32[] leafProof;
+        uint256 leafProofOrder;
+    }
+
     function verifyCommitment(
         bytes32 commitment,
-        bytes calldata opaqueProof
+        Proof calldata proof
     ) external view returns (bool);
 }

--- a/core/packages/contracts/src/InboundQueue.sol
+++ b/core/packages/contracts/src/InboundQueue.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.19;
 
-import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
+import {MerkleProofLib} from "solmate/utils/MerkleProofLib.sol";
 import {AccessControl} from "openzeppelin/access/AccessControl.sol";
 import {IParachainClient} from "./ParachainClient.sol";
 import {IRecipient} from "./IRecipient.sol";
@@ -67,7 +67,7 @@ contract InboundQueue is AccessControl {
 
     function submit(Message calldata message, bytes32[] calldata leafProof, bytes calldata headerProof) external {
         bytes32 leafHash = keccak256(abi.encode(message));
-        bytes32 commitment = MerkleProof.processProof(leafProof, leafHash);
+        bytes32 commitment = MerkleProofLib.calculateRoot(leafProof, leafHash);
         if (!parachainClient.verifyCommitment(commitment, headerProof)) {
             revert InvalidProof();
         }

--- a/core/packages/contracts/src/InboundQueue.sol
+++ b/core/packages/contracts/src/InboundQueue.sol
@@ -66,8 +66,11 @@ contract InboundQueue is AccessControl {
     }
 
     function submit(Message calldata message, bytes32[] calldata leafProof, bytes calldata headerProof) external {
+        // Hash the leaf so that we can combine it with the proof hashes to find the Merkle root.
         bytes32 leafHash = keccak256(abi.encode(message));
+        // Get the root hash that identifies the list of messages that the caller claims the parachain has committed.
         bytes32 commitment = MerkleProofLib.calculateRoot(leafProof, leafHash);
+        // Verify that the parachain has committed the list of messages.
         if (!parachainClient.verifyCommitment(commitment, headerProof)) {
             revert InvalidProof();
         }

--- a/core/packages/contracts/src/InboundQueue.sol
+++ b/core/packages/contracts/src/InboundQueue.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.19;
 
-import {MerkleProofLib} from "solmate/utils/MerkleProofLib.sol";
+import "solmate/utils/MerkleProofLib.sol";
 import {AccessControl} from "openzeppelin/access/AccessControl.sol";
 import {IParachainClient} from "./ParachainClient.sol";
 import {IRecipient} from "./IRecipient.sol";
@@ -65,7 +65,7 @@ contract InboundQueue is AccessControl {
         reward = _reward;
     }
 
-    function submit(Message calldata message, bytes32[] calldata leafProof, bytes calldata headerProof) external {
+    function submit(Message calldata message, bytes32[] calldata leafProof, IParachainClient.Proof calldata headerProof) external {
         // Hash the leaf so that we can combine it with the proof hashes to find the Merkle root.
         bytes32 leafHash = keccak256(abi.encode(message));
         // Get the root hash that identifies the list of messages that the caller claims the parachain has committed.

--- a/core/packages/contracts/src/ParachainClient.sol
+++ b/core/packages/contracts/src/ParachainClient.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.19;
 
-import "openzeppelin/utils/cryptography/MerkleProof.sol";
+import "solmate/utils/MerkleProofLib.sol";
 import "./BeefyClient.sol";
 import "./IParachainClient.sol";
 import "./ScaleCodec.sol";
@@ -11,44 +11,18 @@ contract ParachainClient is IParachainClient {
     uint32 public immutable parachainID;
     bytes4 public immutable encodedParachainID;
 
-    struct HeadProof {
-        uint256 pos;
-        uint256 width;
-        bytes32[] proof;
-    }
-
-    struct MMRLeafPartial {
-        uint8 version;
-        uint32 parentNumber;
-        bytes32 parentHash;
-        uint64 nextAuthoritySetID;
-        uint32 nextAuthoritySetLen;
-        bytes32 nextAuthoritySetRoot;
-    }
-
-    struct Proof {
-        bytes headPrefix;
-        bytes headSuffix;
-        HeadProof headProof;
-        MMRLeafPartial leafPartial;
-        bytes32[] leafProof;
-        uint256 leafProofOrder;
-    }
-
     constructor(BeefyClient _client, uint32 _parachainID) {
         beefyClient = _client;
         parachainID = _parachainID;
         encodedParachainID = ScaleCodec.encodeU32(_parachainID);
     }
 
-    function verifyCommitment(bytes32 commitment, bytes calldata opaqueProof) external view returns (bool) {
-        Proof memory proof = abi.decode(opaqueProof, (Proof));
-
+    function verifyCommitment(bytes32 commitment, Proof calldata proof) external view returns (bool) {
         // Compute the merkle leaf hash of our parachain
         bytes32 parachainHeadHash = createParachainMerkleLeaf(commitment, proof.headPrefix, proof.headSuffix);
 
         // Compute the merkle root hash of all parachain heads
-        bytes32 parachainHeadsRoot = MerkleProof.processProof(proof.headProof.proof, parachainHeadHash);
+        bytes32 parachainHeadsRoot = MerkleProofLib.calculateRoot(proof.headProof.proof, parachainHeadHash);
 
         bytes32 leafHash = createMMRLeaf(proof.leafPartial, parachainHeadsRoot);
         return beefyClient.verifyMMRLeafProof(leafHash, proof.leafProof, proof.leafProofOrder);

--- a/core/packages/contracts/test/InboundQueue.t.sol
+++ b/core/packages/contracts/test/InboundQueue.t.sol
@@ -21,7 +21,14 @@ contract InboundQueueTest is Test {
     ParaID public constant ORIGIN = ParaID.wrap(1001);
     bytes32[] public proof = [bytes32(0x2f9ee6cfdf244060dc28aa46347c5219e303fc95062dd672b4e406ca5c29764b)];
     bytes public message = bytes("message");
-    bytes public parachainHeaderProof = bytes("validProof");
+    IParachainClient.Proof public parachainHeaderProof = IParachainClient.Proof(
+        new bytes(0),
+        new bytes(0),
+        IParachainClient.HeadProof(0, 0, new bytes32[](0)),
+        IParachainClient.MMRLeafPartial(0, 0, bytes32(0), 0, 0, bytes32(0)),
+        new bytes32[](0),
+        0
+    );
 
     function setUp() public {
         IParachainClient parachainClient = new ParachainClientMock();
@@ -55,7 +62,10 @@ contract InboundQueueTest is Test {
         hoax(relayer, 1 ether);
 
         vm.expectRevert(InboundQueue.InvalidProof.selector);
-        channel.submit(InboundQueue.Message(ORIGIN, 1, 1, message), proof, bytes("badProof"));
+
+        IParachainClient.Proof memory badProof = parachainHeaderProof;
+        badProof.headPrefix = new bytes(1);
+        channel.submit(InboundQueue.Message(ORIGIN, 1, 1, message), proof, badProof);
     }
 
     function testSubmitShouldFailInvalidNonce() public {

--- a/core/packages/contracts/test/SolmateMerkleProofLib.t.sol
+++ b/core/packages/contracts/test/SolmateMerkleProofLib.t.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/console.sol";
+import "forge-std/Test.sol";
+
+import {MerkleProofLib} from "solmate/utils/MerkleProofLib.sol";
+
+contract SolmateMerkleProofLibTest is Test {
+    function testVerifyEmptyMerkleProofSuppliedLeafAndRootSame() public {
+        bytes32[] memory proof;
+        assertEq(this.verify(proof, 0x00, 0x00), true);
+    }
+
+    function testVerifyEmptyMerkleProofSuppliedLeafAndRootDifferent() public {
+        bytes32[] memory proof;
+        bytes32 leaf = "a";
+        assertEq(this.verify(proof, 0x00, leaf), false);
+    }
+
+    function testVerifyValidProofSupplied() public {
+        // Merkle tree created from leaves ['a', 'b', 'c'].
+        // Leaf is 'a'.
+        bytes32[] memory proof = new bytes32[](2);
+        proof[0] = 0xb5553de315e0edf504d9150af82dafa5c4667fa618ed0a6f19c69b41166c5510;
+        proof[1] = 0x0b42b6393c1f53060fe3ddbfcd7aadcca894465a5a438f69c87d790b2299b9b2;
+        bytes32 root = 0x5842148bc6ebeb52af882a317c765fccd3ae80589b21a9b8cbf21abb630e46a7;
+        bytes32 leaf = 0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb;
+        assertEq(this.verify(proof, root, leaf), true);
+    }
+
+    function testVerifyShortProofSupplied() public {
+        // Merkle tree created from leaves ['a', 'b', 'c'].
+        // Leaf is 'c'.
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = 0x805b21d846b189efaeb0377d6bb0d201b3872a363e607c25088f025b0c6ae1f8;
+        bytes32 root = 0x5842148bc6ebeb52af882a317c765fccd3ae80589b21a9b8cbf21abb630e46a7;
+        bytes32 leaf = 0x0b42b6393c1f53060fe3ddbfcd7aadcca894465a5a438f69c87d790b2299b9b2;
+
+        assertEq(this.verify(proof, root, leaf), true);
+    }
+
+    function testVerifyLargeProofSupplied() public {
+        // Merkle tree created from leaves ['1', '2', '3', ..., '1000'].
+        // Leaf is '42'.
+        bytes32[] memory proof = new bytes32[](10);
+        proof[0] = 0xcb7c14ce178f56e2e8d86ab33ebc0ae081ba8556a00cd122038841867181caac;
+        proof[1] = 0x081c6649d757735e00e82890581518fc42224f0942420fe385ccb1ee67fb5c34;
+        proof[2] = 0x6e077cb1dd754700e9f78cb6107b091478fbc6d9039792a4dcdecdee8c316f28;
+        proof[3] = 0x06bb7e8a1517e2c41f6583fb693aa50f81e2db3e8aee43b105732f425f26b832;
+        proof[4] = 0x4ecb91ca93d01dbee0cd88bec35d95e275de0f3c76a651c57b626bbee417e14e;
+        proof[5] = 0xf78b5b2a0d2098d5690099983e7875e3a2274b985023d3cf48088b168f543b74;
+        proof[6] = 0x2084f0e5584a39ae0c863c1f95799baa90aafe318185f6a9f67ae11098efbf99;
+        proof[7] = 0x355564742ce4c22df4630c1a84466e23dd8339343fe3e2a67bfb0adce6a4d626;
+        proof[8] = 0xc751a2cbefe4b10e2108a92131dfda6788a4059aa5a9b87aa001935a189de909;
+        proof[9] = 0x698159e44c47a9a66f4efa7fdf710e7b00ae3c3d95522376cacc3580ad5600d3;
+        bytes32 root = 0x147c1ac0abf462d97b0f59c5d3616f81c96566d1e2ddab5359f16c3bf0b48cc9;
+        bytes32 leaf = 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2;
+
+        assertEq(this.verify(proof, root, leaf), true);
+    }
+
+    function testVerifyInvalidProofSupplied() public {
+        // Merkle tree created from leaves ['a', 'b', 'c'].
+        // Leaf is 'a'.
+        // Proof is same as testValidProofSupplied but last byte of first element is modified.
+        bytes32[] memory proof = new bytes32[](2);
+        proof[0] = 0xb5553de315e0edf504d9150af82dafa5c4667fa618ed0a6f19c69b41166c5511;
+        proof[1] = 0x0b42b6393c1f53060fe3ddbfcd7aadcca894465a5a438f69c87d790b2299b9b2;
+        bytes32 root = 0x5842148bc6ebeb52af882a317c765fccd3ae80589b21a9b8cbf21abb630e46a7;
+        bytes32 leaf = 0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb;
+        assertEq(this.verify(proof, root, leaf), false);
+    }
+
+    function testFuzz_RandomProof(uint8 leafCount, uint8 leafIndex) public {
+        vm.assume(leafIndex < leafCount);
+
+        // most significant bit of leafCount is the number of nodes in the second-last layer of a complete binary tree
+        // with leafCount leaves
+        // most-significant bit of leafCount = leafCount -> reverse -> least-significant bit -> reverse
+        uint8 bitReversedLeafCount = reverseBitsU8(leafCount);
+        uint8 lsb = bitReversedLeafCount & (~bitReversedLeafCount+1);
+        uint8 secondLastLayerCount = reverseBitsU8(lsb);
+        uint256 lastLayerCount = 2*(leafCount - secondLastLayerCount);
+
+        bytes32[] memory tree = new bytes32[](2*uint256(leafCount)-1);
+
+        for (uint256 i = 0; i < tree.length; i++) {
+            if (i < lastLayerCount) {
+                // store bottom layer leaf hash
+                tree[tree.length - 1 - i] = keccak256(abi.encodePacked(lastLayerCount - 1 - i));
+            } else if (i < leafCount) {
+                // store second-last layer leaf hash
+                tree[tree.length - 1 - i] = keccak256(abi.encodePacked(leafCount - 1 - (i - lastLayerCount)));
+            } else {
+                // store sorted concatenation of leaf hashes
+                uint256 leftIndex = 2*(tree.length - 1 - i) + 1;
+                tree[tree.length - 1 - i] = hashSorted(tree[leftIndex], tree[leftIndex + 1]);
+            }
+        }
+
+        // Proof size is log2 of secondLastLayerCount, which is always a power of 2 in a complete tree
+        uint8 proofSize = 0;
+        // Count the zeroes after the single bit set in secondLastLayerCount
+        // Subtracting 1 sets all bits smaller than the single bit set in secondLastLayerCount
+        // Then use Kernighan's algorithm to count the set bits
+        uint8 n = secondLastLayerCount - 1;
+        while(n != 0) {
+            n &= n - 1;
+            proofSize++;
+        }
+        // Add 1 when the leaf is in the last layer of a non-perfect tree
+        if (leafIndex < lastLayerCount && lastLayerCount != leafCount) {
+            proofSize += 1;
+        }
+
+        bytes32[] memory proof = new bytes32[](proofSize);
+        uint256 current;
+        if (leafIndex < lastLayerCount) {
+            current = tree.length - lastLayerCount + leafIndex;
+        } else {
+            current = tree.length - leafCount + leafIndex - lastLayerCount ;
+        }
+
+        uint256 sibling;
+        for (uint8 i = 0; i < proof.length; i++) {
+            if (current % 2 == 0) {
+                sibling = current - 1;
+            } else {
+                sibling = current + 1;
+            }
+            proof[i] = tree[sibling];
+
+            current = (current - 1) / 2;
+        }
+
+        assertEq(this.verify(proof, tree[0], keccak256(abi.encodePacked(uint256(leafIndex)))), true);
+    }
+
+    function testFuzzSample() public {
+        uint8 leafCount = 3;
+        uint8 leafIndex = 1;
+
+        // most significant bit of leafCount is the number of nodes in the second-last layer of a complete binary tree
+        // with leafCount leaves
+        // most-significant bit of leafCount = leafCount -> reverse -> least-significant bit -> reverse
+        uint8 bitReversedLeafCount = reverseBitsU8(leafCount);
+        uint8 lsb = bitReversedLeafCount & (~bitReversedLeafCount+1);
+        uint8 secondLastLayerCount = reverseBitsU8(lsb);
+        uint256 lastLayerCount = 2*(leafCount - secondLastLayerCount);
+
+        bytes32[] memory tree = new bytes32[](2*uint256(leafCount)-1);
+
+        for (uint256 i = 0; i < tree.length; i++) {
+            if (i < lastLayerCount) {
+                // store bottom layer leaf hash
+                tree[tree.length - 1 - i] = keccak256(abi.encodePacked(lastLayerCount - 1 - i));
+            } else if (i < leafCount) {
+                // store second-last layer leaf hash
+                tree[tree.length - 1 - i] = keccak256(abi.encodePacked(leafCount - 1 - (i - lastLayerCount)));
+            } else {
+                // store sorted concatenation of leaf hashes
+                uint256 leftIndex = 2*(tree.length - 1 - i) + 1;
+                tree[tree.length - 1 - i] = hashSorted(tree[leftIndex], tree[leftIndex + 1]);
+            }
+        }
+
+        // Proof size is log2 of secondLastLayerCount, which is always a power of 2 in a complete tree
+        uint8 proofSize = 0;
+        // Count the zeroes after the bit set in secondLastLayerCount
+        // Set all bits smaller than the single bit set in secondLastLayerCount
+        uint8 n = secondLastLayerCount - 1;
+        while(n != 0) {
+            n &= n - 1;
+            proofSize++;
+        }
+        // Add 1 when the leaf is in the last layer of a non-perfect tree
+        if (leafIndex < lastLayerCount && lastLayerCount != leafCount) {
+            proofSize += 1;
+        }
+
+        bytes32[] memory proof = new bytes32[](proofSize);
+        uint256 current;
+        if (leafIndex < lastLayerCount) {
+            current = tree.length - lastLayerCount + leafIndex;
+        } else {
+            current = tree.length - leafCount + leafIndex - lastLayerCount ;
+        }
+
+        uint256 sibling;
+        for (uint8 i = 0; i < proof.length; i++) {
+            if (current % 2 == 0) {
+                sibling = current - 1;
+            } else {
+                sibling = current + 1;
+            }
+            proof[i] = tree[sibling];
+
+            current = (current - 1) / 2;
+        }
+
+        assertEq(this.verify(proof, tree[0], keccak256(abi.encodePacked(uint256(leafIndex)))), true);
+    }
+
+    function verify(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf
+    ) external pure returns (bool) {
+        return MerkleProofLib.verify(proof, root, leaf);
+    }
+
+    function hashSorted(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        if(a < b) {
+            return keccak256(abi.encodePacked(a, b));
+        } else {
+            return keccak256(abi.encodePacked(b, a));
+        }
+    }
+
+    function reverseBitsU8(uint8 n) internal pure returns (uint8) {
+        // swap adjacent bits, then pairs, then nibbles
+        uint8 reversed = (n & 0xAA) >> 1 | (n & 0x55) << 1;
+        reversed = (reversed & 0xCC) >> 2 | (reversed & 0x33) << 2;
+        reversed = (reversed & 0xF0) >> 4 | (reversed & 0x0F) << 4;
+        return reversed;
+    }
+}

--- a/core/packages/contracts/test/UpgradeProxy.t.sol
+++ b/core/packages/contracts/test/UpgradeProxy.t.sol
@@ -55,7 +55,7 @@ contract UpgradeProxyTest is Test {
         failedUpgradeTask = new FailingUpgradeTask();
     }
 
-    function createUpgradeMessage(IUpgradeTask task) internal returns (bytes memory) {
+    function createUpgradeMessage(IUpgradeTask task) internal pure returns (bytes memory) {
         return abi.encode(
             UpgradeProxy.Message(
                 UpgradeProxy.Action.Upgrade,

--- a/core/packages/contracts/test/mocks/ParachainClientMock.sol
+++ b/core/packages/contracts/test/mocks/ParachainClientMock.sol
@@ -4,8 +4,17 @@ pragma solidity ^0.8.19;
 import "../../src/IParachainClient.sol";
 
 contract ParachainClientMock is IParachainClient {
-    function verifyCommitment(bytes32, bytes calldata parachainHeaderProof) external pure override returns (bool) {
-        if (keccak256(parachainHeaderProof) == keccak256(bytes("validProof"))) {
+    function verifyCommitment(bytes32, Proof calldata parachainHeaderProof) external pure override returns (bool) {
+        IParachainClient.Proof memory mockProof = IParachainClient.Proof(
+            new bytes(0),
+            new bytes(0),
+            IParachainClient.HeadProof(0, 0, new bytes32[](0)),
+            IParachainClient.MMRLeafPartial(0, 0, bytes32(0), 0, 0, bytes32(0)),
+            new bytes32[](0),
+            0
+        );
+
+        if (keccak256(abi.encode(parachainHeaderProof)) == keccak256(abi.encode(mockProof))) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Needed to add a new function to get the root hash, as the only one available is for verifying a proof. It's currently in our [solmate fork](https://github.com/Snowfork/solmate). I'll work on pushing this upstream.

Also need to check the licenses: Solmate is released under AGPL 3 (though the files we're using have an MIT license identifier as their first line) and our contracts under Apache 2.

Added a large proof test (with data generated in a [benchmarks repo](https://github.com/doubledup/merkle-proof-contract-benchmarks/blob/a14cdb5162eb5cfadfe4042961e716a249969901/src/bin/generate_proof.rs)) and a fuzz test.