### PR TITLE
Verify sync committee supermajority when processing execution headers

### DIFF
--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -614,6 +614,7 @@ pub mod pallet {
 			let validators_root = <ValidatorsRoot<T>>::get();
 			let participation =
 				decompress_sync_committee_bits(update.sync_aggregate.sync_committee_bits);
+			Self::sync_committee_participation_is_supermajority(&participation)?;
 
 			Self::verify_signed_header(
 				&participation,


### PR DESCRIPTION
This basic requirement should have been caught by unit tests. Obviously we need to improve on that. I've cut SNO-437 to track.