### PR TITLE
Split implementation into several files

### DIFF
--- a/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/benchmarking/mod.rs
@@ -22,7 +22,7 @@ benchmarks! {
 		let initial_sync_data = initial_sync();
 		let sync_committee_update = initialize_sync_committee::<T>()?;
 
-		let period = EthereumBeaconClient::<T>::compute_current_sync_period(sync_committee_update.attested_header.slot);
+		let period = compute_period(sync_committee_update.attested_header.slot);
 
 		// initialize LatestFinalizedHeaderState with parent slot of finalized_header_update
 		LatestFinalizedHeader::<T>::set(FinalizedHeaderState {
@@ -45,7 +45,7 @@ benchmarks! {
 
 		let finalized_header_update = finalized_header_update();
 
-		let current_period = EthereumBeaconClient::<T>::compute_current_sync_period(
+		let current_period = compute_period(
 				finalized_header_update.attested_header.slot,
 			);
 
@@ -74,7 +74,7 @@ benchmarks! {
 
 		let header_update = header_update();
 
-		let current_period = EthereumBeaconClient::<T>::compute_current_sync_period(
+		let current_period = compute_period(
 				header_update.header.slot,
 			);
 

--- a/parachain/pallets/ethereum-beacon-client/src/benchmarking/util.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/benchmarking/util.rs
@@ -1,7 +1,7 @@
 use crate::{
-	decompress_sync_committee_bits, Config, LatestSyncCommitteePeriod,
-	Pallet as EthereumBeaconClient, SyncCommitteeUpdate, SyncCommittees, ValidatorsRoot, Vec,
-	SYNC_COMMITTEE_SIZE,
+	compute_period, config::SYNC_COMMITTEE_SIZE, decompress_sync_committee_bits, Config,
+	LatestSyncCommitteePeriod, Pallet as EthereumBeaconClient, SyncCommitteeUpdate, SyncCommittees,
+	ValidatorsRoot, Vec,
 };
 use primitives::{PublicKeyPrepared, SyncCommitteePrepared};
 use sp_core::H256;
@@ -16,12 +16,8 @@ pub fn initialize_sync_committee<T: Config>() -> Result<SyncCommitteeUpdate, &'s
 	let sync_committee_update = sync_committee_update();
 
 	// initialize SyncCommittees with period in sync_committee_update
-	LatestSyncCommitteePeriod::<T>::set(EthereumBeaconClient::<T>::compute_current_sync_period(
-		sync_committee_update.attested_header.slot,
-	));
-	let current_period = EthereumBeaconClient::<T>::compute_current_sync_period(
-		sync_committee_update.attested_header.slot,
-	);
+	LatestSyncCommitteePeriod::<T>::set(compute_period(sync_committee_update.attested_header.slot));
+	let current_period = compute_period(sync_committee_update.attested_header.slot);
 	EthereumBeaconClient::<T>::store_sync_committee(
 		current_period,
 		&initial_sync_data.current_sync_committee,
@@ -32,8 +28,7 @@ pub fn initialize_sync_committee<T: Config>() -> Result<SyncCommitteeUpdate, &'s
 pub fn sync_committee<T: Config>(
 	update: &SyncCommitteeUpdate,
 ) -> Result<SyncCommitteePrepared<SYNC_COMMITTEE_SIZE>, &'static str> {
-	let current_period =
-		EthereumBeaconClient::<T>::compute_current_sync_period(update.attested_header.slot);
+	let current_period = compute_period(update.attested_header.slot);
 	let sync_committee = SyncCommittees::<T>::get(current_period).ok_or("no sync committee")?;
 	Ok(sync_committee)
 }

--- a/parachain/pallets/ethereum-beacon-client/src/functions.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/functions.rs
@@ -1,0 +1,29 @@
+use crate::config::{
+	EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH, SYNC_COMMITTEE_BITS_SIZE,
+	SYNC_COMMITTEE_SIZE,
+};
+
+/// Decompress packed bitvector into byte vector according to SSZ deserialization rules. Each byte
+/// in the decompressed vector is either 0 or 1.
+pub fn decompress_sync_committee_bits(
+	input: [u8; SYNC_COMMITTEE_BITS_SIZE],
+) -> [u8; SYNC_COMMITTEE_SIZE] {
+	primitives::decompress_sync_committee_bits::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>(
+		input,
+	)
+}
+
+/// Compute the sync committee period in which a slot is contained
+pub fn compute_period(slot: u64) -> u64 {
+	slot / SLOTS_PER_EPOCH as u64 / EPOCHS_PER_SYNC_COMMITTEE_PERIOD as u64
+}
+
+/// Compute epoch in which a slot is contained
+pub fn compute_epoch(slot: u64, slots_per_epoch: u64) -> u64 {
+	slot / slots_per_epoch
+}
+
+/// Sums the bit vector of sync committee particpation.
+pub fn sync_committee_sum(sync_committee_bits: &[u8]) -> u32 {
+	sync_committee_bits.iter().fold(0, |acc: u32, x| acc + *x as u32)
+}

--- a/parachain/pallets/ethereum-beacon-client/src/impls.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/impls.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+use frame_support::dispatch::DispatchError;
+use snowbridge_ethereum::{Log, Receipt};
+
+impl<T: Config> Verifier for Pallet<T> {
+	/// Verify a message by verifying the existence of the corresponding
+	/// Ethereum log in a block. Returns the log if successful.
+	fn verify(message: &Message) -> Result<Log, DispatchError> {
+		log::info!(
+			target: "ethereum-beacon-client",
+			"💫 Verifying message with block hash {}",
+			message.proof.block_hash,
+		);
+
+		let header = <ExecutionHeaderBuffer<T>>::get(message.proof.block_hash)
+			.ok_or(Error::<T>::MissingHeader)?;
+
+		let receipt = match Self::verify_receipt_inclusion(header.receipts_root, &message.proof) {
+			Ok(receipt) => receipt,
+			Err(err) => {
+				log::error!(
+					target: "ethereum-beacon-client",
+					"💫 Verify receipt inclusion failed for block {}: {:?}",
+					message.proof.block_hash,
+					err
+				);
+				return Err(err)
+			},
+		};
+
+		log::trace!(
+			target: "ethereum-beacon-client",
+			"💫 Verified receipt inclusion for transaction at index {} in block {}",
+			message.proof.tx_index, message.proof.block_hash,
+		);
+
+		let log = match rlp::decode(&message.data) {
+			Ok(log) => log,
+			Err(err) => {
+				log::error!(
+					target: "ethereum-beacon-client",
+					"💫 RLP log decoded failed {}: {:?}",
+					message.proof.block_hash,
+					err
+				);
+				return Err(Error::<T>::DecodeFailed.into())
+			},
+		};
+
+		if !receipt.contains_log(&log) {
+			log::error!(
+				target: "ethereum-beacon-client",
+				"💫 Event log not found in receipt for transaction at index {} in block {}",
+				message.proof.tx_index, message.proof.block_hash,
+			);
+			return Err(Error::<T>::InvalidProof.into())
+		}
+
+		log::info!(
+			target: "ethereum-beacon-client",
+			"💫 Receipt verification successful for {}",
+			message.proof.block_hash,
+		);
+
+		Ok(log)
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	// Verifies that the receipt encoded in proof.data is included
+	// in the block given by proof.block_hash. Inclusion is only
+	// recognized if the block has been finalized.
+	pub fn verify_receipt_inclusion(
+		receipts_root: H256,
+		proof: &Proof,
+	) -> Result<Receipt, DispatchError> {
+		let result =
+			verify_receipt_proof(receipts_root, &proof.data.1).ok_or(Error::<T>::InvalidProof)?;
+
+		match result {
+			Ok(receipt) => Ok(receipt),
+			Err(err) => {
+				log::trace!(
+					target: "ethereum-beacon-client",
+					"💫 Failed to decode transaction receipt: {}",
+					err
+				);
+				Err(Error::<T>::InvalidProof.into())
+			},
+		}
+	}
+}

--- a/parachain/pallets/ethereum-beacon-client/src/tests.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests.rs
@@ -1,10 +1,11 @@
 use crate::{
+	config::SYNC_COMMITTEE_SIZE,
 	mock::{get_initial_sync, mock_minimal, new_tester},
 	pallet::{
 		ExecutionHeaders, FinalizedBeaconHeaderStates, FinalizedBeaconHeaders,
 		FinalizedBeaconHeadersBlockRoot, SyncCommittees,
 	},
-	verify_merkle_branch, BeaconHeader, Error, H256, SYNC_COMMITTEE_SIZE,
+	sync_committee_sum, verify_merkle_branch, BeaconHeader, Error, H256,
 };
 use frame_support::{assert_err, assert_ok};
 use hex_literal::hex;
@@ -26,14 +27,9 @@ pub fn prepare_milagro_pubkeys() -> Result<Vec<PublicKeyPrepared>, &'static str>
 }
 
 #[test]
-pub fn test_get_sync_committee_sum() {
+pub fn test_sync_committee_sum() {
 	new_tester::<mock_minimal::Test>().execute_with(|| {
-		assert_eq!(
-			mock_minimal::EthereumBeaconClient::get_sync_committee_sum(&[
-				0, 1, 0, 1, 1, 0, 1, 0, 1
-			]),
-			5
-		);
+		assert_eq!(sync_committee_sum(&[0, 1, 0, 1, 1, 0, 1, 0, 1]), 5);
 	});
 }
 

--- a/parachain/pallets/ethereum-beacon-client/src/tests_mainnet.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests_mainnet.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "minimal"))]
 use crate::{
-	config,
+	compute_period, config,
 	config::{SYNC_COMMITTEE_BITS_SIZE, SYNC_COMMITTEE_SIZE},
 	mock::*,
 	Error, ExecutionHeaders, FinalizedBeaconHeaders, FinalizedBeaconHeadersBlockRoot,
@@ -32,9 +32,7 @@ fn it_updates_a_committee_period_sync_update() {
 		get_committee_sync_period_update::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>();
 	let current_sync_committee =
 		get_initial_sync::<{ SYNC_COMMITTEE_SIZE }>().current_sync_committee;
-	let current_period = mock_mainnet::EthereumBeaconClient::compute_current_sync_period(
-		update.attested_header.slot,
-	);
+	let current_period = compute_period(update.attested_header.slot);
 
 	new_tester::<mock_mainnet::Test>().execute_with(|| {
 		LatestSyncCommitteePeriod::<mock_mainnet::Test>::set(current_period);
@@ -60,9 +58,7 @@ fn it_processes_a_finalized_header_update() {
 	let update = get_finalized_header_update::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>();
 	let current_sync_committee =
 		get_initial_sync::<{ SYNC_COMMITTEE_SIZE }>().current_sync_committee;
-	let current_period = mock_mainnet::EthereumBeaconClient::compute_current_sync_period(
-		update.attested_header.slot,
-	);
+	let current_period = compute_period(update.attested_header.slot);
 
 	let slot = update.finalized_header.slot;
 	let import_time = 1616508000u64 + (slot * config::SECONDS_PER_SLOT as u64); // Goerli genesis time +
@@ -97,9 +93,7 @@ fn it_errors_when_weak_subjectivity_period_exceeded_for_a_finalized_header_updat
 	let update = get_finalized_header_update::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>();
 	let current_sync_committee = get_initial_sync::<SYNC_COMMITTEE_SIZE>().current_sync_committee;
 
-	let current_period = mock_mainnet::EthereumBeaconClient::compute_current_sync_period(
-		update.attested_header.slot,
-	);
+	let current_period = compute_period(update.attested_header.slot);
 
 	let slot = update.finalized_header.slot;
 	let import_time = 1616508000u64 + (slot * config::SECONDS_PER_SLOT as u64);
@@ -133,8 +127,7 @@ fn it_processes_a_header_update() {
 	let update = get_header_update();
 	let current_sync_committee =
 		get_initial_sync::<{ config::SYNC_COMMITTEE_SIZE }>().current_sync_committee;
-	let current_period =
-		mock_mainnet::EthereumBeaconClient::compute_current_sync_period(update.header.slot);
+	let current_period = compute_period(update.header.slot);
 
 	let finalized_update =
 		get_finalized_header_update::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>();

--- a/parachain/pallets/ethereum-beacon-client/src/tests_minimal.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/tests_minimal.rs
@@ -1,5 +1,5 @@
 use crate::{
-	config,
+	compute_period, config,
 	config::{SYNC_COMMITTEE_BITS_SIZE, SYNC_COMMITTEE_SIZE},
 	mock::*,
 	pallet::FinalizedBeaconHeadersBlockRoot,
@@ -37,9 +37,7 @@ fn it_updates_a_committee_period_sync_update() {
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		assert_ok!(mock_minimal::EthereumBeaconClient::process_checkpoint_update(&initial_sync));
 
-		let current_period = mock_minimal::EthereumBeaconClient::compute_current_sync_period(
-			update.attested_header.slot,
-		);
+		let current_period = compute_period(update.attested_header.slot);
 
 		assert_ok!(mock_minimal::EthereumBeaconClient::store_sync_committee(
 			current_period,
@@ -90,7 +88,7 @@ fn it_updates_a_invalid_committee_period_sync_update_with_gap() {
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		assert_ok!(mock_minimal::EthereumBeaconClient::initial_sync(initial_sync.clone()));
 
-		let current_period = mock_minimal::EthereumBeaconClient::compute_current_sync_period(
+		let current_period = compute_period(
 			update.attested_header.slot,
 		);
 
@@ -120,9 +118,7 @@ fn it_updates_a_invalid_committee_period_sync_update_with_duplicate_entry() {
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		assert_ok!(mock_minimal::EthereumBeaconClient::process_checkpoint_update(&initial_sync));
 
-		let current_period = mock_minimal::EthereumBeaconClient::compute_current_sync_period(
-			update.attested_header.slot,
-		);
+		let current_period = compute_period(update.attested_header.slot);
 
 		assert_ok!(mock_minimal::EthereumBeaconClient::store_sync_committee(
 			current_period,
@@ -150,9 +146,7 @@ fn it_processes_a_finalized_header_update() {
 	let update = get_finalized_header_update::<SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_SIZE>();
 	let initial_sync = get_initial_sync::<SYNC_COMMITTEE_SIZE>();
 
-	let current_period = mock_minimal::EthereumBeaconClient::compute_current_sync_period(
-		update.attested_header.slot,
-	);
+	let current_period = compute_period(update.attested_header.slot);
 
 	let time_now = SystemTime::now()
 		.duration_since(UNIX_EPOCH)
@@ -253,8 +247,7 @@ fn it_processes_a_header_update() {
 	let finalized_slot = finalized_update.finalized_header.slot;
 	let finalized_block_root: H256 = finalized_update.finalized_header.hash_tree_root().unwrap();
 
-	let current_period =
-		mock_minimal::EthereumBeaconClient::compute_current_sync_period(update.header.slot);
+	let current_period = compute_period(update.header.slot);
 
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		ValidatorsRoot::<mock_minimal::Test>::set(get_validators_root::<SYNC_COMMITTEE_SIZE>());
@@ -287,8 +280,7 @@ fn it_processes_a_header_update() {
 fn it_processes_a_invalid_header_update_not_finalized() {
 	let initial_sync = get_initial_sync::<SYNC_COMMITTEE_SIZE>();
 	let update = get_header_update();
-	let current_period =
-		mock_minimal::EthereumBeaconClient::compute_current_sync_period(update.header.slot);
+	let current_period = compute_period(update.header.slot);
 
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		assert_ok!(mock_minimal::EthereumBeaconClient::process_checkpoint_update(&initial_sync));
@@ -319,8 +311,7 @@ fn it_processes_a_invalid_header_update_not_finalized() {
 fn it_processes_a_invalid_header_update_with_duplicate_entry() {
 	let initial_sync = get_initial_sync::<SYNC_COMMITTEE_SIZE>();
 	let update = get_header_update();
-	let current_period =
-		mock_minimal::EthereumBeaconClient::compute_current_sync_period(update.header.slot);
+	let current_period = compute_period(update.header.slot);
 
 	new_tester::<mock_minimal::Test>().execute_with(|| {
 		assert_ok!(mock_minimal::EthereumBeaconClient::process_checkpoint_update(&initial_sync));

--- a/parachain/pallets/ethereum-beacon-client/src/types.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/types.rs
@@ -1,0 +1,35 @@
+pub use crate::config::{
+	SLOTS_PER_HISTORICAL_ROOT, SYNC_COMMITTEE_BITS_SIZE as SC_BITS_SIZE,
+	SYNC_COMMITTEE_SIZE as SC_SIZE,
+};
+use frame_support::storage::types::OptionQuery;
+use snowbridge_core::RingBufferMapImpl;
+
+// Specialize types based on configured sync committee size
+pub type CheckpointUpdate = primitives::CheckpointUpdate<SC_SIZE>;
+pub type ExecutionHeaderUpdate = primitives::ExecutionHeaderUpdate;
+pub type SyncCommitteeUpdate = primitives::SyncCommitteeUpdate<SC_SIZE, SC_BITS_SIZE>;
+pub type FinalizedHeaderUpdate = primitives::FinalizedHeaderUpdate<SC_SIZE, SC_BITS_SIZE>;
+pub type SyncCommittee = primitives::SyncCommittee<SC_SIZE>;
+pub type SyncCommitteePrepared = primitives::SyncCommitteePrepared<SC_SIZE>;
+pub type SyncAggregate = primitives::SyncAggregate<SC_SIZE, SC_BITS_SIZE>;
+
+/// ExecutionHeader ring buffer implementation
+pub(crate) type ExecutionHeaderBuffer<T> = RingBufferMapImpl<
+	u32,
+	<T as crate::Config>::MaxExecutionHeadersToKeep,
+	crate::ExecutionHeaderIndex<T>,
+	crate::ExecutionHeaderMapping<T>,
+	crate::ExecutionHeaders<T>,
+	OptionQuery,
+>;
+
+/// Sync committee ring buffer implementation
+pub(crate) type SyncCommitteesBuffer<T> = RingBufferMapImpl<
+	u32,
+	<T as crate::Config>::MaxSyncCommitteesToKeep,
+	crate::SyncCommitteesIndex<T>,
+	crate::SyncCommitteesMapping<T>,
+	crate::SyncCommittees<T>,
+	OptionQuery,
+>;

--- a/parachain/pallets/inbound-queue/src/test.rs
+++ b/parachain/pallets/inbound-queue/src/test.rs
@@ -95,10 +95,6 @@ impl Verifier for MockVerifier {
 		let log: Log = rlp::decode(&message.data).unwrap();
 		Ok(log)
 	}
-
-	fn initialize_storage(_: Vec<EthereumHeader>, _: U256, _: u8) -> Result<(), &'static str> {
-		Ok(())
-	}
 }
 
 use snowbridge_router_primitives::InboundMessageConverter;

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -7,9 +7,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::dispatch::DispatchError;
-use snowbridge_ethereum::{Header, Log, U256};
+use snowbridge_ethereum::Log;
 use sp_runtime::DispatchResult;
-use sp_std::prelude::*;
 
 pub mod ringbuffer;
 pub mod types;
@@ -24,11 +23,6 @@ pub use types::{Message, MessageId, MessageNonce, Proof};
 /// functionality.
 pub trait Verifier {
 	fn verify(message: &Message) -> Result<Log, DispatchError>;
-	fn initialize_storage(
-		headers: Vec<Header>,
-		initial_difficulty: U256,
-		descendants_until_final: u8,
-	) -> Result<(), &'static str>;
 }
 
 pub trait OutboundQueue {


### PR DESCRIPTION
I think the beacon code is easier to read and understand if we split some of into other files:

* `types.rs`: Types defined for use by client, and which cannot go into the primitives crate 
* `functions.rs`: Functions defined for use by the client, and which cannot go into the primitives crate
* `impls.rs`: Implementation of `Verifier` trait for message verification.

Other misc changes:
* Renamed `compute_current_sync_period` to `sync_period`.
* Removed unused `initialise_storage` function from `Verifier` trait.