### PR TITLE
Update foundry overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1684228155,
-        "narHash": "sha256-UJ4nQQmrK9bp3fMuKBXMHoRzu1pXvvca8AxJJa4A6PA=",
+        "lastModified": 1685005767,
+        "narHash": "sha256-2B9K9bNGuc3XVauP+LGKXNVVJTiuqNNDNNNbT5m7saM=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "5478ec35584e0c97bd7f576285b6332d14f755e9",
+        "rev": "1435fd712725dfbfbe92293e1405b147bc92867b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
An [overlay commit](https://github.com/shazow/foundry.nix/commit/1435fd712725dfbfbe92293e1405b147bc92867b) was just created that references a [Foundry build that exists](https://github.com/foundry-rs/foundry/releases/tag/nightly-a26edce5d2e1ad28d833328b22e857ecb7075e63). We can use this for now, still not sure what caused it other than weird results from the Github API at the time of the overlay update.
