### PR TITLE
Switch to foundry monthly release for 2023-06

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1685437774,
-        "narHash": "sha256-VkBmpkcdtv8XH4G+T2hm6VUL7Y7zw2Jkkezz9wp6mxU=",
+        "lastModified": 1685870001,
+        "narHash": "sha256-ijUNyTvT/dT9JOcsNiVtu/u1Eicf0HqQ7SPyZ5yRU84=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "ce3316150b8e4cb88e968ab0a7094cd66f94aab4",
+        "rev": "c80b4ea3bdce135164a7aac78aafb7c619b2dd23",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
-        "ref": "main",
+        "ref": "monthly",
         "repo": "foundry.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
         nixpkgs.url = "nixpkgs/nixos-unstable";
         rust-overlay.url = "github:oxalica/rust-overlay";
         flake-utils.url  = "github:numtide/flake-utils";
-        foundry.url = "github:shazow/foundry.nix/main";
+        foundry.url = "github:shazow/foundry.nix/monthly";
     };
 
     outputs = { self, nixpkgs, rust-overlay, flake-utils, foundry }:


### PR DESCRIPTION
The foundry overlay [updated its monthly branch](https://github.com/shazow/foundry.nix/commit/c80b4ea3bdce135164a7aac78aafb7c619b2dd23) yesterday to include [e48d](https://github.com/foundry-rs/foundry/commit/e48db344378c73f4a612cb5c7614b6fff933b7f6). This was needed to fix some test failures, but merged on 2023-05-05 after the last monthly release. Switching to monthly releases means we don't need to keep bumping the nightly version every few days to make builds on new machines work.

New machines failed to build after a few days because Foundry only keeps the last 3 nightly release builds. New machines don't have the locked Foundry version cached and can't fetch them once Foundry's deleted them.

Also, Foundry sometimes built nightly >=3 times in 1 day, so any fresh machine wouldn't work until the next overlay build. This is the issue @claravanstaden ran into, and won't happen when using monthly releases.