### PR TITLE
Downgrade Rust to 1.69.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1684376381,
-        "narHash": "sha256-XVFTXADfvBXKwo4boqfg80awUbT+JgQvlQ8uZ+Xgo1s=",
+        "lastModified": 1686537156,
+        "narHash": "sha256-mJD80brS6h6P4jzwdKID0S9RvfyiruxgJbXvPPIDqF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c9a265c2eaa5783bc18593b1aec39a85653c076",
+        "rev": "e75da5cfc7da874401decaa88f4ccb3b4d64d20d",
         "type": "github"
       },
       "original": {

--- a/parachain/rust-toolchain.toml
+++ b/parachain/rust-toolchain.toml
@@ -6,7 +6,8 @@
 #   - update `channel = "nightly-OLD_DATE"` below
 #   - update nightly-OLD_DATE in .github/workflows/parachain.yml
 
-channel = "nightly-2023-04-22" # 1.71.0 nightly for unstable features
+channel = "nightly-2023-03-04" # 1.69.0 nightly for unstable features and no sign-ext
+# for more on the sign-ext issue: https://github.com/paritytech/cargo-contract/issues/1139
 targets = [
     "wasm32-unknown-unknown",
 ]


### PR DESCRIPTION
Opened as a draft until it's successfully built locally.

This avoids an issue where the sign-ext WASM feature is enabled in Rust >= 1.70.0.

[cargo-contract issue](https://github.com/paritytech/cargo-contract/issues/1139)
[rust issue](https://github.com/rust-lang/rust/issues/109807)
