### PR TITLE
Improve codecov

### DIFF
--- a/.github/workflows/ethereum.yml
+++ b/.github/workflows/ethereum.yml
@@ -48,3 +48,4 @@ jobs:
         with:
           working-directory: core/packages/contracts
           files: lcov.info
+          flags: solidity

--- a/.github/workflows/parachain.yml
+++ b/.github/workflows/parachain.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           working-directory: parachain
           files: cobertura.xml
+          flags: rust
 
   check-cumulus-bridgehub:
     runs-on: snowbridge-runner

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+github_checks:
+    annotations: false
 ignore:
   - "core/packages/contracts/test/mocks"
   - "core/packages/contracts/src/utils"
@@ -8,3 +10,12 @@ ignore:
   - "parachain/pallets/ethereum-beacon-client/src/benchmarking"
   - "parachain/pallets/ethereum-beacon-client/src/weights.rs"
   - "core/packages/contracts/src/DeployScript.sol"
+flags:
+  solidity:
+    paths:
+      - core/packages/contracts
+    carryforward: true
+  rust:
+    paths:
+      - parachain
+    carryforward: true


### PR DESCRIPTION
Turns out the solution for the flaky coverage reports is to use "Carryforward Flags": https://docs.codecov.com/docs/carryforward-flags

Basically it allows us to selectively upload coverage reports for only subset of the repo.

I also disabled annotation spam in PRs.