### PR TITLE
Improve upgrade pattern

### DIFF
--- a/core/packages/contracts/src/BeefyClient.sol
+++ b/core/packages/contracts/src/BeefyClient.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.20;
 
 import {ECDSA} from "openzeppelin/utils/cryptography/ECDSA.sol";
-import {Ownable} from "openzeppelin/access/Ownable.sol";
+import {Auth} from "./Auth.sol";
 import {MerkleProof} from "./utils/MerkleProof.sol";
 import {Bitfield} from "./utils/Bitfield.sol";
 import {MMRProof} from "./utils/MMRProof.sol";
@@ -29,7 +29,7 @@ import {ScaleCodec} from "./ScaleCodec.sol";
  * 4. submitFinalWithHandover (with signature proofs specified by (3))
  *
  */
-contract BeefyClient is Ownable {
+contract BeefyClient is Auth {
     /* Events */
 
     /**
@@ -178,16 +178,14 @@ contract BeefyClient is Ownable {
         randaoCommitExpiration = _randaoCommitExpiration;
     }
 
-    // Once-off post-construction call to set initial configuration.
     function initialize(
         uint64 _initialBeefyBlock,
         ValidatorSet calldata _initialValidatorSet,
         ValidatorSet calldata _nextValidatorSet
-    ) external onlyOwner {
+    ) external onlyRole(ADMIN_ROLE) {
         latestBeefyBlock = _initialBeefyBlock;
         currentValidatorSet = _initialValidatorSet;
         nextValidatorSet = _nextValidatorSet;
-        renounceOwnership();
     }
 
     /* Public Functions */

--- a/core/packages/contracts/src/UpdateOutboundFee.sol
+++ b/core/packages/contracts/src/UpdateOutboundFee.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+pragma solidity ^0.8.20;
+
+import {AccessControl} from "openzeppelin/access/AccessControl.sol";
+
+import {UpgradeTask} from "./UpgradeTask.sol";
+import {Registry} from "./Registry.sol";
+import {OutboundQueue} from "./OutboundQueue.sol";
+import {ParaID} from "./Types.sol";
+
+contract UpdateOutboundFee is UpgradeTask {
+    uint256 public fee;
+
+    constructor(Registry registry, uint256 _fee) UpgradeTask(registry) {
+        fee = _fee;
+    }
+
+    function handle(ParaID origin, bytes calldata message) external override onlyRole(SENDER_ROLE) {}
+
+    function run(bytes calldata params) external override {
+        (uint256 _fee) = abi.decode(params, (uint256));
+        OutboundQueue(resolve(keccak256("OutboundQueue"))).updateFee(_fee);
+    }
+
+    function createUpgradeParams() public view override returns (bytes memory) {
+        return abi.encode(fee);
+    }
+}

--- a/core/packages/contracts/src/UpgradeProxy.sol
+++ b/core/packages/contracts/src/UpgradeProxy.sol
@@ -19,6 +19,7 @@ contract UpgradeProxy is Gateway {
 
     struct UpgradePayload {
         address task;
+        bytes params;
     }
 
     error InvalidMessage();
@@ -41,7 +42,7 @@ contract UpgradeProxy is Gateway {
 
         UpgradePayload memory payload = abi.decode(decoded.payload, (UpgradePayload));
 
-        (bool success,) = payload.task.delegatecall(abi.encodeCall(UpgradeTask.run, ()));
+        (bool success,) = payload.task.delegatecall(abi.encodeCall(UpgradeTask.run, (payload.params)));
         if (!success) {
             revert UpgradeFailed();
         }

--- a/core/packages/contracts/src/UpgradeTask.sol
+++ b/core/packages/contracts/src/UpgradeTask.sol
@@ -4,8 +4,22 @@ pragma solidity 0.8.20;
 
 import {Gateway} from "./Gateway.sol";
 import {Registry} from "./Registry.sol";
+import {UpgradeProxy} from "./UpgradeProxy.sol";
 
 abstract contract UpgradeTask is Gateway {
     constructor(Registry registry) Gateway(registry) {}
-    function run() external virtual;
+    function run(bytes calldata params) external virtual;
+
+    function createUpgradeMessage() external view returns (bytes memory) {
+        return abi.encode(
+            UpgradeProxy.Message(
+                UpgradeProxy.Action.Upgrade,
+                abi.encode(UpgradeProxy.UpgradePayload(address(this), createUpgradeParams()))
+            )
+        );
+    }
+
+    function createUpgradeParams() public view virtual returns (bytes memory) {
+        return "0x";
+    }
 }

--- a/core/packages/contracts/test/mocks/UpgradeTaskMock.sol
+++ b/core/packages/contracts/test/mocks/UpgradeTaskMock.sol
@@ -13,7 +13,7 @@ contract UpgradeTaskMock is UpgradeTask {
     function handle(ParaID origin, bytes calldata message) external override onlyRole(SENDER_ROLE) {}
 
     // In this simple upgrade we just update a fee parameter
-    function run() external override {
+    function run(bytes calldata) external override {
         OutboundQueue(resolve(keccak256("OutboundQueue"))).updateFee(2 ether);
     }
 }
@@ -22,7 +22,7 @@ contract FailingUpgradeTaskMock is UpgradeTask {
     constructor(Registry registry) UpgradeTask(registry) {}
     function handle(ParaID origin, bytes calldata message) external override onlyRole(SENDER_ROLE) {}
 
-    function run() external pure override {
+    function run(bytes calldata) external pure override {
         revert("failed");
     }
 }

--- a/core/packages/test/config/launch-config.toml
+++ b/core/packages/test/config/launch-config.toml
@@ -50,7 +50,7 @@ cumulus_based = true
     command = "{{output_bin_dir}}/polkadot-parachain"
     rpc_port = 8081
     ws_port = 11144
-    args = ["--enable-offchain-indexing=true", "--pruning=archive", "--force-authoring", "-lparachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,ethereum-beacon-client=trace,runtime::bridge-hub=trace,runtime::bridge=trace,runtime::bridge-dispatch=trace,bridge=trace,runtime::bridge-messages=trace,runtime=debug"]
+    args = ["--enable-offchain-indexing=true", "--pruning=archive", "--force-authoring", "-lparachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,ethereum-beacon-client=trace,snowbridge-control=trace,runtime::bridge-hub=trace,runtime::bridge=trace,runtime::bridge-dispatch=trace,bridge=trace,runtime::bridge-messages=trace,runtime=debug"]
 
 ## Statemine
 [[parachains]]

--- a/core/packages/test/scripts/update-outbound-fee.sh
+++ b/core/packages/test/scripts/update-outbound-fee.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eu
+
+source scripts/set-env.sh
+source scripts/xcm-helper.sh
+
+upgrade()
+{
+    pushd "$contract_dir"
+    echo "Deploying upgrade contract..."
+    # 0.002ether~=3.75$,unset env variable RELAYER_FEE first
+    local relayer_fee="${RELAYER_FEE:-2000000000000000}"
+    local response=$(forge create --rpc-url $eth_endpoint_http \
+          --constructor-args \
+          $(address_for Registry) \
+          $relayer_fee \
+          --private-key $PRIVATE_KEY \
+          --gas-limit $eth_gas_limit \
+          src/UpdateOutboundFee.sol:UpdateOutboundFee)
+    local upgrade_contract=$(echo $response | awk -F"Deployed to:" '/Deployed to:/{print $2}' | awk -F"Transaction hash" '/Transaction hash/{print $1}' | sed "s/^ *//")
+    echo "upgrade contract deployed to:" $upgrade_contract
+    # cut params from the last 32*2 characters
+    local upgrade_params=$(cast call --rpc-url $eth_endpoint_http $upgrade_contract "createUpgradeParams()"|grep -v "DEBUG"| sed '/^[[:space:]]*$/d' | rev | cut -c 1-64 | rev)
+    echo "upgrade params:" 0x"$upgrade_params"
+    popd
+
+    echo "Sending upgrade call from relaychain governance..."
+    local callindex="3300"
+    local upgrade_task_address=$(echo $upgrade_contract | cut -c3-)
+    local prefix="0180"
+    local upgrade_call="0x$callindex$upgrade_task_address$prefix$upgrade_params"
+    echo "upgrade call:" $upgrade_call
+    send_governance_transact_from_relaychain $bridgehub_para_id "$upgrade_call" 180000000000 900000
+}
+
+if [ -z "${from_start_services:-}" ]; then
+    upgrade
+fi

--- a/parachain/pallets/control/src/benchmarking.rs
+++ b/parachain/pallets/control/src/benchmarking.rs
@@ -14,11 +14,10 @@ mod benchmarks {
 
 	#[benchmark]
 	fn upgrade() -> Result<(), BenchmarkError> {
-		let caller: T::AccountId = whitelisted_caller();
 		let upgrade_task = H160::repeat_byte(3);
 
 		#[extrinsic_call]
-		_(RawOrigin::Signed(caller), upgrade_task);
+		_(RawOrigin::Root, upgrade_task, None);
 
 		Ok(())
 	}

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -90,6 +90,7 @@ func (li *PolkadotListener) scanCommitments(
 				},
 				"validatorSetID": currentValidatorSet,
 			})
+			logEntry.Info("new commitment received")
 			if validatorSetID < currentValidatorSet || validatorSetID > currentValidatorSet+1 {
 				return fmt.Errorf("commitment has unexpected validatorSetID: blockNumber=%v validatorSetID=%v expectedValidatorSetID=%v",
 					committedBeefyBlock,


### PR DESCRIPTION
Some context:

Currently upgrade pattern requires temporarily contract deployed with params hardcoded which is a bit inflexible and not easy to manage, so in this PR we improve this pattern to be parameterized.

Currently beefy checkpoint allows only one-off initialized first time deployed, we may need to force checkpoint anytime at run time(i.e. same as we do for beacon checkpoint).

Currently in `snowbridge-control` pallet we allow upgrade call from any signed account which is risky. In this PR we ensure only root origin allowed and wrap script for demonstrate `UpdateOutboundFee` with the new upgrade pattern(also avaiable as an E2E test case to demonstrate message relayed from polkadot to ethereum).
