### PR TITLE
Remove hardcoded accounts

### DIFF
--- a/core/packages/test/scripts/configure-bridgehub.sh
+++ b/core/packages/test/scripts/configure-bridgehub.sh
@@ -35,18 +35,18 @@ wait_beacon_chain_ready()
 fund_accounts()
 {
     echo "Funding substrate accounts"
-    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account &
-    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key &
-    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key &
-    transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account &
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key
+    transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account
 }
 
 configure_bridgehub()
 {
-    wait_beacon_chain_ready
     fund_accounts
-    config_beacon_checkpoint
     config_inbound_queue
+    wait_beacon_chain_ready
+    config_beacon_checkpoint
 }
 
 if [ -z "${from_start_services:-}" ]; then

--- a/core/packages/test/scripts/configure-bridgehub.sh
+++ b/core/packages/test/scripts/configure-bridgehub.sh
@@ -32,9 +32,19 @@ wait_beacon_chain_ready()
     done
 }
 
-function configure_bridgehub()
+fund_accounts()
+{
+    echo "Funding substrate accounts"
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account &
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key &
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key &
+    transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account &
+}
+
+configure_bridgehub()
 {
     wait_beacon_chain_ready
+    fund_accounts
     config_beacon_checkpoint
     config_inbound_queue
 }

--- a/core/packages/test/scripts/set-env.sh
+++ b/core/packages/test/scripts/set-env.sh
@@ -64,6 +64,8 @@ statemine_sovereign_account="${STATEMINE_SOVEREIGN_ACCOUNT:-0x70617261e803000000
 beacon_relayer_account="${BEACON_RELAYER_ACCOUNT:-//BeaconRelay}"
 # Execution relay account (5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
 execution_relayer_account="${EXECUTION_RELAYER_ACCOUNT:-//ExecutionRelay}"
+# Registry contract account (5EBBfBLm4uV4JMXXcKvZrPVmP9VyER9YSCgGdMUw5wBXnqag in testnet)
+registry_contract_sovereign_account="${REGISTRY_CONTRACT_SOVEREIGN_ACCOUNT:-0x5d6987649e0dac78ddf852eb0f1b1d1bf2be9623d81cb16c17cfa145948bb6dc}"
 
 # Config for deploying contracts
 

--- a/core/packages/test/scripts/set-env.sh
+++ b/core/packages/test/scripts/set-env.sh
@@ -60,10 +60,10 @@ skip_relayer="${SKIP_RELAYER:-false}"
 
 # Account for statemine (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet) 
 statemine_sovereign_account="${STATEMINE_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
-# Beacon relay account (5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
-beacon_relayer_account="${BEACON_RELAYER_ACCOUNT:-//BeaconRelay}"
-# Execution relay account (5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
-execution_relayer_account="${EXECUTION_RELAYER_ACCOUNT:-//ExecutionRelay}"
+# Beacon relay account (//BeaconRelay 5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
+beacon_relayer_pub_key="${BEACON_RELAYER_PUB_KEY:-0xc46e141b5083721ad5f5056ba1cded69dce4a65f027ed3362357605b1687986a}"
+# Execution relay account (//ExecutionRelay 5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
+execution_relayer_pub_key="${EXECUTION_RELAYER_PUB_KEY:-0x08228efd065c58a043da95c8bf177659fc587643e71e7ed1534666177730196f}"
 # Registry contract account (5EBBfBLm4uV4JMXXcKvZrPVmP9VyER9YSCgGdMUw5wBXnqag in testnet)
 registry_contract_sovereign_account="${REGISTRY_CONTRACT_SOVEREIGN_ACCOUNT:-0x5d6987649e0dac78ddf852eb0f1b1d1bf2be9623d81cb16c17cfa145948bb6dc}"
 

--- a/core/packages/test/scripts/set-env.sh
+++ b/core/packages/test/scripts/set-env.sh
@@ -58,7 +58,7 @@ skip_relayer="${SKIP_RELAYER:-false}"
 
 ## Important accounts
 
-# Account for statemine (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet) 
+# Account for statemine (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet)
 statemine_sovereign_account="${STATEMINE_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
 # Beacon relay account (//BeaconRelay 5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
 beacon_relayer_pub_key="${BEACON_RELAYER_PUB_KEY:-0xc46e141b5083721ad5f5056ba1cded69dce4a65f027ed3362357605b1687986a}"

--- a/core/packages/test/scripts/set-env.sh
+++ b/core/packages/test/scripts/set-env.sh
@@ -56,6 +56,15 @@ relaychain_sudo_seed="${RELAYCHAIN_SUDO_SEED:-//Alice}"
 
 skip_relayer="${SKIP_RELAYER:-false}"
 
+## Important accounts
+
+# Account for statemine (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet) 
+statemine_sovereign_account="${STATEMINE_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
+# Beacon relay account (5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
+beacon_relayer_account="${BEACON_RELAYER_ACCOUNT:-//BeaconRelay}"
+# Execution relay account (5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
+execution_relayer_account="${EXECUTION_RELAYER_ACCOUNT:-//ExecutionRelay}"
+
 # Config for deploying contracts
 
 ## Deployment key

--- a/core/packages/test/scripts/start-relayer.sh
+++ b/core/packages/test/scripts/start-relayer.sh
@@ -129,7 +129,7 @@ start_relayer()
         echo "Starting beacon relay at $(date)"
             "${relay_bin}" run beacon \
                 --config $output_dir/beacon-relay.json \
-                --substrate.private-key $beacon_relayer_account \
+                --substrate.private-key "//BeaconRelay" \
                 >> "$output_dir"/beacon-relay.log 2>&1 || true
             sleep 20
         done
@@ -143,7 +143,7 @@ start_relayer()
         echo "Starting execution relay at $(date)"
             "${relay_bin}" run execution \
                 --config $output_dir/execution-relay.json \
-                --substrate.private-key $execution_relayer_account \
+                --substrate.private-key "//ExecutionRelay" \
                 >> "$output_dir"/execution-relay.log 2>&1 || true
             sleep 20
         done

--- a/core/packages/test/scripts/start-relayer.sh
+++ b/core/packages/test/scripts/start-relayer.sh
@@ -129,7 +129,7 @@ start_relayer()
         echo "Starting beacon relay at $(date)"
             "${relay_bin}" run beacon \
                 --config $output_dir/beacon-relay.json \
-                --substrate.private-key "//BeaconRelay" \
+                --substrate.private-key $beacon_relayer_account \
                 >> "$output_dir"/beacon-relay.log 2>&1 || true
             sleep 20
         done
@@ -143,7 +143,7 @@ start_relayer()
         echo "Starting execution relay at $(date)"
             "${relay_bin}" run execution \
                 --config $output_dir/execution-relay.json \
-                --substrate.private-key "//ExecutionRelay" \
+                --substrate.private-key $execution_relayer_account \
                 >> "$output_dir"/execution-relay.log 2>&1 || true
             sleep 20
         done

--- a/core/packages/test/scripts/start-services.sh
+++ b/core/packages/test/scripts/start-services.sh
@@ -5,7 +5,7 @@ start=$(date +%s)
 
 from_start_services=true
 
-source scripts/set-env.sh
+source scripts/xcm-helper.sh
 source scripts/build-binary.sh
 
 trap kill_all SIGINT SIGTERM EXIT
@@ -44,18 +44,25 @@ deploy_polkadot
 echo "Waiting contract deployed"
 wait_contract_deployed
 
-# 5. config beefy client
+# 5. fund substrate accounts
+echo "Funding substrate accounts"
+transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account 
+transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key
+transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key
+transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account
+
+# 6. config beefy client
 echo "Config beefy client"
 source scripts/configure-beefy.sh
 configure_beefy
 
-# 6. config bridgehub 
+# 7. config bridgehub 
 echo "Config bridgehub"
 source scripts/configure-bridgehub.sh
 configure_bridgehub
 
 if [ "$skip_relayer" == "false" ]; then
-    # 7. start relayer
+    # 8. start relayer
     echo "Starting relayers"
     source scripts/start-relayer.sh
     deploy_relayer

--- a/core/packages/test/scripts/start-services.sh
+++ b/core/packages/test/scripts/start-services.sh
@@ -46,7 +46,7 @@ wait_contract_deployed
 
 # 5. fund substrate accounts
 echo "Funding substrate accounts"
-transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account 
+transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account
 transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key
 transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key
 transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account
@@ -56,7 +56,7 @@ echo "Config beefy client"
 source scripts/configure-beefy.sh
 configure_beefy
 
-# 7. config bridgehub 
+# 7. config bridgehub
 echo "Config bridgehub"
 source scripts/configure-bridgehub.sh
 configure_bridgehub

--- a/core/packages/test/scripts/start-services.sh
+++ b/core/packages/test/scripts/start-services.sh
@@ -5,7 +5,7 @@ start=$(date +%s)
 
 from_start_services=true
 
-source scripts/xcm-helper.sh
+source scripts/set-env.sh
 source scripts/build-binary.sh
 
 trap kill_all SIGINT SIGTERM EXIT
@@ -44,25 +44,18 @@ deploy_polkadot
 echo "Waiting contract deployed"
 wait_contract_deployed
 
-# 5. fund substrate accounts
-echo "Funding substrate accounts"
-transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account
-transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key
-transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key
-transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $registry_contract_sovereign_account
-
-# 6. config beefy client
+# 5. config beefy client
 echo "Config beefy client"
 source scripts/configure-beefy.sh
 configure_beefy
 
-# 7. config bridgehub
+# 6. config bridgehub
 echo "Config bridgehub"
 source scripts/configure-bridgehub.sh
 configure_bridgehub
 
 if [ "$skip_relayer" == "false" ]; then
-    # 8. start relayer
+    # 7. start relayer
     echo "Starting relayers"
     source scripts/start-relayer.sh
     deploy_relayer


### PR DESCRIPTION
Removes hardcoded sovereign and relayer accounts. Accounts are funded via `start-services.sh`.

Resolves: SNO-528
Cumulus companion: https://github.com/Snowfork/cumulus/pull/40