### PR TITLE
Upgrade ssz_rs crate.

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -2585,8 +2585,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "ssz-rs",
- "ssz-rs-derive",
+ "ssz_rs",
+ "ssz_rs_derive",
  "static_assertions",
 ]
 
@@ -3255,28 +3255,6 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-xid",
-]
-
-[[package]]
-name = "ssz-rs"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d18af912abacbf84219be37ab3b42a9abcf10d2a#d18af912abacbf84219be37ab3b42a9abcf10d2a"
-dependencies = [
- "bitvec",
- "num-bigint",
- "sha2 0.9.9",
- "ssz-rs-derive",
- "thiserror",
-]
-
-[[package]]
-name = "ssz-rs-derive"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d18af912abacbf84219be37ab3b42a9abcf10d2a#d18af912abacbf84219be37ab3b42a9abcf10d2a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -2676,8 +2676,8 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-std",
- "ssz-rs",
- "ssz-rs-derive",
+ "ssz_rs",
+ "ssz_rs_derive",
  "static_assertions",
 ]
 
@@ -3273,6 +3273,29 @@ dependencies = [
 name = "ssz-rs-derive"
 version = "0.8.0"
 source = "git+https://github.com/ralexstokes/ssz-rs?rev=d18af912abacbf84219be37ab3b42a9abcf10d2a#d18af912abacbf84219be37ab3b42a9abcf10d2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ssz_rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057291e5631f280978fa9c8009390663ca4613359fc1318e36a8c24c392f6d1f"
+dependencies = [
+ "bitvec",
+ "num-bigint",
+ "sha2 0.9.9",
+ "ssz_rs_derive",
+]
+
+[[package]]
+name = "ssz_rs_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07d54c4d01a1713eb363b55ba51595da15f6f1211435b71466460da022aa140"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.164", optional = true }
 codec = { version = "3.1.5", package = "parity-scale-codec", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.7.0", default-features = false, features = [ "derive" ] }
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev="d18af912abacbf84219be37ab3b42a9abcf10d2a" }
-ssz-rs-derive = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev="d18af912abacbf84219be37ab3b42a9abcf10d2a" }
+ssz_rs = { version="0.9.0", default-features = false }
+ssz_rs_derive = { version="0.9.0", default-features = false }
 byte-slice-cast = { version = "1.2.1", default-features = false }
 rlp = { version = "0.5", default-features = false }
 hex-literal = { version = "0.4.1", optional = true }
@@ -56,7 +56,7 @@ std = [
     "snowbridge-core/std",
     "snowbridge-ethereum/std",
     "primitives/std",
-    "ssz-rs/std",
+    "ssz_rs/std",
     "byte-slice-cast/std",
 ]
 runtime-benchmarks = [

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -79,6 +79,12 @@ impl Into<Token> for Message {
 	}
 }
 
+impl From<u32> for AggregateMessageOrigin {
+	fn from(value: u32) -> Self {
+		AggregateMessageOrigin::Parachain(value.into())
+	}
+}
+
 /// The maximal length of an enqueued message, as determined by the MessageQueue pallet
 pub type MaxEnqueuedMessageSizeOf<T> =
 	<<T as Config>::MessageQueue as EnqueueMessage<AggregateMessageOrigin>>::MaxMessageLen;

--- a/parachain/primitives/beacon/Cargo.toml
+++ b/parachain/primitives/beacon/Cargo.toml
@@ -18,8 +18,8 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
 
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev = "d18af912abacbf84219be37ab3b42a9abcf10d2a" }
-ssz-rs-derive = { git = "https://github.com/ralexstokes/ssz-rs", default-features = false, rev = "d18af912abacbf84219be37ab3b42a9abcf10d2a" }
+ssz_rs = { version="0.9.0", default-features = false }
+ssz_rs_derive = { version="0.9.0", default-features = false }
 byte-slice-cast = { version = "1.2.1", default-features = false }
 
 snowbridge-ethereum = { path = "../../primitives/ethereum", default-features = false }
@@ -43,7 +43,7 @@ std = [
     "sp-io/std",
     "rlp/std",
     "snowbridge-ethereum/std",
-    "ssz-rs/std",
+    "ssz_rs/std",
     "byte-slice-cast/std",
     "milagro_bls/std",
 ]

--- a/parachain/primitives/beacon/src/types.rs
+++ b/parachain/primitives/beacon/src/types.rs
@@ -19,7 +19,7 @@ use crate::ssz::{
 	hash_tree_root, SSZBeaconBlockHeader, SSZExecutionPayloadHeader, SSZForkData, SSZSigningData,
 	SSZSyncAggregate, SSZSyncCommittee,
 };
-use ssz_rs::MerkleizationError;
+use ssz_rs::SimpleSerializeError;
 
 pub use crate::bits::decompress_sync_committee_bits;
 
@@ -131,7 +131,7 @@ pub struct ForkData {
 }
 
 impl ForkData {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
 		hash_tree_root::<SSZForkData>(self.clone().into())
 	}
 }
@@ -143,7 +143,7 @@ pub struct SigningData {
 }
 
 impl SigningData {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
 		hash_tree_root::<SSZSigningData>(self.clone().into())
 	}
 }
@@ -174,7 +174,7 @@ impl<const COMMITTEE_SIZE: usize> Default for SyncCommittee<COMMITTEE_SIZE> {
 }
 
 impl<const COMMITTEE_SIZE: usize> SyncCommittee<COMMITTEE_SIZE> {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
 		hash_tree_root::<SSZSyncCommittee<COMMITTEE_SIZE>>(self.clone().into())
 	}
 }
@@ -235,7 +235,7 @@ pub struct BeaconHeader {
 }
 
 impl BeaconHeader {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
 		hash_tree_root::<SSZBeaconBlockHeader>((*self).into())
 	}
 }
@@ -271,7 +271,7 @@ impl<const COMMITTEE_SIZE: usize, const COMMITTEE_BITS_SIZE: usize> Default
 impl<const COMMITTEE_SIZE: usize, const COMMITTEE_BITS_SIZE: usize>
 	SyncAggregate<COMMITTEE_SIZE, COMMITTEE_BITS_SIZE>
 {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
 		hash_tree_root::<SSZSyncAggregate<COMMITTEE_SIZE>>(self.clone().into())
 	}
 }
@@ -335,8 +335,8 @@ pub struct ExecutionPayloadHeader {
 }
 
 impl ExecutionPayloadHeader {
-	pub fn hash_tree_root(&self) -> Result<H256, MerkleizationError> {
-		hash_tree_root::<SSZExecutionPayloadHeader>(self.clone().into())
+	pub fn hash_tree_root(&self) -> Result<H256, SimpleSerializeError> {
+		hash_tree_root::<SSZExecutionPayloadHeader>(self.clone().try_into()?)
 	}
 }
 


### PR DESCRIPTION
Updates the ssz_rs crate to 0.9.0. The crate name was also changed again from `ssz-rs` back to `ssz_rs`.
Cumulus companion: https://github.com/Snowfork/cumulus/pull/42