### PR TITLE
Bump nixpkgs to use its geth package

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -2,8 +2,8 @@
   "name": "@snowbridge/core",
   "private": true,
   "engines": {
-    "node": "v18.16.0",
-    "pnpm": "8.4.0"
+    "node": "v18.16.1",
+    "pnpm": "8.6.6"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/core/packages/test/scripts/build-binary.sh
+++ b/core/packages/test/scripts/build-binary.sh
@@ -59,19 +59,9 @@ build_relayer()
     cp $relay_bin "$output_bin_dir"
 }
 
-build_geth() {
-    if [ ! -f "$geth_dir/geth" ]; then
-        echo "Building geth binary"
-        mkdir -p $geth_dir
-        GOBIN=$geth_dir go install -v -x github.com/ethereum/go-ethereum/cmd/geth@$geth_version
-    fi
-    cp "$geth_dir/geth" "$output_bin_dir"
-}
-
 install_binary() {
     echo "Building and installing binaries."
     mkdir -p $output_bin_dir
-    build_geth
     build_cumulus_from_source
     build_relaychain
     build_relayer

--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1683408522,
-        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "lastModified": 1689534811,
+        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
 
                     # ethereum
                     foundry-bin
-                    # go-ethereum
+                    go-ethereum
                     # gnupg for forge install
                     gnupg
 


### PR DESCRIPTION
This comes with Node & pnpm version bumps because we're updating nixpkgs, but they're unlikely to cause issues. Still tracking down the BEEFY relayer failure as it affects this section of the upgrades.