### PR TITLE
Replace rust overlay with rustup package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,24 +30,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -97,62 +79,11 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1690683485,
-        "narHash": "sha256-Sp/QpbMg86v12xhCsa6q0yTH8LYaJIcxzbf9LO1zFzM=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "05d480a7aef1aae1bfb67a39134dcf48c5322528",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,23 +3,23 @@
 
     inputs = {
         nixpkgs.url = "nixpkgs/nixos-unstable";
-        rust-overlay.url = "github:oxalica/rust-overlay";
         flake-utils.url  = "github:numtide/flake-utils";
         foundry.url = "github:shazow/foundry.nix/monthly";
     };
 
-    outputs = { self, nixpkgs, rust-overlay, flake-utils, foundry }:
+    outputs = { self, nixpkgs, flake-utils, foundry }:
+
     let
         supportedSystems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
-        overlays = [ (import rust-overlay) foundry.overlay ];
+        overlays = [ foundry.overlay ];
     in
+
     flake-utils.lib.eachSystem supportedSystems (system:
         let
             pkgs = import nixpkgs { inherit system overlays; };
             cwd = builtins.toString ./.;
-            rust =
-              pkgs.rust-bin.fromRustupToolchainFile "${cwd}/rust-toolchain.toml";
         in
+
         with pkgs;
         {
             devShells.default = pkgs.mkShell {
@@ -65,7 +65,7 @@
                     gcc
                     libiconv
                     protobuf
-                    rust
+                    rustup
 
                     cowsay
                 ];


### PR DESCRIPTION
Turns out things work just fine without the overlay. Please test this on your machines though in case I missed something when cleaning.

After a `git clean` and `rustup self uninstall`, the E2E env starts up in a pure shell (with no local Rust installation) and smoketests build & pass. The only errors I got were from forgetting to run the `init.sh` and `make-bindings.sh` scripts, but those are already mentioned in the READMEs 😅 

One issue I can think of is if the Nix rustup version in an impure shell behaves in a way that conflicts with a local one. This seems unlikely, but I've reinstalled Rust locally & compiled other projects, then switched back to Snowbridge in an impure shell and the E2E stack still works.