### PR TITLE
Uniform Interface submit beefy commitment

### DIFF
--- a/contracts/src/BeefyClient.sol
+++ b/contracts/src/BeefyClient.sol
@@ -200,10 +200,10 @@ contract BeefyClient {
         nextValidatorSet = _nextValidatorSet;
     }
 
-    /* Public Functions */
+    /* External Functions */
 
     /**
-     * @dev Begin submission of commitment that was signed by the current validator set
+     * @dev Begin submission of commitment
      * @param commitment contains the commitment signed by the validators
      * @param bitfield a bitfield claiming which validators have signed the commitment
      * @param proof a proof that a single validator from currentValidatorSet has signed the commitment
@@ -211,29 +211,13 @@ contract BeefyClient {
     function submitInitial(Commitment calldata commitment, uint256[] calldata bitfield, ValidatorProof calldata proof)
         external
     {
-        doSubmitInitial(currentValidatorSet, commitment, bitfield, proof);
-    }
+        if (commitment.validatorSetID != currentValidatorSet.id && commitment.validatorSetID != nextValidatorSet.id) {
+            revert InvalidCommitment();
+        }
 
-    /**
-     * @dev Begin submission of commitment that was signed by the next validator set
-     * @param commitment contains the commitment signed by the validators
-     * @param bitfield a bitfield claiming which validators have signed the commitment
-     * @param proof a proof that a single validator from nextValidatorSet has signed the commitment
-     */
-    function submitInitialWithHandover(
-        Commitment calldata commitment,
-        uint256[] calldata bitfield,
-        ValidatorProof calldata proof
-    ) external {
-        doSubmitInitial(nextValidatorSet, commitment, bitfield, proof);
-    }
+        bool is_next_validator_set = commitment.validatorSetID == nextValidatorSet.id;
+        ValidatorSet memory vset = is_next_validator_set ? nextValidatorSet : currentValidatorSet;
 
-    function doSubmitInitial(
-        ValidatorSet memory vset,
-        Commitment calldata commitment,
-        uint256[] calldata bitfield,
-        ValidatorProof calldata proof
-    ) internal {
         // Check if merkle proof is valid based on the validatorSetRoot and if proof is included in bitfield
         if (!isValidatorInSet(vset, proof.account, proof.index, proof.proof) || !Bitfield.isSet(bitfield, proof.index))
         {
@@ -289,32 +273,6 @@ contract BeefyClient {
     }
 
     /**
-     * @dev Submit a commitment for final verification
-     * @param commitment contains the full commitment that was used for the commitmentHash
-     * @param bitfield a bitfield claiming which validators have signed the commitment
-     * @param proofs a struct containing the data needed to verify all validator signatures
-     */
-    function submitFinal(Commitment calldata commitment, uint256[] calldata bitfield, ValidatorProof[] calldata proofs)
-        public
-    {
-        (bytes32 commitmentHash, bytes32 ticketID) = validate(commitment, bitfield);
-
-        Ticket storage ticket = tickets[ticketID];
-
-        if (commitment.validatorSetID != currentValidatorSet.id) {
-            revert InvalidCommitment();
-        }
-        verifyCommitment(commitmentHash, bitfield, currentValidatorSet, ticket, proofs);
-
-        bytes32 newMMRRoot = getFirstMMRRoot(commitment);
-        latestMMRRoot = newMMRRoot;
-        latestBeefyBlock = commitment.blockNumber;
-
-        emit NewMMRRoot(newMMRRoot, commitment.blockNumber);
-        delete tickets[ticketID];
-    }
-
-    /**
      * @dev Submit a commitment and leaf for final verification
      * @param commitment contains the full commitment that was used for the commitmentHash
      * @param bitfield claiming which validators have signed the commitment
@@ -323,26 +281,32 @@ contract BeefyClient {
      * @param leafProof an MMR leaf proof
      * @param leafProofOrder a bitfield describing the order of each item (left vs right)
      */
-    function submitFinalWithHandover(
+    function submitFinal(
         Commitment calldata commitment,
         uint256[] calldata bitfield,
         ValidatorProof[] calldata proofs,
         MMRLeaf calldata leaf,
         bytes32[] calldata leafProof,
         uint256 leafProofOrder
-    ) public {
+    ) external {
         (bytes32 commitmentHash, bytes32 ticketID) = validate(commitment, bitfield);
 
         Ticket storage ticket = tickets[ticketID];
 
-        if (commitment.validatorSetID != nextValidatorSet.id) {
+        if (commitment.validatorSetID != currentValidatorSet.id && commitment.validatorSetID != nextValidatorSet.id) {
             revert InvalidCommitment();
         }
-        verifyCommitment(commitmentHash, bitfield, nextValidatorSet, ticket, proofs);
 
-        if (leaf.nextAuthoritySetID != nextValidatorSet.id + 1) {
+        bool is_next_validator_set = commitment.validatorSetID == nextValidatorSet.id;
+
+        verifyCommitment(
+            commitmentHash, bitfield, is_next_validator_set ? nextValidatorSet : currentValidatorSet, ticket, proofs
+        );
+
+        if (is_next_validator_set && leaf.nextAuthoritySetID != nextValidatorSet.id + 1) {
             revert InvalidMMRLeaf();
         }
+
         bytes32 newMMRRoot = getFirstMMRRoot(commitment);
         bool leafIsValid =
             MMRProof.verifyLeafProof(newMMRRoot, keccak256(encodeMMRLeaf(leaf)), leafProof, leafProofOrder);
@@ -350,16 +314,18 @@ contract BeefyClient {
             revert InvalidMMRLeafProof();
         }
 
-        currentValidatorSet = nextValidatorSet;
-        nextValidatorSet.id = leaf.nextAuthoritySetID;
-        nextValidatorSet.length = leaf.nextAuthoritySetLen;
-        nextValidatorSet.root = leaf.nextAuthoritySetRoot;
+        if (is_next_validator_set) {
+            currentValidatorSet = nextValidatorSet;
+            nextValidatorSet.id = leaf.nextAuthoritySetID;
+            nextValidatorSet.length = leaf.nextAuthoritySetLen;
+            nextValidatorSet.root = leaf.nextAuthoritySetRoot;
+        }
 
         latestMMRRoot = newMMRRoot;
         latestBeefyBlock = commitment.blockNumber;
+        delete tickets[ticketID];
 
         emit NewMMRRoot(newMMRRoot, commitment.blockNumber);
-        delete tickets[ticketID];
     }
 
     /**
@@ -411,7 +377,7 @@ contract BeefyClient {
         );
     }
 
-    /* Private Functions */
+    /* Internal Functions */
 
     // Creates a unique ticket ID for a new interactive prover-verifier session
     function createTicketID(address account, bytes32 commitmentHash) internal pure returns (bytes32 value) {

--- a/contracts/test/BeefyClient.t.sol
+++ b/contracts/test/BeefyClient.t.sol
@@ -174,7 +174,7 @@ contract BeefyClientTest is Test {
 
         createFinalProofs();
 
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
 
         assertEq(beefyClient.latestBeefyBlock(), blockNumber);
         return commitment;
@@ -195,7 +195,7 @@ contract BeefyClientTest is Test {
         // make an invalid signature
         finalValidatorProofs[0].r = 0xb5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c;
         vm.expectRevert(BeefyClient.InvalidSignature.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailValidatorNotInBitfield() public {
@@ -213,7 +213,7 @@ contract BeefyClientTest is Test {
         // make an invalid validator index
         finalValidatorProofs[0].index = 0;
         vm.expectRevert(BeefyClient.InvalidValidatorProof.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithStaleCommitment() public {
@@ -229,7 +229,7 @@ contract BeefyClientTest is Test {
 
         //submit again will be reverted with StaleCommitment
         vm.expectRevert(BeefyClient.StaleCommitment.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithInvalidBitfield() public {
@@ -246,7 +246,7 @@ contract BeefyClientTest is Test {
         // invalid bitfield here
         bitfield[0] = 0;
         vm.expectRevert(BeefyClient.InvalidBitfield.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithoutPrevRandao() public {
@@ -256,7 +256,7 @@ contract BeefyClientTest is Test {
 
         // reverted without commit PrevRandao
         vm.expectRevert(BeefyClient.PrevRandaoNotCaptured.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailForPrevRandaoTooEarlyOrTooLate() public {
@@ -288,7 +288,7 @@ contract BeefyClientTest is Test {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.roll(block.number + randaoCommitDelay);
 
@@ -296,9 +296,7 @@ contract BeefyClientTest is Test {
 
         createFinalProofs();
 
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
         assertEq(beefyClient.latestBeefyBlock(), blockNumber);
     }
 
@@ -306,19 +304,17 @@ contract BeefyClientTest is Test {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.expectRevert(BeefyClient.PrevRandaoNotCaptured.selector);
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitWithHandoverFailStaleCommitment() public {
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
         beefyClient.setLatestBeefyBlock(blockNumber);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.roll(block.number + randaoCommitDelay);
 
@@ -327,9 +323,7 @@ contract BeefyClientTest is Test {
         createFinalProofs();
 
         vm.expectRevert(BeefyClient.StaleCommitment.selector);
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testScaleEncodeCommit() public {
@@ -396,14 +390,14 @@ contract BeefyClientTest is Test {
         initialize(setId + 1);
         //submit will be reverted with InvalidCommitment
         vm.expectRevert(BeefyClient.InvalidCommitment.selector);
-        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitWithHandoverFailWithInvalidValidatorSet() public {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.roll(block.number + randaoCommitDelay);
         commitPrevRandao();
@@ -411,12 +405,10 @@ contract BeefyClientTest is Test {
         createFinalProofs();
 
         //reinitialize with next validator set
-        initialize(setId);
+        initialize(setId + 1);
         //submit will be reverted with InvalidCommitment
         vm.expectRevert(BeefyClient.InvalidCommitment.selector);
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithInvalidTicket() public {
@@ -433,14 +425,14 @@ contract BeefyClientTest is Test {
         BeefyClient.Commitment memory _commitment = BeefyClient.Commitment(blockNumber, setId + 1, commitment.payload);
         //submit will be reverted with InvalidTicket
         vm.expectRevert(BeefyClient.InvalidTicket.selector);
-        beefyClient.submitFinal(_commitment, bitfield, finalValidatorProofs);
+        beefyClient.submitFinal(_commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithInvalidMMRLeaf() public {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.roll(block.number + randaoCommitDelay);
 
@@ -454,16 +446,14 @@ contract BeefyClientTest is Test {
         mmrLeaf.nextAuthoritySetID = setId;
         //submit will be reverted with InvalidCommitment
         vm.expectRevert(BeefyClient.InvalidMMRLeaf.selector);
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithInvalidMMRLeafProof() public {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);
 
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
+        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
 
         vm.roll(block.number + randaoCommitDelay);
 
@@ -475,9 +465,7 @@ contract BeefyClientTest is Test {
         mmrLeaf.parentNumber = 1;
         //submit will be reverted with InvalidCommitment
         vm.expectRevert(BeefyClient.InvalidMMRLeafProof.selector);
-        beefyClient.submitFinalWithHandover(
-            commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder
-        );
+        beefyClient.submitFinal(commitment, bitfield, finalValidatorProofs, mmrLeaf, mmrLeafProofs, leafProofOrder);
     }
 
     function testSubmitFailWithNotEnoughClaims() public {
@@ -487,20 +475,6 @@ contract BeefyClientTest is Test {
         printBitArray(initialBits);
         vm.expectRevert(BeefyClient.NotEnoughClaims.selector);
         beefyClient.submitInitial(commitment, initialBits, finalValidatorProofs[0]);
-    }
-
-    function testSubmitInitialFailWithIncorrectValidatorSet() public {
-        BeefyClient.Commitment memory commitment = initialize(setId);
-
-        vm.expectRevert(BeefyClient.InvalidCommitment.selector);
-        beefyClient.submitInitialWithHandover(commitment, bitfield, finalValidatorProofs[0]);
-    }
-
-    function testSubmitInitialHandoverFailWithIncorrectValidatorSet() public {
-        BeefyClient.Commitment memory commitment = initialize(setId - 1);
-
-        vm.expectRevert(BeefyClient.InvalidCommitment.selector);
-        beefyClient.submitInitial(commitment, bitfield, finalValidatorProofs[0]);
     }
 
     function testRegenerateBitField() public {


### PR DESCRIPTION
### Context

Currently in beefy light client there are two different interfaces for submit beefy commitment with or without handover. I would assume actually there is no big difference between the two branches except for the mmrLeaf verification. 

Furthurmore, IMO it's more secure to also verify mmrLeaf for the non-handover case. So this PR unify the two interfaces to one and it will also make logic in beefy relayer a bit more simple.

The idea here could be immature with something important missing so would like to get some feedback from team before furthur refactor(i.e. revamp and simplify beefy relayer accordingly).

