### PR TITLE
SNO-612: Extend sendToken for Polkadot-native assets

### DIFF
--- a/contracts/src/Agent.sol
+++ b/contracts/src/Agent.sol
@@ -8,6 +8,8 @@ pragma solidity 0.8.20;
 contract Agent {
     error Unauthorized();
 
+    // NOTE: These variables must match those in AgentExecutor.sol, in type, name & order of declaration.
+
     /// @dev The unique ID for this agent, derived from the MultiLocation of the corresponding consensus system on Polkadot
     bytes32 public immutable AGENT_ID;
 

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -47,6 +47,10 @@ contract AgentExecutor {
         emit TokenRegistered(address(this), address(token));
     }
 
+    function burnToken(address token, uint256 amount) external {
+        ERC20(token).burn(token, amount);
+    }
+
     /// @dev Mint ERC20 `token` and transfer to `recipient`. Only callable via `execute`.
     function _mintToken(address token, address recipient, uint256 amount) internal {
         ERC20(token).mint(recipient, amount);

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -47,8 +47,8 @@ contract AgentExecutor {
         emit TokenRegistered(address(this), address(token));
     }
 
-    function burnToken(address token, uint256 amount) external {
-        ERC20(token).burn(token, amount);
+    function burnToken(address token, address sender, uint256 amount) external {
+        ERC20(token).burn(sender, amount);
     }
 
     /// @dev Mint ERC20 `token` and transfer to `recipient`. Only callable via `execute`.

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -36,8 +36,9 @@ contract AgentExecutor {
             (address token, address recipient, uint128 amount) = abi.decode(params, (address, address, uint128));
             _transferToken(token, recipient, amount);
         } else if (command == AgentExecuteCommand.RegisterToken) {
-            (string memory name, string memory symbol, uint8 decimals) = abi.decode(params, (string, string, uint8));
-            _registerToken(name, symbol, decimals);
+            (bytes32 tokenID, string memory name, string memory symbol, uint8 decimals) =
+                abi.decode(params, (bytes32, string, string, uint8));
+            _registerToken(tokenID, name, symbol, decimals);
         } else if (command == AgentExecuteCommand.MintToken) {
             (address token, address recipient, uint256 amount) = abi.decode(params, (address, address, uint256));
             _mintToken(token, recipient, amount);
@@ -57,9 +58,9 @@ contract AgentExecutor {
     }
 
     /// @dev Create a new ERC20 token with this agent as the owner.
-    function _registerToken(string memory name, string memory symbol, uint8 decimals) internal {
+    function _registerToken(bytes32 tokenID, string memory name, string memory symbol, uint8 decimals) internal {
         IERC20 token = new ERC20(name, symbol, decimals);
-        Gateway(GATEWAY).setTokenOwnerAgentID(address(token), AGENT_ID);
+        Gateway(GATEWAY).registerToken(tokenID, address(token), AGENT_ID);
         emit TokenRegistered(address(this), address(token));
     }
 

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -32,16 +32,16 @@ contract AgentExecutor {
     function execute(address, bytes memory data) external {
         (AgentExecuteCommand command, bytes memory params) = abi.decode(data, (AgentExecuteCommand, bytes));
 
-        if (command == AgentExecuteCommand.TransferToken) {
-            (address token, address recipient, uint128 amount) = abi.decode(params, (address, address, uint128));
-            _transferToken(token, recipient, amount);
-        } else if (command == AgentExecuteCommand.RegisterToken) {
+        if (command == AgentExecuteCommand.RegisterToken) {
             (bytes32 tokenID, string memory name, string memory symbol, uint8 decimals) =
                 abi.decode(params, (bytes32, string, string, uint8));
             _registerToken(tokenID, name, symbol, decimals);
         } else if (command == AgentExecuteCommand.MintToken) {
             (bytes32 tokenID, address recipient, uint256 amount) = abi.decode(params, (bytes32, address, uint256));
             _mintToken(tokenID, recipient, amount);
+        } else if (command == AgentExecuteCommand.TransferToken) {
+            (address token, address recipient, uint128 amount) = abi.decode(params, (address, address, uint128));
+            _transferToken(token, recipient, amount);
         }
     }
 

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -40,8 +40,8 @@ contract AgentExecutor {
                 abi.decode(params, (bytes32, string, string, uint8));
             _registerToken(tokenID, name, symbol, decimals);
         } else if (command == AgentExecuteCommand.MintToken) {
-            (address token, address recipient, uint256 amount) = abi.decode(params, (address, address, uint256));
-            _mintToken(token, recipient, amount);
+            (bytes32 tokenID, address recipient, uint256 amount) = abi.decode(params, (bytes32, address, uint256));
+            _mintToken(tokenID, recipient, amount);
         }
     }
 
@@ -65,7 +65,8 @@ contract AgentExecutor {
     }
 
     /// @dev Mint ERC20 `token` and transfer to `recipient`. Only callable via `execute`.
-    function _mintToken(address token, address recipient, uint256 amount) internal {
+    function _mintToken(bytes32 tokenID, address recipient, uint256 amount) internal {
+        address token = Gateway(GATEWAY).getTokenAddress(tokenID);
         ERC20(token).mint(recipient, amount);
     }
 

--- a/contracts/src/AgentExecutor.sol
+++ b/contracts/src/AgentExecutor.sol
@@ -27,9 +27,6 @@ contract AgentExecutor {
         if (command == AgentExecuteCommand.TransferToken) {
             (address token, address recipient, uint128 amount) = abi.decode(params, (address, address, uint128));
             _transferToken(token, recipient, amount);
-        } else if (command == AgentExecuteCommand.RegisterToken) {
-            (string memory name, string memory symbol, uint8 decimals) = abi.decode(params, (string, string, uint8));
-            _registerToken(name, symbol, decimals);
         } else if (command == AgentExecuteCommand.MintToken) {
             (address token, address recipient, uint256 amount) = abi.decode(params, (address, address, uint256));
             _mintToken(token, recipient, amount);
@@ -44,6 +41,12 @@ contract AgentExecutor {
         recipient.safeNativeTransfer(amount);
     }
 
+    /// @dev Create a new ERC20 token with this agent as the owner.
+    function registerToken(string memory name, string memory symbol, uint8 decimals) external {
+        IERC20 token = new ERC20(name, symbol, decimals);
+        emit TokenRegistered(address(this), address(token));
+    }
+
     /// @dev Mint ERC20 `token` and transfer to `recipient`. Only callable via `execute`.
     function _mintToken(address token, address recipient, uint256 amount) internal {
         ERC20(token).mint(recipient, amount);
@@ -52,10 +55,5 @@ contract AgentExecutor {
     /// @dev Transfer ERC20 to `recipient`. Only callable via `execute`.
     function _transferToken(address token, address recipient, uint128 amount) internal {
         IERC20(token).safeTransfer(recipient, amount);
-    }
-
-    function _registerToken(string memory name, string memory symbol, uint8 decimals) internal {
-        IERC20 token = new ERC20(name, symbol, decimals);
-        emit TokenRegistered(address(this), address(token));
     }
 }

--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -53,8 +53,10 @@ library Assets {
         AssetsStorage.Layout storage $ = AssetsStorage.layout();
 
         if (tokenOwnerAgentID == bytes32(0)) {
+            // Ethereum-native token: transfer to agent
             _transferToAgent(agent, token, sender, amount);
         } else {
+            // Polkadot-native token: burn wrapped token
             _burn(agentExecutor, agent, token, sender, amount);
         }
 
@@ -85,8 +87,10 @@ library Assets {
         }
 
         if (tokenOwnerAgentID == bytes32(0)) {
+            // Ethereum-native token: transfer to agent
             _transferToAgent(agent, token, sender, amount);
         } else {
+            // Polkadot-native token: burn wrapped token
             _burn(agentExecutor, agent, token, sender, amount);
         }
 

--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -55,7 +55,7 @@ library Assets {
         if (tokenOwnerAgentID == bytes32(0)) {
             _transferToAgent(agent, token, sender, amount);
         } else {
-            _burn(agentExecutor, agent, token, amount);
+            _burn(agentExecutor, agent, token, sender, amount);
         }
 
         if (destinationChain == assetHubParaID) {
@@ -87,7 +87,7 @@ library Assets {
         if (tokenOwnerAgentID == bytes32(0)) {
             _transferToAgent(agent, token, sender, amount);
         } else {
-            _burn(agentExecutor, agent, token, amount);
+            _burn(agentExecutor, agent, token, sender, amount);
         }
 
         payload = SubstrateTypes.SendToken(address(this), token, destinationChain, destinationAddress, amount);
@@ -108,8 +108,8 @@ library Assets {
         IERC20(token).safeTransferFrom(sender, agent, amount);
     }
 
-    function _burn(address agentExecutor, address agent, address token, uint256 amount) internal {
-        bytes memory call = abi.encodeCall(AgentExecutor.burnToken, (token, amount));
+    function _burn(address agentExecutor, address agent, address token, address sender, uint256 amount) internal {
+        bytes memory call = abi.encodeCall(AgentExecutor.burnToken, (token, sender, amount));
         (bool success, bytes memory returndata) = (Agent(payable(agent)).invoke(agentExecutor, call));
         Call.verifyResult(success, returndata);
     }

--- a/contracts/src/ERC20.sol
+++ b/contracts/src/ERC20.sol
@@ -89,7 +89,7 @@ contract ERC20 is IERC20, IERC20Permit {
      *
      * Requirements:
      *
-     * - `to` cannot be the zero address.
+     * - `account` cannot be the zero address.
      */
     function mint(address account, uint256 amount) external virtual onlyOwner {
         _mint(account, amount);
@@ -260,7 +260,7 @@ contract ERC20 is IERC20, IERC20Permit {
      *
      * Requirements:
      *
-     * - `to` cannot be the zero address.
+     * - `account` cannot be the zero address.
      */
     function _mint(address account, uint256 amount) internal virtual {
         if (account == address(0)) revert InvalidAccount();

--- a/contracts/src/ERC20.sol
+++ b/contracts/src/ERC20.sol
@@ -96,6 +96,22 @@ contract ERC20 is IERC20, IERC20Permit {
     }
 
     /**
+     * @dev Destroys `amount` tokens from `account` by transferring them to
+     * the zero address, reducing the total supply. Can only be called by
+     * the owner.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function burn(address account, uint256 amount) external virtual onlyOwner {
+        _burn(account, amount);
+    }
+
+    /**
      * @dev See {IERC20-transfer}.
      *
      * Requirements:

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -424,6 +424,11 @@ contract Gateway is IGateway, IInitializable {
         $.ownerAgentIDs[token] = agentID;
     }
 
+    function getTokenAddress(bytes32 tokenID) external view returns (address) {
+        CoreStorage.Layout storage $ = CoreStorage.layout();
+        return $.tokens[tokenID];
+    }
+
     /**
      * Assets
      */

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -413,13 +413,14 @@ contract Gateway is IGateway, IInitializable {
     }
 
     // @dev Register a new fungible Polkadot token for an agent
-    function setTokenOwnerAgentID(address token, bytes32 agentID) external {
+    function registerToken(bytes32 tokenID, address token, bytes32 agentID) external {
         CoreStorage.Layout storage $ = CoreStorage.layout();
 
-        if ($.ownerAgentIDs[token] != bytes32(0)) {
+        if ($.tokens[tokenID] != address(0) || $.ownerAgentIDs[token] != bytes32(0)) {
             revert TokenAlreadyRegistered();
         }
 
+        $.tokens[tokenID] = token;
         $.ownerAgentIDs[token] = agentID;
     }
 
@@ -473,8 +474,8 @@ contract Gateway is IGateway, IInitializable {
         payable
     {
         CoreStorage.Layout storage $ = CoreStorage.layout();
-        bytes32 tokenOwnerAgentID = $.ownerAgentIDs[token];
 
+        bytes32 tokenOwnerAgentID = $.ownerAgentIDs[token];
         address agent;
         if (tokenOwnerAgentID == bytes32(0)) {
             agent = $.agents[ASSET_HUB_AGENT_ID];

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -462,10 +462,28 @@ contract Gateway is IGateway, IInitializable {
         payable
     {
         CoreStorage.Layout storage $ = CoreStorage.layout();
-        address assetHubAgent = $.agents[ASSET_HUB_AGENT_ID];
+
+        bytes32 tokenOwnerAgentID = $.ownerAgentIDs[token];
+        address agent;
+        if (tokenOwnerAgentID == bytes32(0)) {
+            agent = $.agents[ASSET_HUB_AGENT_ID];
+        } else {
+            agent = $.agents[tokenOwnerAgentID];
+            if (agent == address(0)) {
+                revert AgentDoesNotExist();
+            }
+        }
 
         (bytes memory payload, uint256 extraFee) = Assets.sendToken(
-            ASSET_HUB_PARA_ID, assetHubAgent, token, msg.sender, destinationChain, destinationAddress, amount
+            ASSET_HUB_PARA_ID,
+            agent,
+            AGENT_EXECUTOR,
+            tokenOwnerAgentID,
+            token,
+            msg.sender,
+            destinationChain,
+            destinationAddress,
+            amount
         );
 
         _submitOutbound(ASSET_HUB_PARA_ID, payload, extraFee);
@@ -477,10 +495,28 @@ contract Gateway is IGateway, IInitializable {
         payable
     {
         CoreStorage.Layout storage $ = CoreStorage.layout();
-        address assetHubAgent = $.agents[ASSET_HUB_AGENT_ID];
+        bytes32 tokenOwnerAgentID = $.ownerAgentIDs[token];
+
+        address agent;
+        if (tokenOwnerAgentID == bytes32(0)) {
+            agent = $.agents[ASSET_HUB_AGENT_ID];
+        } else {
+            agent = $.agents[tokenOwnerAgentID];
+            if (agent == address(0)) {
+                revert AgentDoesNotExist();
+            }
+        }
 
         (bytes memory payload, uint256 extraFee) = Assets.sendToken(
-            ASSET_HUB_PARA_ID, assetHubAgent, token, msg.sender, destinationChain, destinationAddress, amount
+            ASSET_HUB_PARA_ID,
+            agent,
+            AGENT_EXECUTOR,
+            tokenOwnerAgentID,
+            token,
+            msg.sender,
+            destinationChain,
+            destinationAddress,
+            amount
         );
 
         _submitOutbound(ASSET_HUB_PARA_ID, payload, extraFee);

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -160,6 +160,11 @@ contract Gateway is IGateway, IInitializable {
             catch {
                 success = false;
             }
+        } else if (message.command == Command.Upgrade) {
+            try Gateway(this).upgrade{gas: DISPATCH_GAS}(message.params) {}
+            catch {
+                success = false;
+            }
         } else if (message.command == Command.SetOperatingMode) {
             try Gateway(this).setOperatingMode{gas: DISPATCH_GAS}(message.params) {}
             catch {
@@ -167,11 +172,6 @@ contract Gateway is IGateway, IInitializable {
             }
         } else if (message.command == Command.TransferNativeFromAgent) {
             try Gateway(this).transferNativeFromAgent{gas: DISPATCH_GAS}(message.params) {}
-            catch {
-                success = false;
-            }
-        } else if (message.command == Command.Upgrade) {
-            try Gateway(this).upgrade{gas: DISPATCH_GAS}(message.params) {}
             catch {
                 success = false;
             }

--- a/contracts/src/Types.sol
+++ b/contracts/src/Types.sol
@@ -63,10 +63,10 @@ struct Config {
 /// @dev Messages from Polkadot take the form of these commands.
 enum Command {
     AgentExecute,
-    Upgrade,
     CreateAgent,
     CreateChannel,
     UpdateChannel,
+    Upgrade,
     SetOperatingMode,
     TransferNativeFromAgent
 }

--- a/contracts/src/Types.sol
+++ b/contracts/src/Types.sol
@@ -73,7 +73,7 @@ enum Command {
 }
 
 enum AgentExecuteCommand {
-    TransferToken,
     RegisterToken,
-    MintToken
+    MintToken,
+    TransferToken
 }

--- a/contracts/src/Types.sol
+++ b/contracts/src/Types.sol
@@ -68,11 +68,11 @@ enum Command {
     UpdateChannel,
     Upgrade,
     SetOperatingMode,
-    TransferNativeFromAgent
+    TransferNativeFromAgent,
+    RegisterToken
 }
 
 enum AgentExecuteCommand {
     TransferToken,
-    MintToken,
-    RegisterToken
+    MintToken
 }

--- a/contracts/src/Types.sol
+++ b/contracts/src/Types.sol
@@ -74,5 +74,6 @@ enum Command {
 
 enum AgentExecuteCommand {
     TransferToken,
+    RegisterToken,
     MintToken
 }

--- a/contracts/src/storage/AssetsStorage.sol
+++ b/contracts/src/storage/AssetsStorage.sol
@@ -2,9 +2,6 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 pragma solidity 0.8.20;
 
-import {Agent} from "../Agent.sol";
-import {ParaID} from "../Types.sol";
-
 library AssetsStorage {
     struct Layout {
         uint256 registerTokenFee;

--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -12,6 +12,8 @@ library CoreStorage {
         mapping(ParaID paraID => Channel) channels;
         // Agents
         mapping(bytes32 agentID => address) agents;
+        // Token addresses
+        mapping(bytes32 tokenID => address) tokens;
         // AgentIDs of token owners
         mapping(address token => bytes32) ownerAgentIDs;
         // The default fee charged to users for submitting outbound message to Polkadot

--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -14,6 +14,8 @@ library CoreStorage {
         mapping(ParaID paraID => Channel) channels;
         // Agents
         mapping(bytes32 agentID => address) agents;
+        // AgentIDs of token owners
+        mapping(address token => bytes32) ownerAgentIDs;
         // The default fee charged to users for submitting outbound message to Polkadot
         uint256 defaultFee;
         // The default reward given to relayers for submitting inbound messages from Polkadot

--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 pragma solidity 0.8.20;
 
-import {AgentExecutor} from "../AgentExecutor.sol";
-import {Agent} from "../Agent.sol";
 import {Channel, OperatingMode, ParaID} from "../Types.sol";
 
 library CoreStorage {


### PR DESCRIPTION
Stacking this on #926. I'm not sure about initiating burn within `Assets`, given the need to invoke an agent. Would it be more appropriate to burn in `Gateway`? (where we invoke agents & register Polkadot tokens) Should we rather move Polkadot token registration into `Assets` as well?

[SNO-612](https://linear.app/snowfork/issue/SNO-612)