### PR TITLE
Standardize variables for deployment

### DIFF
--- a/smoketest/tests/upgrade_gateway.rs
+++ b/smoketest/tests/upgrade_gateway.rs
@@ -46,7 +46,7 @@ const BRIDGE_HUB_PARA_ID: u32 = 1013;
 const GATEWAY_PROXY_CONTRACT: &str = "0xEDa338E4dC46038493b885327842fD3E301CaB39";
 const GATETWAY_UPGRADE_MOCK_CONTRACT: [u8; 20] = hex!("f8f7758fbcefd546eaeff7de24aff666b6228e73");
 const GATETWAY_UPGRADE_MOCK_CODE_HASH: [u8; 32] =
-	hex!("9ed4c5736e9322ae52d21856271c96e1c130477bce199fb4a35679866ce2a657");
+	hex!("ad2eaa7103b39aea14dac05981ce0ff31a8f51267eaf2a0e480c94159afc904f");
 
 #[tokio::test]
 async fn upgrade_gateway() {

--- a/web/packages/test/.envrc-example
+++ b/web/packages/test/.envrc-example
@@ -9,7 +9,7 @@ source_up_if_exists
 # export BEEFY_START_BLOCK=           # Start block to configure beefy client, default value: 1
 # export RELAYCHAIN_ENDPOINT=         # Relaychain endpoint, default value: ws://localhost:9944
 # export PARACHAIN_RUNTIME=           # Runtime type of parachain should be one of snowbase|snowblink|snowbridge
-# export BRIDGEHUB_PALLETS_OWNER=     # Pubkey of bridge owner that can halt/resume the bridge pallets, default value: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (Alice test account)
+# export BRIDGE_HUB_PALLETS_OWNER=     # Pubkey of bridge owner that can halt/resume the bridge pallets, default value: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (Alice test account)
 
 
 ## Eth config for production

--- a/web/packages/test/scripts/configure-bridgehub-owner.sh
+++ b/web/packages/test/scripts/configure-bridgehub-owner.sh
@@ -13,19 +13,19 @@ config_pallet_owner()
     local pallet="30"
     local callindex="03"
     local payload="0x$pallet$callindex$option$owner"
-    send_governance_transact_from_relaychain $bridgehub_para_id "$payload"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$payload"
 
     # config owner of outbound queue
     local pallet="31"
     local callindex="00"
     local payload="0x$pallet$callindex$option$owner"
-    send_governance_transact_from_relaychain $bridgehub_para_id "$payload"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$payload"
 
     # config owner of beacon client owner
     local pallet="32"
     local callindex="03"
     local payload="0x$pallet$callindex$option$owner"
-    send_governance_transact_from_relaychain $bridgehub_para_id "$payload"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$payload"
 }
 
 

--- a/web/packages/test/scripts/configure-bridgehub.sh
+++ b/web/packages/test/scripts/configure-bridgehub.sh
@@ -9,7 +9,7 @@ config_beacon_checkpoint()
     pushd $root_dir
     local check_point_call=$($relay_bin generate-beacon-checkpoint --spec $active_spec --url $beacon_endpoint_http)
     popd
-    send_governance_transact_from_relaychain $bridgehub_para_id "$check_point_call" 180000000000 900000
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$check_point_call" 180000000000 900000
 }
 
 config_inbound_queue()
@@ -18,7 +18,7 @@ config_inbound_queue()
     local callindex="01"
     local payload="0x$pallet$callindex$(address_for GatewayProxy | tr "[:upper:]" "[:lower:]" | cut -c3-)"
 
-    send_governance_transact_from_relaychain $bridgehub_para_id "$payload"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$payload"
 }
 
 wait_beacon_chain_ready()

--- a/web/packages/test/scripts/configure-bridgehub.sh
+++ b/web/packages/test/scripts/configure-bridgehub.sh
@@ -36,7 +36,7 @@ wait_beacon_chain_ready()
 fund_accounts()
 {
     echo "Funding substrate accounts"
-    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $statemine_sovereign_account
+    transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $assethub_sovereign_account
     transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $beacon_relayer_pub_key
     transfer_balance $relaychain_ws_url "//Charlie" 1013 1000000000000000 $execution_relayer_pub_key
     transfer_balance $relaychain_ws_url "//Charlie" 1000 1000000000000000 $gateway_contract_sovereign_account

--- a/web/packages/test/scripts/set-env.sh
+++ b/web/packages/test/scripts/set-env.sh
@@ -42,14 +42,14 @@ beacon_endpoint_http="${BEACON_HTTP_ENDPOINT:-http://127.0.0.1:9596}"
 
 # Local substrate chain endpoints
 bridgehub_ws_url="${BRIDGE_HUB_WS_URL:-ws://127.0.0.1:11144}"
-bridgehub_para_id="${BRIDGE_HUB_PARAID:-1013}"
 bridgehub_seed="${BRIDGE_HUB_SEED:-//Alice}"
 bridgehub_pallets_owner="${BRIDGE_HUB_PALLETS_OWNER:-0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d}"
+export BRIDGE_HUB_PARAID="${BRIDGE_HUB_PARAID:-1013}"
 export BRIDGE_HUB_AGENT_ID="${BRIDGE_HUB_AGENT_ID:-0x05f0ced792884ed09997292bd95f8d0d1094bb3bded91ec3f2f08531624037d6}"
 
 assethub_ws_url="${ASSET_HUB_WS_URL:-ws://127.0.0.1:12144}"
-assethub_para_id="${ASSET_HUB_PARAID:-1000}"
 assethub_seed="${ASSET_HUB_SEED:-//Alice}"
+export ASSET_HUB_PARAID="${ASSET_HUB_PARAID:-1000}"
 export ASSET_HUB_AGENT_ID="${ASSET_HUB_AGENT_ID:-0x72456f48efed08af20e5b317abf8648ac66e86bb90a411d9b0b713f7364b75b4}"
 
 relaychain_ws_url="${RELAYCHAIN_WS_URL:-ws://127.0.0.1:9944}"

--- a/web/packages/test/scripts/set-env.sh
+++ b/web/packages/test/scripts/set-env.sh
@@ -41,14 +41,16 @@ basic_eth_addresses="${BASIC_ETH_ADDRESSES:-0x89b4ab1ef20763630df9743acf15586560
 beacon_endpoint_http="${BEACON_HTTP_ENDPOINT:-http://127.0.0.1:9596}"
 
 # Local substrate chain endpoints
-bridgehub_ws_url="${BRIDGEHUB_WS_URL:-ws://127.0.0.1:11144}"
-bridgehub_para_id="${BRIDGEHUB_PARA_ID:-1013}"
-bridgehub_seed="${BRIDGEHUB_SEED:-//Alice}"
-bridgehub_pallets_owner="${BRIDGEHUB_PALLETS_OWNER:-0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d}"
+bridgehub_ws_url="${BRIDGE_HUB_WS_URL:-ws://127.0.0.1:11144}"
+bridgehub_para_id="${BRIDGE_HUB_PARAID:-1013}"
+bridgehub_seed="${BRIDGE_HUB_SEED:-//Alice}"
+bridgehub_pallets_owner="${BRIDGE_HUB_PALLETS_OWNER:-0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d}"
+export BRIDGE_HUB_AGENT_ID="${BRIDGE_HUB_AGENT_ID:-0x05f0ced792884ed09997292bd95f8d0d1094bb3bded91ec3f2f08531624037d6}"
 
-statemine_ws_url="${STATEMINE_WS_URL:-ws://127.0.0.1:12144}"
-statemine_para_id="${STATEMINE_PARA_ID:-1000}"
-statemine_seed="${STATEMINE_SEED:-//Alice}"
+assethub_ws_url="${ASSET_HUB_WS_URL:-ws://127.0.0.1:12144}"
+assethub_para_id="${ASSET_HUB_PARAID:-1000}"
+assethub_seed="${ASSET_HUB_SEED:-//Alice}"
+export ASSET_HUB_AGENT_ID="${ASSET_HUB_AGENT_ID:-0x72456f48efed08af20e5b317abf8648ac66e86bb90a411d9b0b713f7364b75b4}"
 
 relaychain_ws_url="${RELAYCHAIN_WS_URL:-ws://127.0.0.1:9944}"
 relaychain_sudo_seed="${RELAYCHAIN_SUDO_SEED:-//Alice}"
@@ -57,8 +59,8 @@ skip_relayer="${SKIP_RELAYER:-false}"
 
 ## Important accounts
 
-# Account for statemine (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet)
-statemine_sovereign_account="${STATEMINE_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
+# Account for assethub (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet)
+assethub_sovereign_account="${ASSETHUB_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
 # Beacon relay account (//BeaconRelay 5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
 beacon_relayer_pub_key="${BEACON_RELAYER_PUB_KEY:-0xc46e141b5083721ad5f5056ba1cded69dce4a65f027ed3362357605b1687986a}"
 # Execution relay account (//ExecutionRelay 5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
@@ -79,13 +81,7 @@ export PRIVATE_KEY="${DEPLOYER_ETH_KEY:-0x4e9444a6efd6d42725a250b650a781da2737ea
 export RANDAO_COMMIT_DELAY="${ETH_RANDAO_DELAY:-3}"
 export RANDAO_COMMIT_EXP="${ETH_RANDAO_EXP:-3}"
 
-export BRIDGE_HUB_PARAID=$bridgehub_para_id
-# TODO: update placeholder value
-export BRIDGE_HUB_AGENT_ID="0x05f0ced792884ed09997292bd95f8d0d1094bb3bded91ec3f2f08531624037d6"
 
-export ASSET_HUB_PARAID=$statemine_para_id
-# TODO: update placeholder value
-export ASSET_HUB_AGENT_ID="0x72456f48efed08af20e5b317abf8648ac66e86bb90a411d9b0b713f7364b75b4"
 
 export DEFAULT_FEE=1
 export DEFAULT_REWARD=1

--- a/web/packages/test/scripts/set_operating_mode.sh
+++ b/web/packages/test/scripts/set_operating_mode.sh
@@ -6,12 +6,12 @@ source scripts/xcm-helper.sh
 
 enable_gateway() {
     local transact_call="0x330400"
-    send_governance_transact_from_relaychain $bridgehub_para_id "$transact_call"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$transact_call"
 }
 
 disable_gateway() {
     local transact_call="0x330401"
-    send_governance_transact_from_relaychain $bridgehub_para_id "$transact_call"
+    send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$transact_call"
 }
 
 read -p "Enable gateway? (Y/N): " confirm

--- a/web/packages/test/scripts/start-relayer.sh
+++ b/web/packages/test/scripts/start-relayer.sh
@@ -22,7 +22,7 @@ config_relayer(){
         --arg k1 "$(address_for GatewayProxy)" \
         --arg k2 "$(address_for BeefyClient)" \
         --arg eth_endpoint_ws $eth_endpoint_ws \
-        --arg channelID $BRIDGE_HUB_PARAID \
+        --arg channelID $bridgehub_para_id \
         --arg eth_gas_limit $eth_gas_limit \
     '
       .source.contracts.Gateway = $k1
@@ -40,7 +40,7 @@ config_relayer(){
         --arg k1 "$(address_for GatewayProxy)" \
         --arg k2 "$(address_for BeefyClient)" \
         --arg eth_endpoint_ws $eth_endpoint_ws \
-        --arg channelID $ASSET_HUB_PARAID \
+        --arg channelID $assethub_para_id \
         --arg eth_gas_limit $eth_gas_limit \
     '
       .source.contracts.Gateway = $k1
@@ -67,7 +67,7 @@ config_relayer(){
     jq \
         --arg eth_endpoint_ws $eth_endpoint_ws \
         --arg k1 "$(address_for GatewayProxy)" \
-        --arg channelID $ASSET_HUB_PARAID \
+        --arg channelID $assethub_para_id \
     '
       .source.ethereum.endpoint = $eth_endpoint_ws
     | .source.contracts.Gateway = $k1

--- a/web/packages/test/scripts/start-relayer.sh
+++ b/web/packages/test/scripts/start-relayer.sh
@@ -22,7 +22,7 @@ config_relayer(){
         --arg k1 "$(address_for GatewayProxy)" \
         --arg k2 "$(address_for BeefyClient)" \
         --arg eth_endpoint_ws $eth_endpoint_ws \
-        --arg channelID $bridgehub_para_id \
+        --arg channelID $BRIDGE_HUB_PARAID \
         --arg eth_gas_limit $eth_gas_limit \
     '
       .source.contracts.Gateway = $k1
@@ -40,7 +40,7 @@ config_relayer(){
         --arg k1 "$(address_for GatewayProxy)" \
         --arg k2 "$(address_for BeefyClient)" \
         --arg eth_endpoint_ws $eth_endpoint_ws \
-        --arg channelID $assethub_para_id \
+        --arg channelID $ASSET_HUB_PARAID \
         --arg eth_gas_limit $eth_gas_limit \
     '
       .source.contracts.Gateway = $k1
@@ -67,7 +67,7 @@ config_relayer(){
     jq \
         --arg eth_endpoint_ws $eth_endpoint_ws \
         --arg k1 "$(address_for GatewayProxy)" \
-        --arg channelID $assethub_para_id \
+        --arg channelID $ASSET_HUB_PARAID \
     '
       .source.ethereum.endpoint = $eth_endpoint_ws
     | .source.contracts.Gateway = $k1


### PR DESCRIPTION
Partially Resolves: SNO-545

1. Make agent ids overridable.
2. Use the name assethub over statemine in scripts.
3. Upgrade smoketest failing on main due to contract code hash change.

Tested with `start-services.sh` and running smoketests.