### PR TITLE
Implement fees in outbound router since it is not supported

### DIFF
--- a/parachain/primitives/router/src/outbound/mod.rs
+++ b/parachain/primitives/router/src/outbound/mod.rs
@@ -130,7 +130,8 @@ where
 
 		log::info!(target: "xcm::ethereum_blob_exporter", "message validated: location = {local_sub_location:?}, agent_id = '{agent_id:?}'");
 
-		// TODO (SNO-581): Make sure we charge fees for message delivery. Currently this is set to zero.
+		// TODO (SNO-581): Make sure we charge fees for message delivery. Currently this is set to
+		// zero.
 		Ok((ticket.encode(), MultiAssets::default()))
 	}
 
@@ -183,9 +184,7 @@ impl<'a, Call> XcmConverter<'a, Call> {
 		Self { iter: message.inner().iter(), ethereum_network, gateway_address }
 	}
 
-	fn convert(
-		&mut self,
-	) -> Result<AgentExecuteCommand, XcmConverterError> {
+	fn convert(&mut self) -> Result<AgentExecuteCommand, XcmConverterError> {
 		// Get target fees if specified.
 		self.check_fee_info()?;
 
@@ -209,9 +208,9 @@ impl<'a, Call> XcmConverter<'a, Call> {
 	fn check_fee_info(&mut self) -> Result<(), XcmConverterError> {
 		use XcmConverterError::*;
 		match self.next()? {
-			UnpaidExecution { check_origin: None, weight_limit: Unlimited } => return Ok(()),
-			_ => return Err(TargetFeeExpected),
-		};
+			UnpaidExecution { check_origin: None, weight_limit: Unlimited } => Ok(()),
+			_ => Err(TargetFeeExpected),
+		}
 	}
 
 	fn native_tokens_unlock_message(&mut self) -> Result<AgentExecuteCommand, XcmConverterError> {

--- a/parachain/primitives/router/src/outbound/mod.rs
+++ b/parachain/primitives/router/src/outbound/mod.rs
@@ -25,13 +25,13 @@ pub struct EthereumBlobExporter<
 >(PhantomData<(UniversalLocation, GatewayLocation, OutboundQueue, AgentHashedDescription)>);
 
 impl<UniversalLocation, GatewayLocation, OutboundQueue, AgentHashedDescription> ExportXcm
-for EthereumBlobExporter<UniversalLocation, GatewayLocation, OutboundQueue, AgentHashedDescription>
-	where
-		UniversalLocation: Get<InteriorMultiLocation>,
-		GatewayLocation: Get<MultiLocation>,
-		OutboundQueue: OutboundQueueTrait,
-		OutboundQueue::Ticket: Encode + Decode,
-		AgentHashedDescription: ConvertLocation<H256>,
+	for EthereumBlobExporter<UniversalLocation, GatewayLocation, OutboundQueue, AgentHashedDescription>
+where
+	UniversalLocation: Get<InteriorMultiLocation>,
+	GatewayLocation: Get<MultiLocation>,
+	OutboundQueue: OutboundQueueTrait,
+	OutboundQueue::Ticket: Encode + Decode,
+	AgentHashedDescription: ConvertLocation<H256>,
 {
 	type Ticket = Vec<u8>;
 
@@ -64,7 +64,7 @@ for EthereumBlobExporter<UniversalLocation, GatewayLocation, OutboundQueue, Agen
 
 		let gateway_address = match gateway_junctions {
 			X1(AccountKey20 { network, key })
-			if network.is_none() || network == Some(gateway_network) =>
+				if network.is_none() || network == Some(gateway_network) =>
 				key,
 			_ => {
 				log::trace!(target: "xcm::ethereum_blob_exporter", "skipped due to unmatched registry contract {gateway_junctions:?}.");
@@ -217,7 +217,7 @@ impl<'a, Call> XcmConverter<'a, Call> {
 		let execution_fee = match self.next()? {
 			WithdrawAsset(fee_asset) => match self.next()? {
 				BuyExecution { fees: execution_fee, weight_limit: Unlimited }
-				if fee_asset.len() == 1 && fee_asset.contains(execution_fee) =>
+					if fee_asset.len() == 1 && fee_asset.contains(execution_fee) =>
 					Some(execution_fee),
 				_ => return Err(BuyExecutionExpected),
 			},
@@ -278,10 +278,10 @@ impl<'a, Call> XcmConverter<'a, Call> {
 			if let MultiLocation {
 				parents: 0,
 				interior:
-				X2(
-					AccountKey20 { network: gateway_network, key: gateway_address },
-					AccountKey20 { network: token_network, key: token_address },
-				),
+					X2(
+						AccountKey20 { network: gateway_network, key: gateway_address },
+						AccountKey20 { network: token_network, key: token_address },
+					),
 			} = asset_location
 			{
 				if gateway_network.is_some() && gateway_network != &Some(*self.ethereum_network) {
@@ -575,11 +575,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let mut message: Option<Xcm<()>> = Some(
@@ -593,11 +593,11 @@ mod tests {
 						network: Some(network),
 						key: beneficiary_address,
 					})
-						.into(),
+					.into(),
 				},
 				SetTopic([0; 32]),
 			]
-				.into(),
+			.into(),
 		);
 
 		let result =
@@ -656,11 +656,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let mut message: Option<Xcm<()>> = Some(
@@ -673,11 +673,11 @@ mod tests {
 						network: Some(network),
 						key: beneficiary_address,
 					})
-						.into(),
+					.into(),
 				},
 				SetTopic([0; 32]),
 			]
-				.into(),
+			.into(),
 		);
 
 		let result =
@@ -718,11 +718,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -735,7 +735,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 		let expected_payload = AgentExecuteCommand::TransferToken {
 			token: token_address.into(),
@@ -759,11 +759,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -775,7 +775,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 		let expected_payload = AgentExecuteCommand::TransferToken {
 			token: token_address.into(),
@@ -799,11 +799,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(All);
 
 		let message: Xcm<()> = vec![
@@ -815,7 +815,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 		let expected_payload = AgentExecuteCommand::TransferToken {
 			token: token_address.into(),
@@ -837,16 +837,16 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let message: Xcm<()> = vec![
 			UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 			WithdrawAsset(assets),
 		]
-			.into();
+		.into();
 
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 		let result = converter.convert();
@@ -878,11 +878,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -894,7 +894,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -917,11 +917,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -934,7 +934,7 @@ mod tests {
 			},
 			ClearTopic,
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -957,11 +957,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -975,7 +975,7 @@ mod tests {
 			SetTopic([0; 32]),
 			ClearOrigin,
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -998,11 +998,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -1014,7 +1014,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1036,11 +1036,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 
 		let message: Xcm<()> = vec![
 			WithdrawAsset(fees),
@@ -1048,7 +1048,7 @@ mod tests {
 			WithdrawAsset(assets),
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1077,7 +1077,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1105,7 +1105,7 @@ mod tests {
 				fun: Fungible(500),
 			},
 		]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = assets.clone().into();
 
 		let message: Xcm<()> = vec![
@@ -1118,7 +1118,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1141,11 +1141,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(0));
 
 		let message: Xcm<()> = vec![
@@ -1158,7 +1158,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1181,11 +1181,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: NonFungible(AssetInstance::Index(0)),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1198,7 +1198,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1221,11 +1221,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(0),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1238,7 +1238,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1258,7 +1258,7 @@ mod tests {
 			id: Concrete(X3(GlobalConsensus(Polkadot), Parachain(1000), GeneralIndex(0)).into()),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1271,7 +1271,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1294,11 +1294,11 @@ mod tests {
 					AccountKey20 { network: Some(network), key: GATEWAY },
 					AccountKey20 { network: Some(Ethereum { chain_id: 2 }), key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1311,7 +1311,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1336,11 +1336,11 @@ mod tests {
 					AccountKey20 { network: Some(network), key: BAD_REGISTRY },
 					AccountKey20 { network: Some(network), key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1353,7 +1353,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1376,11 +1376,11 @@ mod tests {
 					AccountKey20 { network: Some(Ethereum { chain_id: 2 }), key: GATEWAY },
 					AccountKey20 { network: Some(network), key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1393,7 +1393,7 @@ mod tests {
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1418,11 +1418,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1436,11 +1436,11 @@ mod tests {
 					Parachain(1000),
 					AccountId32 { network: Some(Polkadot), id: beneficiary_address },
 				)
-					.into(),
+				.into(),
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();
@@ -1464,11 +1464,11 @@ mod tests {
 					AccountKey20 { network: None, key: GATEWAY },
 					AccountKey20 { network: None, key: token_address },
 				)
-					.into(),
+				.into(),
 			),
 			fun: Fungible(1000),
 		}]
-			.into();
+		.into();
 		let filter: MultiAssetFilter = Wild(WildMultiAsset::AllCounted(1));
 
 		let message: Xcm<()> = vec![
@@ -1481,11 +1481,11 @@ mod tests {
 					network: Some(Ethereum { chain_id: 2 }),
 					key: beneficiary_address,
 				})
-					.into(),
+				.into(),
 			},
 			SetTopic([0; 32]),
 		]
-			.into();
+		.into();
 		let mut converter = XcmConverter::new(&message, &network, &GATEWAY);
 
 		let result = converter.convert();

--- a/smoketest/src/constants.rs
+++ b/smoketest/src/constants.rs
@@ -4,6 +4,7 @@ pub const ETHEREUM_API: &str = "ws://localhost:8546";
 pub const ETHEREUM_HTTP_API: &str = "http://localhost:8545";
 pub const BRIDGE_HUB_WS_URL: &str = "ws://127.0.0.1:11144";
 pub const BRIDGE_HUB_PARA_ID: u32 = 1013;
+pub const ASSET_HUB_WS_URL: &str = "ws://127.0.0.1:12144";
 
 pub const TEMPLATE_NODE_WS_URL: &str = "ws://127.0.0.1:13144";
 

--- a/smoketest/src/constants.rs
+++ b/smoketest/src/constants.rs
@@ -18,6 +18,7 @@ pub const ETHEREUM_ADDRESS: [u8; 20] = hex!("90A987B944Cb1dCcE5564e5FDeCD7a54D3d
 
 // GatewayProxy in local setup
 pub const GATEWAY_PROXY_CONTRACT: [u8; 20] = hex!("EDa338E4dC46038493b885327842fD3E301CaB39");
+pub const WETH_CONTRACT: [u8; 20] = hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
 
 // Agent for sibling parachain 1001
 pub const SIBLING_AGENT_ID: [u8; 32] =

--- a/smoketest/src/helper.rs
+++ b/smoketest/src/helper.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use subxt::blocks::ExtrinsicEvents;
 use subxt::events::StaticEvent;
 use subxt::tx::{PairSigner, TxPayload};
-use subxt::{Config, OnlineClient, PolkadotConfig};
+use subxt::{Config, OnlineClient, PolkadotConfig, SubstrateConfig};
 use templateXcm::{
     v3::{junction::Junction, junctions::Junctions, multilocation::MultiLocation},
     VersionedMultiLocation, VersionedXcm,
@@ -34,6 +34,20 @@ impl Config for TemplateConfig {
     type Hasher = <PolkadotConfig as Config>::Hasher;
     type Header = <PolkadotConfig as Config>::Header;
     type ExtrinsicParams = <PolkadotConfig as Config>::ExtrinsicParams;
+}
+
+/// Custom config that works with Statemint
+pub enum AssetHubConfig {}
+
+impl Config for AssetHubConfig {
+    type Index = <PolkadotConfig as Config>::Index;
+    type Hash = <PolkadotConfig as Config>::Hash;
+    type AccountId = <PolkadotConfig as Config>::AccountId;
+    type Address = <PolkadotConfig as Config>::Address;
+    type Signature = <PolkadotConfig as Config>::Signature;
+    type Hasher = <PolkadotConfig as Config>::Hasher;
+    type Header = <PolkadotConfig as Config>::Header;
+    type ExtrinsicParams = <SubstrateConfig as Config>::ExtrinsicParams;
 }
 
 pub struct TestClients {

--- a/smoketest/tests/transfer_token.rs
+++ b/smoketest/tests/transfer_token.rs
@@ -5,12 +5,33 @@ use ethers::{
 use std::{sync::Arc, time::Duration};
 use snowbridge_smoketest::contracts::weth9::WETH9;
 use subxt::{
-    tx::{PairSigner, TxPayload},
+    tx::{PairSigner},
     OnlineClient, PolkadotConfig,
 };
-use snowbridge_smoketest::constants::{ASSET_HUB_WS_URL, ETHEREUM_API};
+use snowbridge_smoketest::constants::{ASSET_HUB_WS_URL, ETHEREUM_API, GATEWAY_PROXY_CONTRACT, WETH_CONTRACT};
+use sp_core::{sr25519::Pair, Pair as PairT};
+use snowbridge_smoketest::{
+    contracts::weth9::{TransferFilter},
+    parachains::{
+        assethub::api::runtime_types::xcm::{
+            v3::{
+                junction::{Junction, NetworkId},
+                junctions::Junctions,
+                multiasset::{AssetId, Fungibility, MultiAsset, MultiAssets},
+                multilocation::MultiLocation,
+            },
+            VersionedMultiAssets, VersionedMultiLocation,
+        },
+        assethub::{self},
+    },
+};
+use hex_literal::hex;
+use sp_core::bytes::to_hex;
+use subxt::tx::TxPayload;
+use assethub::api::bridge_transfer::calls::TransactionApi;
+use snowbridge_smoketest::helper::TemplateConfig;
 
-
+const DESTINATION_ADDRESS: [u8; 20] = hex!("44a57ee2f2FCcb85FDa2B0B18EBD0D8D2333700e");
 
 #[tokio::test]
 async fn transfer_token() {
@@ -28,5 +49,55 @@ async fn transfer_token() {
     let assethub: OnlineClient<PolkadotConfig> =
         OnlineClient::from_url(ASSET_HUB_WS_URL).await.unwrap();
 
-    let ferdie = dev::ferdie();
+    let keypair: Pair = Pair::from_string("//Ferdie", None).expect("cannot create keypair");
+
+    let signer: PairSigner<PolkadotConfig, _> = PairSigner::new(keypair);
+
+    //let amount: u128 = 1_000_000_000;
+    /*let assets = VersionedMultiAssets::V3(MultiAssets(vec![MultiAsset {
+        id: AssetId::Concrete(MultiLocation {
+            parents: 2,
+            interior: Junctions::X3(
+                Junction::GlobalConsensus(NetworkId::Ethereum { chain_id: 15 }),
+                Junction::AccountKey20 { network: None, key: GATEWAY_PROXY_CONTRACT.into() },
+                Junction::AccountKey20 { network: None, key: WETH_CONTRACT.into() },
+            ),
+        }),
+        fun: Fungibility::Fungible(amount),
+    }]));
+    let destination = VersionedMultiLocation::V3(MultiLocation {
+        parents: 1,
+        interior: Junctions::X2(
+            Junction::GlobalConsensus(NetworkId::Ethereum { chain_id: 15 }),
+            Junction::AccountKey20 { network: None, key: DESTINATION_ADDRESS.into() },
+        ),
+    });*/
+
+    /*
+    let assets = VersionedMultiAssets::V3(MultiAssets(vec![]));
+    let destination = VersionedMultiLocation::V3(MultiLocation {
+        parents: 1,
+        interior: Junctions::X2(
+            Junction::GlobalConsensus(NetworkId::Ethereum { chain_id: 15 }),
+            Junction::AccountKey20 { network: None, key: DESTINATION_ADDRESS.into() },
+        ),
+    });
+
+    let bridge_transfer_call = TransactionApi.transfer_asset_via_bridge();*/
+
+    let calldata = assethub::api::system::calls::TransactionApi.remark(String::from("Hello, world!").into_bytes());
+
+    //let calldata = hex::encode(bridge_transfer_call.encode_call_data(&assethub.metadata()).unwrap());
+    //println!("Encoded {:?}", calldata);
+
+    let result = assethub
+        .tx()
+        .sign_and_submit_then_watch_default(&calldata, &signer)
+        .await
+        .expect("send through call.")
+        .wait_for_finalized_success()
+        .await
+        .expect("call success");
+
+    println!("bridge_transfer call issued at assethub block hash {:?}", result.block_hash());
 }

--- a/smoketest/tests/transfer_token.rs
+++ b/smoketest/tests/transfer_token.rs
@@ -1,0 +1,32 @@
+use ethers::{
+    providers::{Provider, Ws},
+    types::Address,
+};
+use std::{sync::Arc, time::Duration};
+use snowbridge_smoketest::contracts::weth9::WETH9;
+use subxt::{
+    tx::{PairSigner, TxPayload},
+    OnlineClient, PolkadotConfig,
+};
+use snowbridge_smoketest::constants::{ASSET_HUB_WS_URL, ETHEREUM_API};
+
+
+
+#[tokio::test]
+async fn transfer_token() {
+    let ethereum_provider = Provider::<Ws>::connect(ETHEREUM_API)
+        .await
+        .unwrap()
+        .interval(Duration::from_millis(10u64));
+
+
+    let ethereum_client = Arc::new(ethereum_provider);
+
+    let weth_addr: Address = WETH_CONTRACT.into();
+    let weth = WETH9::new(weth_addr, ethereum_client.clone());
+
+    let assethub: OnlineClient<PolkadotConfig> =
+        OnlineClient::from_url(ASSET_HUB_WS_URL).await.unwrap();
+
+    let ferdie = dev::ferdie();
+}


### PR DESCRIPTION
Remove support for target chain fees in the XCM message, since they are not handled in the target chain at all. In any case, target chain fees will be added in: https://github.com/Snowfork/snowbridge/pull/924

Resolves: [SNO-645](https://linear.app/snowfork/issue/SNO-645)
Cumulus companion: https://github.com/Snowfork/cumulus/pull/62