### PR TITLE
SNO-653: Add constant attribute for MaxUpgradeDataSize

### DIFF
--- a/parachain/pallets/control/src/lib.rs
+++ b/parachain/pallets/control/src/lib.rs
@@ -54,6 +54,7 @@ pub mod pallet {
 		type OwnParaId: Get<ParaId>;
 
 		/// Max size of params passed to initializer of the new implementation contract
+		#[pallet::constant]
 		type MaxUpgradeDataSize: Get<u32>;
 
 		/// Implementation that ensures origin is an XCM location for agent operations


### PR DESCRIPTION
Audit finding 26
[SNO-653](https://linear.app/snowfork/issue/SNO-653)