### PR TITLE
Reward relayer from asset hub sovereign account that matches asset hub

### DIFF
--- a/.github/workflows/parachain.yml
+++ b/.github/workflows/parachain.yml
@@ -80,7 +80,6 @@ jobs:
           --manifest-path parachain/Cargo.toml
           --workspace
           --features runtime-benchmarks
-          --exclude snowbridge-query-events
           --exclude snowbridge-ethereum-beacon-client
       # Run tests for beacon light client, excluding benchmark tests
       - name: Tests for beacon light client excluding benchmark tests

--- a/parachain/pallets/control/src/benchmarking.rs
+++ b/parachain/pallets/control/src/benchmarking.rs
@@ -8,12 +8,12 @@ use crate::Pallet as SnowbridgeControl;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 use snowbridge_core::outbound::OperatingMode;
-use sp_runtime::traits::AccountIdConversion;
 use xcm::prelude::*;
 
 fn fund_sovereign_account<T: Config>(para_id: ParaId) -> Result<(), BenchmarkError> {
 	let amount: BalanceOf<T> = u16::MAX.into();
-	T::Token::mint_into(&para_id.into_account_truncating(), amount)?;
+	let sovereign_account = sibling_sovereign_account::<T>(para_id);
+	T::Token::mint_into(&sovereign_account, amount)?;
 	Ok(())
 }
 

--- a/parachain/pallets/control/src/lib.rs
+++ b/parachain/pallets/control/src/lib.rs
@@ -41,7 +41,7 @@ use snowbridge_core::{
 	outbound::{
 		Command, Initializer, Message, OperatingMode, OutboundQueue as OutboundQueueTrait, ParaId,
 	},
-	AgentId,
+	AgentId, SiblingParaId,
 };
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -226,7 +226,8 @@ pub mod pallet {
 			Agents::<T>::insert(agent_id, ());
 
 			let command = Command::CreateAgent { agent_id };
-			let pays_fee = PaysFee::<T>::Yes(para_id.into_account_truncating());
+			let sibling_para_id: SiblingParaId = para_id.into();
+			let pays_fee = PaysFee::<T>::Yes(sibling_para_id.into_account_truncating());
 			Self::send(T::OwnParaId::get(), command, pays_fee)?;
 
 			Self::deposit_event(Event::<T>::CreateAgent {
@@ -260,7 +261,8 @@ pub mod pallet {
 			Channels::<T>::insert(para_id, ());
 
 			let command = Command::CreateChannel { para_id, agent_id };
-			let pays_fee = PaysFee::<T>::Yes(para_id.into_account_truncating());
+			let sibling_para_id: SiblingParaId = para_id.into();
+			let pays_fee = PaysFee::<T>::Yes(sibling_para_id.into_account_truncating());
 			Self::send(T::OwnParaId::get(), command, pays_fee)?;
 
 			Self::deposit_event(Event::<T>::CreateChannel { para_id, agent_id });

--- a/parachain/pallets/control/src/lib.rs
+++ b/parachain/pallets/control/src/lib.rs
@@ -30,7 +30,7 @@ pub use weights::*;
 use frame_support::traits::fungible::{Inspect, Mutate};
 use sp_core::{RuntimeDebug, H160, H256};
 use sp_runtime::{
-	traits::{AccountIdConversion, BadOrigin, Hash},
+	traits::{BadOrigin, Hash},
 	DispatchError,
 };
 use sp_std::prelude::*;
@@ -41,7 +41,7 @@ use snowbridge_core::{
 	outbound::{
 		Command, Initializer, Message, OperatingMode, OutboundQueue as OutboundQueueTrait, ParaId,
 	},
-	AgentId, SiblingParaId,
+	AgentId, sibling_sovereign_account
 };
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -226,8 +226,7 @@ pub mod pallet {
 			Agents::<T>::insert(agent_id, ());
 
 			let command = Command::CreateAgent { agent_id };
-			let sibling_para_id: SiblingParaId = para_id.into();
-			let pays_fee = PaysFee::<T>::Yes(sibling_para_id.into_account_truncating());
+			let pays_fee = PaysFee::<T>::Yes(sibling_sovereign_account::<T>(para_id));
 			Self::send(T::OwnParaId::get(), command, pays_fee)?;
 
 			Self::deposit_event(Event::<T>::CreateAgent {
@@ -261,8 +260,7 @@ pub mod pallet {
 			Channels::<T>::insert(para_id, ());
 
 			let command = Command::CreateChannel { para_id, agent_id };
-			let sibling_para_id: SiblingParaId = para_id.into();
-			let pays_fee = PaysFee::<T>::Yes(sibling_para_id.into_account_truncating());
+			let pays_fee = PaysFee::<T>::Yes(sibling_sovereign_account::<T>(para_id));
 			Self::send(T::OwnParaId::get(), command, pays_fee)?;
 
 			Self::deposit_event(Event::<T>::CreateChannel { para_id, agent_id });

--- a/parachain/pallets/control/src/tests.rs
+++ b/parachain/pallets/control/src/tests.rs
@@ -11,7 +11,7 @@ fn create_agent() {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let agent_id = make_agent_id(origin_location);
-		let sovereign_account = ParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
 
 		// fund sovereign account of origin
 		let _ = Balances::mint_into(&sovereign_account, 10000);
@@ -112,7 +112,7 @@ fn create_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = ParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
 		let origin = make_xcm_origin(origin_location);
 
 		// fund sovereign account of origin
@@ -128,7 +128,7 @@ fn create_channel_fail_already_exists() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = ParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
 		let origin = make_xcm_origin(origin_location);
 
 		// fund sovereign account of origin
@@ -190,7 +190,7 @@ fn update_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = ParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
 		let origin = make_xcm_origin(origin_location);
 
 		// First create the channel
@@ -284,7 +284,7 @@ fn force_update_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = ParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
 		let origin = make_xcm_origin(origin_location);
 
 		// First create the channel
@@ -498,7 +498,7 @@ fn force_transfer_native_from_agent_bad_origin() {
 fn sibling_sovereign_account() {
 	new_test_ext().execute_with(|| {
 		let para_id = 1001;
-		let sovereign_account: AccountId32 = ParaId::from(para_id).into_account_truncating();
+		let sovereign_account: AccountId32 = SiblingParaId::from(para_id).into_account_truncating();
 		println!(
 			"Sovereign account for parachain {}: {:#?}",
 			para_id,

--- a/parachain/pallets/control/src/tests.rs
+++ b/parachain/pallets/control/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{mock::*, *};
 use frame_support::{assert_noop, assert_ok};
 use sp_core::H256;
-use sp_runtime::{traits::AccountIdConversion, AccountId32, DispatchError::BadOrigin, TokenError};
+use sp_runtime::{AccountId32, DispatchError::BadOrigin, TokenError};
 
 #[test]
 fn create_agent() {
@@ -11,7 +11,7 @@ fn create_agent() {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let agent_id = make_agent_id(origin_location);
-		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
 
 		// fund sovereign account of origin
 		let _ = Balances::mint_into(&sovereign_account, 10000);
@@ -112,7 +112,7 @@ fn create_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
 		let origin = make_xcm_origin(origin_location);
 
 		// fund sovereign account of origin
@@ -128,7 +128,7 @@ fn create_channel_fail_already_exists() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
 		let origin = make_xcm_origin(origin_location);
 
 		// fund sovereign account of origin
@@ -190,7 +190,7 @@ fn update_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
 		let origin = make_xcm_origin(origin_location);
 
 		// First create the channel
@@ -284,7 +284,7 @@ fn force_update_channel() {
 	new_test_ext().execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
-		let sovereign_account = SiblingParaId::from(origin_para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
 		let origin = make_xcm_origin(origin_location);
 
 		// First create the channel
@@ -495,10 +495,10 @@ fn force_transfer_native_from_agent_bad_origin() {
 
 #[ignore]
 #[test]
-fn sibling_sovereign_account() {
+fn check_sibling_sovereign_account() {
 	new_test_ext().execute_with(|| {
 		let para_id = 1001;
-		let sovereign_account: AccountId32 = SiblingParaId::from(para_id).into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(para_id.into());
 		println!(
 			"Sovereign account for parachain {}: {:#?}",
 			para_id,

--- a/parachain/pallets/inbound-queue/src/benchmarking/mod.rs
+++ b/parachain/pallets/inbound-queue/src/benchmarking/mod.rs
@@ -24,8 +24,7 @@ mod benchmarks {
 			create_message.execution_header,
 		);
 
-		let dest_para: SiblingParaId = 1000u32.into();
-		let sovereign_account = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<T>(1000u32.into());
 
 		let minimum_balance = T::Token::minimum_balance();
 		let minimum_balance_u32: u32 = minimum_balance

--- a/parachain/pallets/inbound-queue/src/benchmarking/mod.rs
+++ b/parachain/pallets/inbound-queue/src/benchmarking/mod.rs
@@ -24,7 +24,7 @@ mod benchmarks {
 			create_message.execution_header,
 		);
 
-		let dest_para: ParaId = 1000u32.into();
+		let dest_para: SiblingParaId = 1000u32.into();
 		let sovereign_account = dest_para.into_account_truncating();
 
 		let minimum_balance = T::Token::minimum_balance();

--- a/parachain/pallets/inbound-queue/src/lib.rs
+++ b/parachain/pallets/inbound-queue/src/lib.rs
@@ -35,7 +35,7 @@ use xcm::v3::{
 use envelope::Envelope;
 use snowbridge_core::{
 	inbound::{Message, Verifier},
-	ParaId,
+	ParaId, SiblingParaId
 };
 use snowbridge_router_primitives::{
 	inbound,
@@ -218,9 +218,12 @@ pub mod pallet {
 				}
 			})?;
 
+			// Convert to a sibling parachain ID (uses bytes "sibl" instead of "para" to derive
+			// the sovereign account ID, to match how Assethub derives the account ID).
+			let sibling_para_id: SiblingParaId = envelope.dest.into();
 			// Reward relayer from the sovereign account of the destination parachain
 			// Expected to fail if sovereign account has no funds
-			let sovereign_account = envelope.dest.into_account_truncating();
+			let sovereign_account = sibling_para_id.into_account_truncating();
 			T::Token::transfer(&sovereign_account, &who, T::Reward::get(), Preservation::Preserve)?;
 
 			// Decode message into XCM

--- a/parachain/pallets/inbound-queue/src/lib.rs
+++ b/parachain/pallets/inbound-queue/src/lib.rs
@@ -25,7 +25,6 @@ use frame_support::{
 use frame_system::ensure_signed;
 use scale_info::TypeInfo;
 use sp_core::H160;
-use sp_runtime::traits::AccountIdConversion;
 use sp_std::convert::TryFrom;
 use xcm::v3::{
 	send_xcm, Junction::*, Junctions::*, MultiLocation, SendError as XcmpSendError, SendXcm,
@@ -35,7 +34,7 @@ use xcm::v3::{
 use envelope::Envelope;
 use snowbridge_core::{
 	inbound::{Message, Verifier},
-	ParaId, SiblingParaId
+	ParaId, sibling_sovereign_account
 };
 use snowbridge_router_primitives::{
 	inbound,
@@ -218,12 +217,9 @@ pub mod pallet {
 				}
 			})?;
 
-			// Convert to a sibling parachain ID (uses bytes "sibl" instead of "para" to derive
-			// the sovereign account ID, to match how Assethub derives the account ID).
-			let sibling_para_id: SiblingParaId = envelope.dest.into();
 			// Reward relayer from the sovereign account of the destination parachain
 			// Expected to fail if sovereign account has no funds
-			let sovereign_account = sibling_para_id.into_account_truncating();
+			let sovereign_account = sibling_sovereign_account::<T>(envelope.dest);
 			T::Token::transfer(&sovereign_account, &who, T::Reward::get(), Preservation::Preserve)?;
 
 			// Decode message into XCM

--- a/parachain/pallets/inbound-queue/src/test.rs
+++ b/parachain/pallets/inbound-queue/src/test.rs
@@ -257,6 +257,9 @@ const XCM_HASH: [u8; 32] = [
 	232, 213, 62, 94, 48, 47, 152, 37, 168, 162, 89, 100, 6, 74, 63, 95, 211, 11, 222, 210, 1, 209,
 	126, 44, 164, 122, 166, 156, 208, 228, 209, 9,
 ];
+const ASSET_HUB_PARAID: u32 = 1000u32;
+
+use snowbridge_core::ParaId;
 
 #[test]
 fn test_submit_happy_path() {
@@ -265,8 +268,7 @@ fn test_submit_happy_path() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: SiblingParaId = 1000u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 		println!("account: {}", sovereign_account);
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 
@@ -281,7 +283,7 @@ fn test_submit_happy_path() {
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
 		expect_events(vec![InboundQueueEvent::MessageReceived {
-			dest: dest_para.into(),
+			dest: ASSET_HUB_PARAID.into(),
 			nonce: 1,
 			xcm_hash: XCM_HASH,
 		}
@@ -296,8 +298,7 @@ fn test_submit_xcm_send_failure() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of parachain 1001
-		let dest_para: SiblingParaId = 1001u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(1001u32.into());
 		println!("account: {}", sovereign_account);
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 
@@ -324,8 +325,7 @@ fn test_submit_with_invalid_gateway() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: ParaId = 1000u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
@@ -351,8 +351,7 @@ fn test_submit_with_invalid_nonce() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: SiblingParaId = 1000u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
@@ -385,8 +384,7 @@ fn test_submit_no_funds_to_reward_relayers() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Create sovereign account for Asset Hub (Statemint), but with no funds to cover rewards
-		let dest_para: ParaId = 1000u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 		assert_ok!(Balances::mint_into(&sovereign_account, 2));
 
 		// Submit message

--- a/parachain/pallets/inbound-queue/src/test.rs
+++ b/parachain/pallets/inbound-queue/src/test.rs
@@ -265,7 +265,7 @@ fn test_submit_happy_path() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: ParaId = 1000u32.into();
+		let dest_para: SiblingParaId = 1000u32.into();
 		let sovereign_account: AccountId = dest_para.into_account_truncating();
 		println!("account: {}", sovereign_account);
 		let _ = Balances::mint_into(&sovereign_account, 10000);
@@ -281,7 +281,7 @@ fn test_submit_happy_path() {
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
 		expect_events(vec![InboundQueueEvent::MessageReceived {
-			dest: dest_para,
+			dest: dest_para.into(),
 			nonce: 1,
 			xcm_hash: XCM_HASH,
 		}
@@ -296,7 +296,7 @@ fn test_submit_xcm_send_failure() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of parachain 1001
-		let dest_para: ParaId = 1001u32.into();
+		let dest_para: SiblingParaId = 1001u32.into();
 		let sovereign_account: AccountId = dest_para.into_account_truncating();
 		println!("account: {}", sovereign_account);
 		let _ = Balances::mint_into(&sovereign_account, 10000);
@@ -351,7 +351,7 @@ fn test_submit_with_invalid_nonce() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: ParaId = 1000u32.into();
+		let dest_para: SiblingParaId = 1000u32.into();
 		let sovereign_account: AccountId = dest_para.into_account_truncating();
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 

--- a/parachain/pallets/inbound-queue/src/test.rs
+++ b/parachain/pallets/inbound-queue/src/test.rs
@@ -259,8 +259,6 @@ const XCM_HASH: [u8; 32] = [
 ];
 const ASSET_HUB_PARAID: u32 = 1000u32;
 
-use snowbridge_core::ParaId;
-
 #[test]
 fn test_submit_happy_path() {
 	new_tester().execute_with(|| {
@@ -442,8 +440,7 @@ fn test_submit_with_invalid_payload_unsupported_version() {
 		let origin = RuntimeOrigin::signed(relayer);
 
 		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let dest_para: ParaId = 1000u32.into();
-		let sovereign_account: AccountId = dest_para.into_account_truncating();
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -18,3 +18,4 @@ use sp_core::H256;
 
 /// The ID of an agent contract
 pub type AgentId = H256;
+

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -12,7 +12,7 @@ pub mod inbound;
 pub mod outbound;
 pub mod ringbuffer;
 
-pub use polkadot_parachain::primitives::{Id as ParaId, IsSystem};
+pub use polkadot_parachain::primitives::{Id as ParaId, Sibling as SiblingParaId, IsSystem};
 pub use ringbuffer::{RingBufferMap, RingBufferMapImpl};
 use sp_core::H256;
 

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -15,7 +15,11 @@ pub mod ringbuffer;
 pub use polkadot_parachain::primitives::{Id as ParaId, Sibling as SiblingParaId, IsSystem};
 pub use ringbuffer::{RingBufferMap, RingBufferMapImpl};
 use sp_core::H256;
+use sp_runtime::traits::AccountIdConversion;
 
 /// The ID of an agent contract
 pub type AgentId = H256;
 
+pub fn sibling_sovereign_account<T>(para_id: ParaId) -> T::AccountId where T: frame_system::Config {
+    SiblingParaId::from(para_id).into_account_truncating()
+}

--- a/web/packages/test/scripts/set-env.sh
+++ b/web/packages/test/scripts/set-env.sh
@@ -61,10 +61,10 @@ skip_relayer="${SKIP_RELAYER:-false}"
 
 ## Important accounts
 
-# Account for assethub (1000 sibling parachain 5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV in testnet)
+# Account for assethub (Sibling parachain 1000 5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV in testnet)
 assethub_sovereign_account="${ASSETHUB_SOVEREIGN_ACCOUNT:-0x7369626ce8030000000000000000000000000000000000000000000000000000}"
-# Account for template (Para 1001)
-template_sovereign_account="${TEMPLATE_SOVEREIGN_ACCOUNT:-0x70617261e9030000000000000000000000000000000000000000000000000000}"
+# Account for template (Sibling parachain 1001 5Eg2fntP2UgYZNc5tW8xmmCmeXJ3hmNXaZ9MvcpbMdvh1bBJ in testnet)
+template_sovereign_account="${TEMPLATE_SOVEREIGN_ACCOUNT:-0x7369626ce9030000000000000000000000000000000000000000000000000000}"
 # Beacon relay account (//BeaconRelay 5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)
 beacon_relayer_pub_key="${BEACON_RELAYER_PUB_KEY:-0xc46e141b5083721ad5f5056ba1cded69dce4a65f027ed3362357605b1687986a}"
 # Execution relay account (//ExecutionRelay 5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)

--- a/web/packages/test/scripts/set-env.sh
+++ b/web/packages/test/scripts/set-env.sh
@@ -61,8 +61,8 @@ skip_relayer="${SKIP_RELAYER:-false}"
 
 ## Important accounts
 
-# Account for assethub (1000 5Ec4AhPZk8STuex8Wsi9TwDtJQxKqzPJRCH7348Xtcs9vZLJ in testnet)
-assethub_sovereign_account="${ASSETHUB_SOVEREIGN_ACCOUNT:-0x70617261e8030000000000000000000000000000000000000000000000000000}"
+# Account for assethub (1000 sibling parachain 5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV in testnet)
+assethub_sovereign_account="${ASSETHUB_SOVEREIGN_ACCOUNT:-0x7369626ce8030000000000000000000000000000000000000000000000000000}"
 # Account for template (Para 1001)
 template_sovereign_account="${TEMPLATE_SOVEREIGN_ACCOUNT:-0x70617261e9030000000000000000000000000000000000000000000000000000}"
 # Beacon relay account (//BeaconRelay 5GWFwdZb6JyU46e6ZiLxjGxogAHe8SenX76btfq8vGNAaq8c in testnet)


### PR DESCRIPTION
Updates the way we get sovereign account IDs from parachain IDs. Use the SiblingId struct instead of Id, since that is what AssetHub does. The sovereign account we use should be the same as the account ID used on AssetHub.