### PR TITLE
Refactor outbound queue pallet

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3135,7 +3135,6 @@ dependencies = [
 name = "snowbridge-core"
 version = "0.1.1"
 dependencies = [
- "derivative",
  "ethabi-decode",
  "frame-support",
  "frame-system",
@@ -3146,6 +3145,7 @@ dependencies = [
  "serde",
  "snowbridge-beacon-primitives",
  "snowbridge-ethereum",
+ "sp-arithmetic",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -3246,7 +3246,6 @@ dependencies = [
  "hex-literal",
  "pallet-message-queue",
  "parity-scale-codec",
- "rlp",
  "scale-info",
  "serde",
  "snowbridge-core",

--- a/parachain/pallets/control/Cargo.toml
+++ b/parachain/pallets/control/Cargo.toml
@@ -20,7 +20,6 @@ scale-info = { version = "2.9.0", default-features = false, features = ["derive"
 frame-benchmarking = { path = "../../../polkadot-sdk/substrate/frame/benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../../polkadot-sdk/substrate/frame/support", default-features = false }
 frame-system = { path = "../../../polkadot-sdk/substrate/frame/system", default-features = false }
-snowbridge-core = { path = "../../primitives/core", default-features = false }
 log = { version = "0.4.20", default-features = false }
 
 sp-core = { path = "../../../polkadot-sdk/substrate/primitives/core", default-features = false }
@@ -33,6 +32,7 @@ xcm-builder = { package = "staging-xcm-builder", path = "../../../polkadot-sdk/p
 xcm-executor = { package = "staging-xcm-executor", path = "../../../polkadot-sdk/polkadot/xcm/xcm-executor", default-features = false }
 
 ethabi = { git = "https://github.com/Snowfork/ethabi-decode.git", package = "ethabi-decode", branch = "master", default-features = false }
+snowbridge-core = { path = "../../primitives/core", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.1"
@@ -59,8 +59,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"ethabi/std",
-	"snowbridge-core/std",
-	"log/std",
+	"snowbridge-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/parachain/pallets/control/src/lib.rs
+++ b/parachain/pallets/control/src/lib.rs
@@ -2,14 +2,39 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 //! Governance API for controlling the Ethereum side of the bridge
 //!
-//! * upgrade: Upgrade the gateway contract (permissioned)
-//! * set_operating_mode: Update the operating mode of the gateway contract (permissioned)
-//! * create_agent: Create agent for a sibling (permissionless)
-//! * create_channel: Create channel for a sibling (permissionless)
-//! * update_channel: Update a channel for a sibling (permissionless)
-//! * force_update_channel: Allow root to update a channel for a sibling (permissioned)
-//! * transfer_native_from_agent: Withdraw ether from an agent (permissionless)
-//! * force_transfer_native_from_agent: Allow root to withdraw ether from an agent (permissionless)
+//! # Extrinsics
+//!
+//! ## Agents
+//!
+//! Agents are smart contracts on Ethereum that act as proxies for consensus systems on Polkadot
+//! networks.
+//!
+//! * [`Call::create_agent`]: Create agent for a sibling parachain
+//! * [`Call::transfer_native_from_agent`]: Withdraw ether from an agent
+//!
+//! The `create_agent` extrinsic should be called via an XCM `Transact` instruction from the sibling
+//! parachain.
+//!
+//! ## Channels
+//!
+//! Each sibling parachain has its own dedicated messaging channel for sending and receiving
+//! messages. As a prerequisite to creating a channel, the sibling should have already created
+//! an agent using the `create_agent` extrinsic.
+//!
+//! * [`Call::create_channel`]: Create channel for a sibling
+//! * [`Call::update_channel`]: Update a channel for a sibling
+//!
+//! ## Governance
+//!
+//! Only Polkadot governance itself can call these extrinsics. Delivery fees are waived.
+//!
+//! * [`Call::upgrade`]`: Upgrade the gateway contract
+//! * [`Call::set_operating_mode`]: Update the operating mode of the gateway contract
+//! * [`Call::force_update_channel`]: Allow root to update a channel for a sibling
+//! * [`Call::force_transfer_native_from_agent`]: Allow root to withdraw ether from an agent
+//!
+//! Typically, Polkadot governance will use the `force_transfer_native_from_agent` and
+//! `force_update_channel` and extrinsics to manage agents and channels for system parachains.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/parachain/pallets/control/src/lib.rs
+++ b/parachain/pallets/control/src/lib.rs
@@ -43,11 +43,8 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use snowbridge_core::{
-	outbound::{
-		Command, Initializer, Message, OperatingMode, OutboundQueue as OutboundQueueTrait,
-		SendError,
-	},
-	sibling_sovereign_account, AgentId, ParaId,
+	outbound::{Command, Initializer, Message, OperatingMode, ParaId, SendError, SendMessage},
+	sibling_sovereign_account, AgentId,
 };
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -92,9 +89,9 @@ pub enum PaysFee<T>
 where
 	T: Config,
 {
-	/// Fully charge includes (base_fee + delivery_fee)
+	/// Fully charge includes (local + remote fee)
 	Yes(AccountIdOf<T>),
-	/// Partially charge includes base_fee only
+	/// Partially charge includes local only
 	Partial(AccountIdOf<T>),
 	/// No charge
 	No,
@@ -115,7 +112,7 @@ pub mod pallet {
 		type MessageHasher: Hash<Output = H256>;
 
 		/// Send messages to Ethereum
-		type OutboundQueue: OutboundQueueTrait<Balance = BalanceOf<Self>>;
+		type OutboundQueue: SendMessage<Balance = BalanceOf<Self>>;
 
 		/// The ID of this parachain
 		type OwnParaId: Get<ParaId>;
@@ -413,7 +410,7 @@ pub mod pallet {
 
 			let payment = match pays_fee {
 				PaysFee::Yes(account) => Some((account, fee.total())),
-				PaysFee::Partial(account) => Some((account, fee.base)),
+				PaysFee::Partial(account) => Some((account, fee.local)),
 				PaysFee::No => None,
 			};
 
@@ -426,7 +423,7 @@ pub mod pallet {
 				)?;
 			}
 
-			T::OutboundQueue::submit(ticket).map_err(|err| Error::<T>::Send(err))?;
+			T::OutboundQueue::deliver(ticket).map_err(|err| Error::<T>::Send(err))?;
 			Ok(())
 		}
 

--- a/parachain/pallets/control/src/mock.rs
+++ b/parachain/pallets/control/src/mock.rs
@@ -3,7 +3,7 @@
 use crate as snowbridge_control;
 use frame_support::{
 	parameter_types,
-	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, Contains},
+	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, Contains, GenesisBuild},
 	weights::IdentityFee,
 	PalletId,
 };
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 		System: frame_system,
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		XcmOrigin: pallet_xcm_origin::{Pallet, Origin},
-		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Event<T>},
+		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Config, Event<T>},
 		EthereumControl: snowbridge_control,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>}
 	}
@@ -172,9 +172,6 @@ impl snowbridge_outbound_queue::Config for Test {
 	type OwnParaId = OwnParaId;
 	type GasMeter = ConstantGasMeter;
 	type Balance = u128;
-	type DeliveryFeePerGas = ConstU128<1>;
-	type DeliveryRefundPerGas = ConstU128<1>;
-	type DeliveryReward = ConstU128<1>;
 	type WeightToFee = IdentityFee<u128>;
 	type WeightInfo = ();
 }
@@ -230,7 +227,15 @@ impl crate::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+	let config = snowbridge_outbound_queue::GenesisConfig {
+		operating_mode: Default::default(),
+		fee_config: Default::default(),
+	};
+
+	GenesisBuild::<Test>::assimilate_storage(&config, &mut storage).unwrap();
+
 	let mut ext: sp_io::TestExternalities = storage.into();
 	let initial_amount = InitialFunding::get().into();
 	let test_para_id = TestParaId::get();

--- a/parachain/pallets/control/src/mock.rs
+++ b/parachain/pallets/control/src/mock.rs
@@ -3,7 +3,7 @@
 use crate as snowbridge_control;
 use frame_support::{
 	parameter_types,
-	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, Contains},
+	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, ConstU8, Contains},
 	weights::IdentityFee,
 	PalletId,
 };
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 		System: frame_system,
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		XcmOrigin: pallet_xcm_origin::{Pallet, Origin},
-		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Config<T>, Event<T>},
+		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Event<T>},
 		EthereumControl: snowbridge_control,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>}
 	}
@@ -167,6 +167,7 @@ impl snowbridge_outbound_queue::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Hashing = Keccak256;
 	type MessageQueue = MessageQueue;
+	type Decimals = ConstU8<10>;
 	type MaxMessagePayloadSize = MaxMessagePayloadSize;
 	type MaxMessagesPerBlock = MaxMessagesPerBlock;
 	type OwnParaId = OwnParaId;
@@ -227,15 +228,7 @@ impl crate::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-
-	snowbridge_outbound_queue::GenesisConfig::<Test> {
-		operating_mode: Default::default(),
-		fee_config: Default::default(),
-		_config: Default::default(),
-	}
-	.assimilate_storage(&mut storage)
-	.unwrap();
+	let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
 	let initial_amount = InitialFunding::get().into();

--- a/parachain/pallets/control/src/mock.rs
+++ b/parachain/pallets/control/src/mock.rs
@@ -3,7 +3,7 @@
 use crate as snowbridge_control;
 use frame_support::{
 	parameter_types,
-	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, Contains, GenesisBuild},
+	traits::{tokens::fungible::Mutate, ConstU128, ConstU16, ConstU64, Contains},
 	weights::IdentityFee,
 	PalletId,
 };
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 		System: frame_system,
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		XcmOrigin: pallet_xcm_origin::{Pallet, Origin},
-		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Config, Event<T>},
+		OutboundQueue: snowbridge_outbound_queue::{Pallet, Call, Storage, Config<T>, Event<T>},
 		EthereumControl: snowbridge_control,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>}
 	}
@@ -227,14 +227,15 @@ impl crate::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 
-	let config = snowbridge_outbound_queue::GenesisConfig {
+	snowbridge_outbound_queue::GenesisConfig::<Test> {
 		operating_mode: Default::default(),
 		fee_config: Default::default(),
-	};
-
-	GenesisBuild::<Test>::assimilate_storage(&config, &mut storage).unwrap();
+		_config: Default::default(),
+	}
+	.assimilate_storage(&mut storage)
+	.unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
 	let initial_amount = InitialFunding::get().into();

--- a/parachain/pallets/control/src/tests.rs
+++ b/parachain/pallets/control/src/tests.rs
@@ -524,7 +524,7 @@ fn charge_fee_for_create_agent() {
 			Message { origin: para_id.into(), command: Command::CreateAgent { agent_id } };
 		let (_, fee) = OutboundQueue::validate(&message).unwrap();
 		let sovereign_balance = Balances::balance(&sovereign_account);
-		assert_eq!(sovereign_balance + fee.base + fee.delivery, InitialFunding::get());
+		assert_eq!(sovereign_balance + fee.local + fee.remote, InitialFunding::get());
 
 		// and treasury_balance increased
 		let treasury_balance = Balances::balance(&TreasuryAccount::get());
@@ -560,7 +560,7 @@ fn charge_fee_for_transfer_native_from_agent() {
 		};
 		let (_, fee) = OutboundQueue::validate(&message).unwrap();
 		let sovereign_balance_after = Balances::balance(&sovereign_account);
-		assert_eq!(sovereign_balance_after + fee.base, sovereign_balance_before);
+		assert_eq!(sovereign_balance_after + fee.local, sovereign_balance_before);
 	});
 }
 

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! * [`Call::submit`]: Submit a finalized beacon header with an optional sync committee update
 //! * [`Call::submit_execution_header`]: Submit an execution header together with an ancestry proof
-//!   that can be verified against an already imported beacon header.
+//!   that can be verified against an already imported finalized beacon header.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod config;

--- a/parachain/pallets/ethereum-beacon-client/src/lib.rs
+++ b/parachain/pallets/ethereum-beacon-client/src/lib.rs
@@ -1,6 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 //! Ethereum Beacon Client
+//!
+//! A light client that verifies consensus updates signed by the sync committee of the beacon chain.
+//!
+//! # Extrinsics
+//!
+//! ## Governance
+//!
+//! * [`Call::force_checkpoint`]: Set the initial trusted consensus checkpoint.
+//! * [`Call::set_operating_mode`]: Set the operating mode of the pallet. Can be used to disable
+//!   processing of conensus updates.
+//!
+//! ## Consensus Updates
+//!
+//! * [`Call::submit`]: Submit a finalized beacon header with an optional sync committee update
+//! * [`Call::submit_execution_header`]: Submit an execution header together with an ancestry proof
+//!   that can be verified against an already imported beacon header.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod config;

--- a/parachain/pallets/inbound-queue/src/lib.rs
+++ b/parachain/pallets/inbound-queue/src/lib.rs
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+//! Inbound Queue
+//!
+//! # Overview
+//!
+//! Receives messages emitted by the Gateway contract on Ethereum, whereupon they are verified,
+//! translated to XCM, and finally sent to their final destination parachain.
+//!
+//! The message relayers are rewarded using native currency from the sovereign account of the
+//! destination parachain.
+//!
+//! # Extrinsics
+//!
+//! ## Governance
+//!
+//! * [`Call::set_operating_mode`]: Set the operating mode of the pallet. Can be used to disable
+//!   processing of inbound messages.
+//!
+//! ## Message Submission
+//!
+//! * [`Call::submit`]: Submit a message for verification and dispatch the final destination
+//!   parachain.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod envelope;
@@ -76,19 +97,20 @@ pub mod pallet {
 		type Token: Mutate<Self::AccountId>;
 
 		/// The amount to reward message relayers
+		#[pallet::constant]
 		type Reward: Get<BalanceOf<Self>>;
 
 		/// XCM message sender
 		type XcmSender: SendXcm;
 
-		type WeightInfo: WeightInfo;
-
-		// Gateway contract address
+		// Address of the Gateway contract
 		#[pallet::constant]
 		type GatewayAddress: Get<H160>;
 
 		/// Convert inbound message to XCM
 		type MessageConverter: ConvertMessage;
+
+		type WeightInfo: WeightInfo;
 
 		#[cfg(feature = "runtime-benchmarks")]
 		type Helper: BenchmarkHelper<Self>;

--- a/parachain/pallets/outbound-queue/Cargo.toml
+++ b/parachain/pallets/outbound-queue/Cargo.toml
@@ -10,11 +10,10 @@ repository = "https://github.com/Snowfork/snowbridge"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-serde = { version = "1.0.188", optional = true }
+serde = { version = "1.0.188", features = ["derive", "alloc"], default-features = false }
 codec = { version = "3.6.1", package = "parity-scale-codec", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.9.0", default-features = false, features = [ "derive" ] }
 hex-literal = { version = "0.4.1", optional = true }
-rlp = { version = "0.5", default-features = false, optional = true }
 
 frame-benchmarking = { path = "../../../polkadot-sdk/substrate/frame/benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../../polkadot-sdk/substrate/frame/support", default-features = false }
@@ -25,23 +24,21 @@ sp-runtime = { path = "../../../polkadot-sdk/substrate/primitives/runtime", defa
 sp-io = { path = "../../../polkadot-sdk/substrate/primitives/io", default-features = false }
 sp-arithmetic = { path = "../../../polkadot-sdk/substrate/primitives/arithmetic", default-features = false }
 
-snowbridge-core = { path = "../../primitives/core", default-features = false }
+snowbridge-core = { path = "../../primitives/core", features = ["serde"], default-features = false }
 snowbridge-outbound-queue-merkle-tree = { path = "merkle-tree", default-features = false }
 ethabi = { git = "https://github.com/Snowfork/ethabi-decode.git", package = "ethabi-decode", branch = "master", default-features = false }
 
 xcm = { package = "staging-xcm", path = "../../../polkadot-sdk/polkadot/xcm", default-features = false }
 
 [dev-dependencies]
-frame-benchmarking = { path = "../../../polkadot-sdk/substrate/frame/benchmarking" }
 pallet-message-queue = { path = "../../../polkadot-sdk/substrate/frame/message-queue", default-features = false }
 sp-keyring = { path = "../../../polkadot-sdk/substrate/primitives/keyring" }
 hex-literal = { version = "0.4.1" }
-rlp = { version = "0.5" }
 
 [features]
 default = ["std"]
 std = [
-    "serde",
+    "serde/std",
     "codec/std",
     "scale-info/std",
     "frame-support/std",
@@ -63,5 +60,4 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
     "hex-literal",
-    "rlp",
 ]

--- a/parachain/pallets/outbound-queue/runtime-api/src/lib.rs
+++ b/parachain/pallets/outbound-queue/runtime-api/src/lib.rs
@@ -9,8 +9,12 @@ use snowbridge_outbound_queue_merkle_tree::MerkleProof;
 sp_api::decl_runtime_apis! {
 	pub trait OutboundQueueApi<Balance> where Balance: BalanceT
 	{
+		/// Generate a merkle proof for a committed message identified by `leaf_index`.
+		/// The merkle root is stored in the block header as a
+		/// [`sp_runtime::generic::DigestItem::Other`]
 		fn prove_message(leaf_index: u64) -> Option<MerkleProof>;
 
+		/// Calculate the delivery fee for `message`
 		fn calculate_fee(message: Message) -> Option<Balance>;
 	}
 }

--- a/parachain/pallets/outbound-queue/src/api.rs
+++ b/parachain/pallets/outbound-queue/src/api.rs
@@ -4,7 +4,7 @@
 
 use crate::{Config, MessageLeaves};
 use frame_support::storage::StorageStreamIter;
-use snowbridge_core::outbound::{Message, OutboundQueue};
+use snowbridge_core::outbound::{Message, SendMessage};
 use snowbridge_outbound_queue_merkle_tree::{merkle_proof, MerkleProof};
 
 pub fn prove_message<T>(leaf_index: u64) -> Option<MerkleProof>

--- a/parachain/pallets/outbound-queue/src/benchmarking.rs
+++ b/parachain/pallets/outbound-queue/src/benchmarking.rs
@@ -20,7 +20,7 @@ mod benchmarks {
 	/// Benchmark for processing a message.
 	#[benchmark]
 	fn do_process_message() -> Result<(), BenchmarkError> {
-		let enqueued_message = EnqueuedMessage {
+		let enqueued_message = QueuedMessage {
 			id: H256::zero().into(),
 			origin: 1000.into(),
 			command: Command::Upgrade {
@@ -47,7 +47,7 @@ mod benchmarks {
 
 	/// Benchmark for producing final messages commitment
 	#[benchmark]
-	fn do_commit_messages() -> Result<(), BenchmarkError> {
+	fn commit() -> Result<(), BenchmarkError> {
 		// Assume worst case, where `MaxMessagesPerBlock` messages need to be committed.
 		for i in 0..T::MaxMessagesPerBlock::get() {
 			let leaf_data: [u8; 1] = [i as u8];
@@ -57,7 +57,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			OutboundQueue::<T>::commit_messages();
+			OutboundQueue::<T>::commit();
 		}
 
 		Ok(())
@@ -65,17 +65,17 @@ mod benchmarks {
 
 	/// Benchmark for producing commitment for a single message
 	#[benchmark]
-	fn do_commit_one_message() -> Result<(), BenchmarkError> {
+	fn commit_single() -> Result<(), BenchmarkError> {
 		let leaf = <T as Config>::Hashing::hash(&[100; 1]);
 		MessageLeaves::<T>::append(leaf);
 
 		#[block]
 		{
-			OutboundQueue::<T>::commit_messages();
+			OutboundQueue::<T>::commit();
 		}
 
 		Ok(())
 	}
 
-	impl_benchmark_test_suite!(OutboundQueue, crate::test::new_tester(), crate::test::Test,);
+	impl_benchmark_test_suite!(OutboundQueue, crate::mock::new_tester(), crate::mock::Test,);
 }

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -65,7 +65,7 @@
 //! ## Fee Computation Function
 //!
 //! ```text
-//! LocalFee(Message) = ProcessingWeight(Message)
+//! LocalFee(Message) = WeightToFee(ProcessMessageWeight(Message))
 //! RemoteFee(Message) = MaxGasRequired(Message) * FeePerGas + Reward
 //! Fee(Message) = LocalFee(Message) + (RemoteFee(Message) / Ratio("ETH/DOT"))
 //! ```

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -91,6 +91,7 @@ use frame_support::{
 	storage::StorageStreamIter,
 	traits::{tokens::Balance, EnqueueMessage, Get, ProcessMessageError},
 	weights::{Weight, WeightToFee},
+	DefaultNoBound,
 };
 use snowbridge_core::{
 	outbound::{
@@ -234,14 +235,16 @@ pub mod pallet {
 	pub type FeeConfig<T: Config> = StorageValue<_, FeeConfigRecord, ValueQuery>;
 
 	#[pallet::genesis_config]
-	#[derive(Default)]
-	pub struct GenesisConfig {
+	#[derive(DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
 		pub operating_mode: BasicOperatingMode,
 		pub fee_config: FeeConfigRecord,
+		#[serde(skip)]
+		pub _config: sp_std::marker::PhantomData<T>,
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			self.fee_config.validate().expect("invalid fee configuration");
 			OperatingMode::<T>::put(self.operating_mode);

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -30,7 +30,7 @@
 //!    b. Reading the actual message content from the `Messages` vector in storage
 //!
 //! On the Ethereum side, the message root is ultimately the thing being
-//! by the Polkadot light client.
+//! verified by the Polkadot light client.
 //!
 //! # Message Priorities
 //!

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -275,7 +275,8 @@ pub mod pallet {
 		}
 
 		fn integrity_test() {
-			assert!(T::Decimals::get() > 0, "Decimals should usually be 10 or 12");
+			let decimals = T::Decimals::get();
+			assert!(decimals == 10 || decimals == 12, "Decimals should be 10 or 12");
 		}
 	}
 

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -1,20 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
-
 //! Pallet for committing outbound messages for delivery to Ethereum
 //!
+//! # Overview
+//!
 //! The message submission pipeline works like this:
-//! 1. The message is first validated via [`OutboundQueue::validate`]
-//! 2. The message is then enqueued for processing via [`OutboundQueue::submit`]
-//! 3. The message queue is maintained by the external [`MessageQueue`] pallet
-//! 4. [`MessageQueue`] delivers messages back to this pallet via `ProcessMessage::process_message`
-//! 5. The message is processed in `do_process_message` a. Assigned a nonce b. ABI-encoded, hashed,
-//!    and stored in the `Leaves` vector
-//! 6. At the end of the block, a merkle root is constructed from all the leaves in `Leaves`.
+//! 1. The message is first validated via the implementation for
+//!    [`snowbridge_core::outbound::SendMessage::validate`]
+//! 2. The message is then enqueued for later processing via the implementation
+//!    for [`snowbridge_core::outbound::SendMessage::deliver`]
+//! 3. The underlying message queue is implemented by [`Config::MessageQueue`]
+//! 4. The message queue delivers messages back to this pallet via
+//!    the implementation for [`frame_support::traits::ProcessMessage::process_message`]
+//! 5. The message is processed in `Pallet::do_process_message`:
+//!    a. Assigned a nonce
+//!    b. ABI-encoded, hashed, and stored in the `MessageLeaves` vector
+//! 6. At the end of the block, a merkle root is constructed from all the
+//!    leaves in `MessageLeaves`.
 //! 7. This merkle root is inserted into the parachain header as a digest item
+//! 8. Offchain relayers can read the committed message from the `Messages`
+//!    storage item.
 //!
 //! On the Ethereum side, the message root is ultimately the thing being
 //! by the Polkadot light client.
+//!
+//! # Message Priorities
 //!
 //! Within the message submission pipeline, messages have different priorities,
 //! which results in differing processing behavior.
@@ -25,56 +35,89 @@
 //! The processing of governance commands can never be halted. This effectively
 //! allows us to pause processing of normal user messages while still allowing
 //! governance commands to be sent to Ethereum.
+//!
+//! # Fees
+//!
+//! An upfront fee must be paid for delivering a message. This fee covers several
+//! components:
+//! 1. The weight of processing the message locally
+//! 2. The gas refund paid out to relayers for message submission
+//! 3. An additional reward paid out to relayers for message submission
+//!
+//! Messages are weighed to determine the maximum amount of gas they could
+//! consume on Ethereum. Using this upper bound, a final fee can be calculated.
+//!
+//! The fee calculation also requires the following parameters:
+//! * ETH/DOT exchange rate
+//! * Ether fee per unit of gas
+//!
+//! By design, it is expected that governance should manually update these
+//! parameters every few weeks using the [`Call::set_fee_config`] extrinsic.
+//!
+//! ## Fee Computation Function
+//!
+//! ```text
+//! LocalFee(Message) = ProcessingWeight(Message)
+//! RemoteFee(Message) = MaxGasRequired(Message) * FeePerGas + Reward
+//! Fee(Message) = LocalFee(Message) + (RemoteFee(Message) / Ratio("ETH/DOT"))
+//! ```
+//!
+//! # Message Types
+//!
+//! The naming of message types indicates their processing state:
+//!
+//! 1. `Message`: Message initially received
+//! 2. `QueuedMessage`: Message queued for eventual commitment
+//! 3. `CommittedMessage`: Message has been committed for delivery
 #![cfg_attr(not(feature = "std"), no_std)]
 pub mod api;
+pub mod process_message_impl;
+pub mod send_message_impl;
+pub mod types;
 pub mod weights;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
 #[cfg(test)]
+mod mock;
+
+#[cfg(test)]
 mod test;
 
-use codec::{Decode, Encode};
-use ethabi::{self};
+use codec::Decode;
 use frame_support::{
 	ensure,
 	storage::StorageStreamIter,
-	traits::{tokens::Balance, EnqueueMessage, Get, ProcessMessage, ProcessMessageError},
+	traits::{tokens::Balance, EnqueueMessage, Get, ProcessMessageError},
 	weights::{Weight, WeightToFee},
 };
-use snowbridge_core::ParaId;
-use sp_core::H256;
-use sp_runtime::traits::{Hash, Saturating};
-use sp_std::prelude::*;
-
 use snowbridge_core::{
 	outbound::{
-		AggregateMessageOrigin, Command, EnqueuedMessage, ExportOrigin, Fees, GasMeter, Message,
-		MessageHash, OutboundQueue as OutboundQueueTrait, OutboundQueueTicket, PreparedMessage,
-		SendError,
+		AggregateMessageOrigin, Command, ExportOrigin, Fee, GasMeter, QueuedMessage,
+		VersionedQueuedMessage,
 	},
-	BasicOperatingMode,
+	BasicOperatingMode, ParaId,
 };
 use snowbridge_outbound_queue_merkle_tree::merkle_root;
 pub use snowbridge_outbound_queue_merkle_tree::MerkleProof;
+use sp_core::H256;
+use sp_runtime::{
+	traits::{CheckedDiv, Hash},
+	FixedPointNumber,
+};
+use sp_std::prelude::*;
+pub use types::{CommittedMessage, FeeConfigRecord, ProcessMessageOriginOf};
 pub use weights::WeightInfo;
 
-/// The maximal length of an enqueued message, as determined by the MessageQueue pallet
-pub type MaxEnqueuedMessageSizeOf<T> =
-	<<T as Config>::MessageQueue as EnqueueMessage<AggregateMessageOrigin>>::MaxMessageLen;
-
-pub type ProcessMessageOriginOf<T> = <Pallet<T> as ProcessMessage>::Origin;
-
 pub use pallet::*;
-
-pub const LOG_TARGET: &str = "snowbridge-outbound-queue";
 
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
+	use sp_arithmetic::FixedU128;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
@@ -90,7 +133,7 @@ pub mod pallet {
 		/// Measures the maximum gas used to execute a command on Ethereum
 		type GasMeter: GasMeter;
 
-		type Balance: Balance + From<u64>;
+		type Balance: Balance + From<u128>;
 
 		/// Max bytes in a message payload
 		#[pallet::constant]
@@ -103,18 +146,6 @@ pub mod pallet {
 		/// The ID of this parachain
 		#[pallet::constant]
 		type OwnParaId: Get<ParaId>;
-
-		/// The delivery fee in DOT per unit of gas
-		#[pallet::constant]
-		type DeliveryFeePerGas: Get<Self::Balance>;
-
-		/// The refund in ETH (wei) per unit of gas
-		#[pallet::constant]
-		type DeliveryRefundPerGas: Get<u128>;
-
-		/// The reward in ETH (wei)
-		#[pallet::constant]
-		type DeliveryReward: Get<u128>;
 
 		/// Convert a weight value into a deductible fee based.
 		type WeightToFee: WeightToFee<Balance = Self::Balance>;
@@ -147,7 +178,12 @@ pub mod pallet {
 			count: u64,
 		},
 		/// Set OperatingMode
-		OperatingModeChanged { mode: BasicOperatingMode },
+		OperatingModeChanged {
+			mode: BasicOperatingMode,
+		},
+		FeeConfigChanged {
+			fee_config: FeeConfigRecord,
+		},
 	}
 
 	#[pallet::error]
@@ -156,6 +192,8 @@ pub mod pallet {
 		MessageTooLarge,
 		/// The pallet is halted
 		Halted,
+		// Invalid fee config
+		InvalidFeeConfig,
 	}
 
 	/// Messages to be committed in the current block. This storage value is killed in
@@ -166,7 +204,7 @@ pub mod pallet {
 	/// Inspired by the `frame_system::Pallet::Events` storage value
 	#[pallet::storage]
 	#[pallet::unbounded]
-	pub(super) type Messages<T: Config> = StorageValue<_, Vec<PreparedMessage>, ValueQuery>;
+	pub(super) type Messages<T: Config> = StorageValue<_, Vec<CommittedMessage>, ValueQuery>;
 
 	/// Number of high priority messages that are waiting to be processed.
 	/// While this number is greater than zero, processing of lower priority
@@ -191,6 +229,26 @@ pub mod pallet {
 	#[pallet::getter(fn operating_mode)]
 	pub type OperatingMode<T: Config> = StorageValue<_, BasicOperatingMode, ValueQuery>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn fee_config)]
+	pub type FeeConfig<T: Config> = StorageValue<_, FeeConfigRecord, ValueQuery>;
+
+	#[pallet::genesis_config]
+	#[derive(Default)]
+	pub struct GenesisConfig {
+		pub operating_mode: BasicOperatingMode,
+		pub fee_config: FeeConfigRecord,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {
+			self.fee_config.validate().expect("invalid fee configuration");
+			OperatingMode::<T>::put(self.operating_mode);
+			FeeConfig::<T>::put(self.fee_config);
+		}
+	}
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
 	where
@@ -201,11 +259,11 @@ pub mod pallet {
 			Messages::<T>::kill();
 			MessageLeaves::<T>::kill();
 			// Reserve some weight for the `on_finalize` handler
-			T::WeightInfo::commit_messages()
+			T::WeightInfo::commit()
 		}
 
 		fn on_finalize(_: BlockNumberFor<T>) {
-			Self::commit_messages();
+			Self::commit();
 		}
 	}
 
@@ -219,15 +277,25 @@ pub mod pallet {
 			mode: BasicOperatingMode,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			OperatingMode::<T>::set(mode);
+			OperatingMode::<T>::put(mode);
 			Self::deposit_event(Event::OperatingModeChanged { mode });
+			Ok(())
+		}
+
+		#[pallet::call_index(4)]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
+		pub fn set_fee_config(origin: OriginFor<T>, fee_config: FeeConfigRecord) -> DispatchResult {
+			ensure_root(origin)?;
+			fee_config.validate().map_err(|_| Error::<T>::InvalidFeeConfig)?;
+			FeeConfig::<T>::put(fee_config);
+			Self::deposit_event(Event::FeeConfigChanged { fee_config });
 			Ok(())
 		}
 	}
 
 	impl<T: Config> Pallet<T> {
 		/// Generate a messages commitment and insert it into the header digest
-		pub(crate) fn commit_messages() {
+		pub(crate) fn commit() {
 			let count = MessageLeaves::<T>::decode_len().unwrap_or_default() as u64;
 			if count == 0 {
 				return
@@ -249,41 +317,45 @@ pub mod pallet {
 			origin: ProcessMessageOriginOf<T>,
 			mut message: &[u8],
 		) -> Result<bool, ProcessMessageError> {
+			use AggregateMessageOrigin::*;
+			use ExportOrigin::*;
+			use ProcessMessageError::*;
+
 			// Yield if the maximum number of messages has been processed this block.
 			// This ensures that the weight of `on_finalize` has a known maximum bound.
 			ensure!(
 				MessageLeaves::<T>::decode_len().unwrap_or(0) <
 					T::MaxMessagesPerBlock::get() as usize,
-				ProcessMessageError::Yield
+				Yield
 			);
 
-			if let AggregateMessageOrigin::Export(ExportOrigin::Here) = origin {
-				// Decrease PendingHighPriorityMessageCount by one
+			if let Export(Here) = origin {
 				PendingHighPriorityMessageCount::<T>::mutate(|count| {
 					*count = count.saturating_sub(1)
 				});
 			} else {
-				ensure!(!Self::operating_mode().is_halted(), ProcessMessageError::Yield);
-				ensure!(
-					PendingHighPriorityMessageCount::<T>::get() == 0,
-					ProcessMessageError::Yield
-				);
+				ensure!(!Self::operating_mode().is_halted(), Yield);
+				ensure!(PendingHighPriorityMessageCount::<T>::get() == 0, Yield);
 			}
 
-			let enqueued_message: EnqueuedMessage =
-				EnqueuedMessage::decode(&mut message).map_err(|_| ProcessMessageError::Corrupt)?;
+			// Decode bytes into versioned message
+			let versioned_enqueued_message: VersionedQueuedMessage =
+				VersionedQueuedMessage::decode(&mut message).map_err(|_| Corrupt)?;
+
+			// Convert versioned message into latest supported message version
+			let enqueued_message: QueuedMessage =
+				versioned_enqueued_message.try_into().map_err(|_| Unsupported)?;
 
 			let next_nonce = Nonce::<T>::get(enqueued_message.origin).saturating_add(1);
 
 			let command = enqueued_message.command.index();
 			let params = enqueued_message.command.abi_encode();
 			let max_dispatch_gas = T::GasMeter::maximum_required(&enqueued_message.command) as u128;
-			let max_refund = Self::maximum_refund(&enqueued_message.command);
-			let reward = T::DeliveryReward::get();
+			let max_refund = Self::calculate_maximum_gas_refund(&enqueued_message.command);
+			let reward = Self::fee_config().reward;
 
-			// Construct a prepared message, which when ABI-encoded is what the
-			// other side of the bridge will verify.
-			let message: PreparedMessage = PreparedMessage {
+			// Construct the final committed message
+			let message = CommittedMessage {
 				origin: enqueued_message.origin,
 				nonce: next_nonce,
 				command,
@@ -314,94 +386,46 @@ pub mod pallet {
 			T::GasMeter::MAXIMUM_BASE_GAS + T::GasMeter::maximum_required(command)
 		}
 
-		/// Fee in DOT for delivering a message.
-		pub(crate) fn delivery_fee(command: &Command) -> T::Balance {
-			let max_gas_used = Self::maximum_overall_required_gas(command);
-			T::DeliveryFeePerGas::get().saturating_mul(max_gas_used.into())
+		/// Calculate fee in native currency for delivering a message.
+		pub(crate) fn calculate_fee(command: &Command) -> Option<Fee<T::Balance>> {
+			let max_gas = Self::maximum_overall_required_gas(command);
+			let remote_fee = Self::calculate_remote_fee(
+				max_gas,
+				Self::fee_config().fee_per_gas,
+				Self::fee_config().reward,
+			);
+			let remote_fee = FixedU128::from(remote_fee)
+				.checked_div(&Self::fee_config().exchange_rate)?
+				.into_inner()
+				.checked_div(FixedU128::accuracy())
+				.expect("accuracy is not zero; qed")
+				.into();
+			let local_fee = Self::calculate_local_fee();
+			let fee = Fee::from((local_fee, remote_fee));
+
+			Some(fee)
+		}
+
+		/// Calculate fee in remote currency for dispatching a message on Ethereum
+		pub(crate) fn calculate_remote_fee(
+			max_gas_required: u64,
+			fee_per_gas: u128,
+			reward: u128,
+		) -> u128 {
+			fee_per_gas.saturating_mul(max_gas_required.into()).saturating_add(reward)
+		}
+
+		/// Calculate fee in native currency for processing a message locally
+		pub(crate) fn calculate_local_fee() -> T::Balance {
+			T::WeightToFee::weight_to_fee(
+				&T::WeightInfo::do_process_message().saturating_add(T::WeightInfo::commit_single()),
+			)
 		}
 
 		/// Maximum refund in Ether for delivering a message
-		pub(crate) fn maximum_refund(command: &Command) -> u128 {
-			let max_gas_used = Self::maximum_overall_required_gas(command);
-			T::DeliveryRefundPerGas::get().saturating_mul(max_gas_used as u128)
-		}
-	}
-
-	impl<T: Config> OutboundQueueTrait for Pallet<T> {
-		type Ticket = OutboundQueueTicket<MaxEnqueuedMessageSizeOf<T>>;
-		type Balance = T::Balance;
-
-		fn validate(message: &Message) -> Result<(Self::Ticket, Fees<Self::Balance>), SendError> {
-			// The inner payload should not be too large
-			let payload = message.command.abi_encode();
-
-			// Create a message id for tracking progress in submission pipeline
-			let message_id: MessageHash = sp_io::hashing::blake2_256(&(message.encode())).into();
-
-			ensure!(
-				payload.len() < T::MaxMessagePayloadSize::get() as usize,
-				SendError::MessageTooLarge
-			);
-
-			let base_fee = T::WeightToFee::weight_to_fee(
-				&T::WeightInfo::do_process_message()
-					.saturating_add(T::WeightInfo::commit_one_message()),
-			);
-			let delivery_fee = Self::delivery_fee(&message.command);
-
-			let command = message.command.clone();
-			let fee = Fees { base: base_fee, delivery: delivery_fee };
-
-			let enqueued_message: EnqueuedMessage =
-				EnqueuedMessage { id: message_id, origin: message.origin, command };
-			// The whole message should not be too large
-			let encoded =
-				enqueued_message.encode().try_into().map_err(|_| SendError::MessageTooLarge)?;
-
-			let ticket =
-				OutboundQueueTicket { id: message_id, origin: message.origin, message: encoded };
-
-			Ok((ticket, fee))
-		}
-
-		fn submit(ticket: Self::Ticket) -> Result<MessageHash, SendError> {
-			// Assign an `AggregateMessageOrigin` to track the message within the MessageQueue
-			// pallet. Governance commands are assigned origin `ExportOrigin::Here`. In other words
-			// emitted from BridgeHub itself.
-			let origin = if ticket.origin == T::OwnParaId::get() {
-				AggregateMessageOrigin::Export(ExportOrigin::Here)
-			} else {
-				AggregateMessageOrigin::Export(ExportOrigin::Sibling(ticket.origin))
-			};
-
-			if let AggregateMessageOrigin::Export(ExportOrigin::Here) = origin {
-				// Increase PendingHighPriorityMessageCount by one
-				PendingHighPriorityMessageCount::<T>::mutate(|count| {
-					*count = count.saturating_add(1)
-				});
-			} else {
-				ensure!(!Self::operating_mode().is_halted(), SendError::Halted);
-			}
-
-			T::MessageQueue::enqueue_message(ticket.message.as_bounded_slice(), origin);
-			Self::deposit_event(Event::MessageQueued { id: ticket.id });
-			Ok(ticket.id)
-		}
-	}
-
-	impl<T: Config> ProcessMessage for Pallet<T> {
-		type Origin = AggregateMessageOrigin;
-		fn process_message(
-			message: &[u8],
-			origin: Self::Origin,
-			meter: &mut frame_support::weights::WeightMeter,
-			_: &mut [u8; 32],
-		) -> Result<bool, ProcessMessageError> {
-			let weight = T::WeightInfo::do_process_message();
-			if meter.try_consume(weight).is_err() {
-				return Err(ProcessMessageError::Overweight(weight))
-			}
-			Self::do_process_message(origin, message)
+		pub(crate) fn calculate_maximum_gas_refund(command: &Command) -> u128 {
+			let max_gas = Self::maximum_overall_required_gas(command);
+			Self::fee_config().fee_per_gas.saturating_mul(max_gas.into())
 		}
 	}
 }

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -295,7 +295,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::call_index(4)]
+		#[pallet::call_index(1)]
 		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
 		pub fn set_fee_config(origin: OriginFor<T>, fee_config: FeeConfigRecord) -> DispatchResult {
 			ensure_root(origin)?;

--- a/parachain/pallets/outbound-queue/src/lib.rs
+++ b/parachain/pallets/outbound-queue/src/lib.rs
@@ -252,6 +252,7 @@ pub mod pallet {
 		FeeConfigRecord {
 			exchange_rate: FixedU128::saturating_from_rational(1, 400),
 			fee_per_gas: 30 * GWEI,
+			#[allow(clippy::identity_op)]
 			reward: 1 * METH,
 		}
 	}
@@ -398,24 +399,22 @@ pub mod pallet {
 		/// Calculate fee in native currency for delivering a message.
 		pub(crate) fn calculate_fee(command: &Command) -> Fee<T::Balance> {
 			let max_gas = Self::maximum_overall_required_gas(command);
-			let remote_fee = Self::calculate_remote_fee(
+			let remote = Self::calculate_remote_fee(
 				max_gas,
 				Self::fee_config().fee_per_gas,
 				Self::fee_config().reward,
 			);
 
-			let remote_fee = FixedU128::from(remote_fee)
+			let remote = FixedU128::from(remote)
 				.checked_div(&Self::fee_config().exchange_rate)
 				.expect("exchange rate is not zero; qed")
 				.into_inner()
 				.checked_div(FixedU128::accuracy())
-				.expect("accuracy is not zero; qed")
-				.into();
+				.expect("accuracy is not zero; qed");
 
-			let remote_fee = Self::convert_from_ether_decimals(remote_fee);
+			let remote = Self::convert_from_ether_decimals(remote);
 
-			let local_fee = Self::calculate_local_fee();
-			Fee::from((local_fee, remote_fee))
+			Fee::from((Self::calculate_local_fee(), remote))
 		}
 
 		/// Calculate fee in remote currency for dispatching a message on Ethereum

--- a/parachain/pallets/outbound-queue/src/mock.rs
+++ b/parachain/pallets/outbound-queue/src/mock.rs
@@ -4,15 +4,14 @@ use super::*;
 
 use frame_support::{
 	parameter_types,
-	traits::{Everything, GenesisBuild, Hooks},
+	traits::{Everything, Hooks},
 	weights::IdentityFee,
 };
 
 use sp_core::{ConstU32, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup, Keccak256},
-	AccountId32,
+	AccountId32, BuildStorage,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -23,7 +22,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Storage, Event<T>},
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},
-		OutboundQueue: crate::{Pallet, Storage, Config, Event<T>},
+		OutboundQueue: crate::{Pallet, Storage, Config<T>, Event<T>},
 	}
 );
 
@@ -97,14 +96,15 @@ fn setup() {
 }
 
 pub fn new_tester() -> sp_io::TestExternalities {
-	let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 
-	let config = crate::GenesisConfig {
+	crate::GenesisConfig::<Test> {
 		operating_mode: Default::default(),
 		fee_config: FeeConfigRecord { exchange_rate: (1, 10).into(), fee_per_gas: 1, reward: 1 },
-	};
-
-	GenesisBuild::<Test>::assimilate_storage(&config, &mut storage).unwrap();
+		_config: Default::default(),
+	}
+	.assimilate_storage(&mut storage)
+	.unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
 	ext.execute_with(|| setup());

--- a/parachain/pallets/outbound-queue/src/mock.rs
+++ b/parachain/pallets/outbound-queue/src/mock.rs
@@ -9,7 +9,7 @@ use frame_support::{
 };
 
 use snowbridge_core::outbound::*;
-use sp_core::{ConstU32, H160, H256};
+use sp_core::{ConstU32, ConstU8, H160, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup, Keccak256},
 	AccountId32, BuildStorage,
@@ -23,7 +23,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Storage, Event<T>},
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},
-		OutboundQueue: crate::{Pallet, Storage, Config<T>, Event<T>},
+		OutboundQueue: crate::{Pallet, Storage, Event<T>},
 	}
 );
 
@@ -83,10 +83,11 @@ impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Hashing = Keccak256;
 	type MessageQueue = MessageQueue;
+	type Decimals = ConstU8<10>;
 	type MaxMessagePayloadSize = ConstU32<1024>;
 	type MaxMessagesPerBlock = ConstU32<20>;
 	type OwnParaId = OwnParaId;
-	type GasMeter = ();
+	type GasMeter = ConstantGasMeter;
 	type Balance = u128;
 	type WeightToFee = IdentityFee<u128>;
 	type WeightInfo = ();
@@ -97,16 +98,7 @@ fn setup() {
 }
 
 pub fn new_tester() -> sp_io::TestExternalities {
-	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-
-	crate::GenesisConfig::<Test> {
-		operating_mode: Default::default(),
-		fee_config: FeeConfigRecord { exchange_rate: (1, 10).into(), fee_per_gas: 1, reward: 1 },
-		_config: Default::default(),
-	}
-	.assimilate_storage(&mut storage)
-	.unwrap();
-
+	let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	let mut ext: sp_io::TestExternalities = storage.into();
 	ext.execute_with(|| setup());
 	ext

--- a/parachain/pallets/outbound-queue/src/mock.rs
+++ b/parachain/pallets/outbound-queue/src/mock.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+use super::*;
+
+use frame_support::{
+	parameter_types,
+	traits::{Everything, GenesisBuild, Hooks},
+	weights::IdentityFee,
+};
+
+use sp_core::{ConstU32, H256};
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup, Keccak256},
+	AccountId32,
+};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+type AccountId = AccountId32;
+
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system::{Pallet, Call, Storage, Event<T>},
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},
+		OutboundQueue: crate::{Pallet, Storage, Config, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type Nonce = u64;
+	type Block = Block;
+}
+
+parameter_types! {
+	pub const HeapSize: u32 = 32 * 1024;
+	pub const MaxStale: u32 = 32;
+	pub static ServiceWeight: Option<Weight> = Some(Weight::from_parts(100, 100));
+}
+
+impl pallet_message_queue::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type MessageProcessor = OutboundQueue;
+	type Size = u32;
+	type QueueChangeHandler = ();
+	type HeapSize = HeapSize;
+	type MaxStale = MaxStale;
+	type ServiceWeight = ServiceWeight;
+	type QueuePausedQuery = ();
+}
+
+parameter_types! {
+	pub const OwnParaId: ParaId = ParaId::new(1013);
+}
+
+impl crate::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Hashing = Keccak256;
+	type MessageQueue = MessageQueue;
+	type MaxMessagePayloadSize = ConstU32<1024>;
+	type MaxMessagesPerBlock = ConstU32<20>;
+	type OwnParaId = OwnParaId;
+	type GasMeter = ();
+	type Balance = u128;
+	type WeightToFee = IdentityFee<u128>;
+	type WeightInfo = ();
+}
+
+fn setup() {
+	System::set_block_number(1);
+}
+
+pub fn new_tester() -> sp_io::TestExternalities {
+	let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+	let config = crate::GenesisConfig {
+		operating_mode: Default::default(),
+		fee_config: FeeConfigRecord { exchange_rate: (1, 10).into(), fee_per_gas: 1, reward: 1 },
+	};
+
+	GenesisBuild::<Test>::assimilate_storage(&config, &mut storage).unwrap();
+
+	let mut ext: sp_io::TestExternalities = storage.into();
+	ext.execute_with(|| setup());
+	ext
+}
+
+pub fn run_to_end_of_next_block() {
+	// finish current block
+	MessageQueue::on_finalize(System::block_number());
+	OutboundQueue::on_finalize(System::block_number());
+	System::on_finalize(System::block_number());
+	// start next block
+	System::set_block_number(System::block_number() + 1);
+	System::on_initialize(System::block_number());
+	OutboundQueue::on_initialize(System::block_number());
+	MessageQueue::on_initialize(System::block_number());
+	// finish next block
+	MessageQueue::on_finalize(System::block_number());
+	OutboundQueue::on_finalize(System::block_number());
+	System::on_finalize(System::block_number());
+}

--- a/parachain/pallets/outbound-queue/src/process_message_impl.rs
+++ b/parachain/pallets/outbound-queue/src/process_message_impl.rs
@@ -1,0 +1,24 @@
+//! Implementation for [`frame_support::traits::ProcessMessage`]
+use super::*;
+use crate::weights::WeightInfo;
+use frame_support::{
+	traits::{ProcessMessage, ProcessMessageError},
+	weights::WeightMeter,
+};
+use snowbridge_core::outbound::AggregateMessageOrigin;
+
+impl<T: Config> ProcessMessage for Pallet<T> {
+	type Origin = AggregateMessageOrigin;
+	fn process_message(
+		message: &[u8],
+		origin: Self::Origin,
+		meter: &mut WeightMeter,
+		_: &mut [u8; 32],
+	) -> Result<bool, ProcessMessageError> {
+		let weight = T::WeightInfo::do_process_message();
+		if !meter.check_accrue(weight) {
+			return Err(ProcessMessageError::Overweight(weight))
+		}
+		Self::do_process_message(origin, message)
+	}
+}

--- a/parachain/pallets/outbound-queue/src/process_message_impl.rs
+++ b/parachain/pallets/outbound-queue/src/process_message_impl.rs
@@ -16,7 +16,7 @@ impl<T: Config> ProcessMessage for Pallet<T> {
 		_: &mut [u8; 32],
 	) -> Result<bool, ProcessMessageError> {
 		let weight = T::WeightInfo::do_process_message();
-		if !meter.check_accrue(weight) {
+		if meter.try_consume(weight).is_err() {
 			return Err(ProcessMessageError::Overweight(weight))
 		}
 		Self::do_process_message(origin, message)

--- a/parachain/pallets/outbound-queue/src/queue_paused_query_impl.rs
+++ b/parachain/pallets/outbound-queue/src/queue_paused_query_impl.rs
@@ -1,0 +1,28 @@
+//! Implementation for [`frame_support::traits::QueuePausedQuery`]
+use super::*;
+use frame_support::traits::QueuePausedQuery;
+use snowbridge_core::outbound::{AggregateMessageOrigin, ExportOrigin};
+
+impl<T> QueuePausedQuery<AggregateMessageOrigin> for Pallet<T>
+where
+	T: Config,
+{
+	fn is_paused(origin: &AggregateMessageOrigin) -> bool {
+		use AggregateMessageOrigin::*;
+		use ExportOrigin::*;
+
+		// Queues for sibling parachains are paused when:
+		// 1. The pallet is halted
+		// 2. A higher-priority queue has pending messages
+		if let Export(Sibling(_)) = origin {
+			if Self::operating_mode().is_halted() {
+				return true
+			}
+			if PendingHighPriorityMessageCount::<T>::get() > 0 {
+				return true
+			}
+		}
+
+		false
+	}
+}

--- a/parachain/pallets/outbound-queue/src/send_message_impl.rs
+++ b/parachain/pallets/outbound-queue/src/send_message_impl.rs
@@ -7,7 +7,7 @@ use frame_support::{
 	CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
 use snowbridge_core::outbound::{
-	AggregateMessageOrigin, QueuedMessage, ExportOrigin, Fee, Message, SendError, SendMessage,
+	AggregateMessageOrigin, ExportOrigin, Fee, Message, QueuedMessage, SendError, SendMessage,
 	VersionedQueuedMessage,
 };
 use sp_core::H256;
@@ -40,7 +40,7 @@ impl<T: Config> SendMessage for Pallet<T> {
 			SendError::MessageTooLarge
 		);
 
-		let fee = Self::calculate_fee(&message.command).ok_or(SendError::Overflow)?;
+		let fee = Self::calculate_fee(&message.command);
 
 		let queued_message: VersionedQueuedMessage = QueuedMessage {
 			id: message_id,
@@ -49,9 +49,7 @@ impl<T: Config> SendMessage for Pallet<T> {
 		}
 		.into();
 		// The whole message should not be too large
-		let encoded = queued_message.encode()
-			.try_into()
-			.map_err(|_| SendError::MessageTooLarge)?;
+		let encoded = queued_message.encode().try_into().map_err(|_| SendError::MessageTooLarge)?;
 
 		let ticket = Ticket { id: message_id, origin: message.origin, message: encoded };
 

--- a/parachain/pallets/outbound-queue/src/send_message_impl.rs
+++ b/parachain/pallets/outbound-queue/src/send_message_impl.rs
@@ -1,0 +1,87 @@
+//! Implementation for [`snowbridge_core::outbound::SendMessage`]
+use super::*;
+use codec::Encode;
+use frame_support::{
+	ensure,
+	traits::{EnqueueMessage, Get},
+	CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound,
+};
+use snowbridge_core::outbound::{
+	AggregateMessageOrigin, QueuedMessage, ExportOrigin, Fee, Message, SendError, SendMessage,
+	VersionedQueuedMessage,
+};
+use sp_core::H256;
+use sp_runtime::BoundedVec;
+
+/// The maximal length of an enqueued message, as determined by the MessageQueue pallet
+pub type MaxEnqueuedMessageSizeOf<T> =
+	<<T as Config>::MessageQueue as EnqueueMessage<AggregateMessageOrigin>>::MaxMessageLen;
+
+#[derive(Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound)]
+pub struct Ticket<MaxMessageSize: Get<u32>> {
+	pub id: H256,
+	pub origin: ParaId,
+	pub message: BoundedVec<u8, MaxMessageSize>,
+}
+
+impl<T: Config> SendMessage for Pallet<T> {
+	type Ticket = Ticket<MaxEnqueuedMessageSizeOf<T>>;
+	type Balance = T::Balance;
+
+	fn validate(message: &Message) -> Result<(Self::Ticket, Fee<Self::Balance>), SendError> {
+		// The inner payload should not be too large
+		let payload = message.command.abi_encode();
+
+		// Create a message id for tracking progress in submission pipeline
+		let message_id: H256 = sp_io::hashing::blake2_256(&(message.encode())).into();
+
+		ensure!(
+			payload.len() < T::MaxMessagePayloadSize::get() as usize,
+			SendError::MessageTooLarge
+		);
+
+		let fee = Self::calculate_fee(&message.command).ok_or(SendError::Overflow)?;
+
+		let queued_message: VersionedQueuedMessage = QueuedMessage {
+			id: message_id,
+			origin: message.origin,
+			command: message.command.clone(),
+		}
+		.into();
+		// The whole message should not be too large
+		let encoded = queued_message.encode()
+			.try_into()
+			.map_err(|_| SendError::MessageTooLarge)?;
+
+		let ticket = Ticket { id: message_id, origin: message.origin, message: encoded };
+
+		Ok((ticket, fee))
+	}
+
+	fn deliver(ticket: Self::Ticket) -> Result<H256, SendError> {
+		use AggregateMessageOrigin::*;
+		use ExportOrigin::*;
+
+		// Assign an `AggregateMessageOrigin` to track the message within the MessageQueue
+		// pallet. Governance commands are assigned origin `ExportOrigin::Here`. In other words
+		// emitted from BridgeHub itself.
+		let origin = if ticket.origin == T::OwnParaId::get() {
+			Export(Here)
+		} else {
+			Export(Sibling(ticket.origin))
+		};
+
+		if let Export(Here) = origin {
+			// Increase PendingHighPriorityMessageCount by one
+			PendingHighPriorityMessageCount::<T>::mutate(|count| *count = count.saturating_add(1));
+		} else {
+			ensure!(!Self::operating_mode().is_halted(), SendError::Halted);
+		}
+
+		let message = ticket.message.as_bounded_slice();
+
+		T::MessageQueue::enqueue_message(message, origin);
+		Self::deposit_event(Event::MessageQueued { id: ticket.id });
+		Ok(ticket.id)
+	}
+}

--- a/parachain/pallets/outbound-queue/src/test.rs
+++ b/parachain/pallets/outbound-queue/src/test.rs
@@ -134,7 +134,7 @@ fn set_fee_config_root_only() {
 	new_tester().execute_with(|| {
 		let origin = RuntimeOrigin::signed(AccountId32::from([0; 32]));
 		assert_noop!(
-			OutboundQueue::set_fee_config(origin, Default::default()),
+			OutboundQueue::set_fee_config(origin, DefaultFeeConfig::get()),
 			DispatchError::BadOrigin,
 		);
 	})

--- a/parachain/pallets/outbound-queue/src/test.rs
+++ b/parachain/pallets/outbound-queue/src/test.rs
@@ -9,53 +9,16 @@ use frame_support::{
 };
 
 use codec::Encode;
-use snowbridge_core::outbound::{
-	AgentExecuteCommand, Command, ExportOrigin, Initializer, Message, SendError, SendMessage,
-};
-use sp_core::{H160, H256};
+use snowbridge_core::outbound::{Command, ExportOrigin, SendError, SendMessage};
+use sp_core::H256;
 use sp_runtime::{AccountId32, DispatchError};
 
 #[test]
-fn submit_messages_from_multiple_origins_and_commit() {
+fn submit_messages_and_commit() {
 	new_tester().execute_with(|| {
-		//next_block();
-
 		for para_id in 1000..1004 {
-			let message = Message {
-				origin: para_id.into(),
-				command: Command::Upgrade {
-					impl_address: H160::zero(),
-					impl_code_hash: H256::zero(),
-					initializer: None,
-				},
-			};
-
+			let message = mock_message(para_id);
 			let (ticket, _) = OutboundQueue::validate(&message).unwrap();
-			assert_ok!(OutboundQueue::deliver(ticket));
-		}
-
-		for para_id in 1000..1004 {
-			let message = Message {
-				origin: para_id.into(),
-				command: Command::CreateAgent { agent_id: Default::default() },
-			};
-
-			let (ticket, _) = OutboundQueue::validate(&message).unwrap();
-			assert_ok!(OutboundQueue::deliver(ticket));
-		}
-
-		for para_id in 1000..1004 {
-			let message = Message {
-				origin: para_id.into(),
-				command: Command::Upgrade {
-					impl_address: Default::default(),
-					impl_code_hash: Default::default(),
-					initializer: None,
-				},
-			};
-
-			let (ticket, _) = OutboundQueue::validate(&message).unwrap();
-
 			assert_ok!(OutboundQueue::deliver(ticket));
 		}
 
@@ -64,30 +27,20 @@ fn submit_messages_from_multiple_origins_and_commit() {
 
 		for para_id in 1000..1004 {
 			let origin: ParaId = (para_id as u32).into();
-			assert_eq!(Nonce::<Test>::get(origin), 3);
+			assert_eq!(Nonce::<Test>::get(origin), 1);
 		}
 
 		let digest = System::digest();
 		let digest_items = digest.logs();
 		assert!(digest_items.len() == 1 && digest_items[0].as_other().is_some());
+		assert_eq!(Messages::<Test>::decode_len(), Some(4));
 	});
 }
 
 #[test]
 fn submit_message_fail_too_large() {
 	new_tester().execute_with(|| {
-		let message = Message {
-			origin: 1000.into(),
-			command: Command::Upgrade {
-				impl_address: H160::zero(),
-				impl_code_hash: H256::zero(),
-				initializer: Some(Initializer {
-					params: (0..1000).map(|_| 1u8).collect::<Vec<u8>>(),
-					maximum_required_gas: 0,
-				}),
-			},
-		};
-
+		let message = mock_invalid_governance_message::<Test>();
 		assert_err!(OutboundQueue::validate(&message), SendError::MessageTooLarge);
 	});
 }
@@ -95,17 +48,8 @@ fn submit_message_fail_too_large() {
 #[test]
 fn calculate_fees() {
 	new_tester().execute_with(|| {
-		let command = Command::Upgrade {
-			impl_address: H160::zero(),
-			impl_code_hash: H256::zero(),
-			initializer: Some(Initializer {
-				params: (0..256).map(|_| 1u8).collect::<Vec<u8>>(),
-				maximum_required_gas: 0,
-			}),
-		};
-
+		let command = mock_message(1000).command;
 		let fee = OutboundQueue::calculate_fee(&command).unwrap();
-
 		// ((gas(2) * fee_per_gas(1)) + reward(1)) / xrate(1/10) = 30
 		assert_eq!(fee.remote, 30);
 	});
@@ -154,21 +98,10 @@ fn process_message_yields_on_max_messages_per_block() {
 #[test]
 fn process_message_fails_on_overweight_message() {
 	new_tester().execute_with(|| {
-		let origin = AggregateMessageOrigin::Export(ExportOrigin::Sibling(1000.into()));
-
-		let message = QueuedMessage {
-			id: Default::default(),
-			origin: 1000.into(),
-			command: Command::Upgrade {
-				impl_address: Default::default(),
-				impl_code_hash: Default::default(),
-				initializer: None,
-			},
-		}
-		.encode();
-
+		let sibling_id = 1000;
+		let origin = AggregateMessageOrigin::Export(ExportOrigin::Sibling(sibling_id.into()));
+		let message = mock_message(sibling_id).encode();
 		let mut meter = WeightMeter::with_limit(Weight::from_parts(1, 1));
-
 		assert_noop!(
 			OutboundQueue::process_message(&message.as_slice(), origin, &mut meter, &mut [0u8; 32]),
 			ProcessMessageError::Overweight(<Test as Config>::WeightInfo::do_process_message())
@@ -213,159 +146,66 @@ fn set_fee_config_invalid() {
 }
 
 #[test]
-fn submit_low_priority_messages_yield_when_there_is_high_priority_message() {
+fn low_priority_messages_are_processed_last() {
+	use AggregateMessageOrigin::*;
+	use ExportOrigin::*;
+
+	let sibling_id = 1000;
+	let high_priority_queue = Export(Here);
+	let low_priority_queue = Export(Sibling(sibling_id.into()));
+
 	new_tester().execute_with(|| {
-		// submit a low priority message from asset_hub first
-		let message = Message {
-			origin: 1000.into(),
-			command: Command::AgentExecute {
-				agent_id: Default::default(),
-				command: AgentExecuteCommand::TransferToken {
-					token: Default::default(),
-					recipient: Default::default(),
-					amount: 0,
-				},
-			},
-		};
-		let result = OutboundQueue::validate(&message);
-		assert!(result.is_ok());
-		let ticket = result.unwrap();
-		assert_ok!(OutboundQueue::deliver(ticket.0));
-
-		// then submit a high priority message from bridge_hub
-		let message = Message {
-			origin: 1013.into(),
-			command: Command::Upgrade {
-				impl_address: H160::zero(),
-				impl_code_hash: H256::zero(),
-				initializer: None,
-			},
-		};
-		let result = OutboundQueue::validate(&message);
-		assert!(result.is_ok());
-		let ticket = result.unwrap();
-		assert_ok!(OutboundQueue::deliver(ticket.0));
-		let mut footprint =
-			MessageQueue::footprint(AggregateMessageOrigin::Export(ExportOrigin::Here));
-		println!("{:?}", footprint);
-		assert_eq!(footprint.count, 1);
-
-		// process a low priority message from asset_hub will yield
-		let origin = AggregateMessageOrigin::Export(ExportOrigin::Sibling(1000.into()));
-		let message = QueuedMessage {
-			id: Default::default(),
-			origin: 1000.into(),
-			command: Command::AgentExecute {
-				agent_id: Default::default(),
-				command: AgentExecuteCommand::TransferToken {
-					token: Default::default(),
-					recipient: Default::default(),
-					amount: 0,
-				},
-			},
-		}
-		.encode();
-
-		let mut meter = WeightMeter::new();
-
-		assert_noop!(
-			OutboundQueue::process_message(&message.as_slice(), origin, &mut meter, &mut [0u8; 32]),
-			ProcessMessageError::Yield
-		);
-
-		// run to next block and ensure high priority message processed
-		ServiceWeight::set(Some(Weight::MAX));
-		run_to_end_of_next_block();
-		let digest = System::digest();
-		let digest_items = digest.logs();
-		assert!(digest_items.len() == 1 && digest_items[0].as_other().is_some());
-		footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(ExportOrigin::Here));
-		assert_eq!(footprint.count, 0);
-	});
-}
-
-#[test]
-fn submit_high_priority_message_will_not_blocked_even_when_low_priority_queue_get_spammed() {
-	new_tester().execute_with(|| {
-		// submit a lot of low priority messages from asset_hub which will need multiple blocks to
+		// submit a lot of high priority messages from asset_hub which will need multiple blocks to
 		// execute(60 for 3 blocks)
 		let max_messages = 60;
 		for _ in 0..max_messages {
-			let message = Message {
-				origin: 1000.into(),
-				command: Command::AgentExecute {
-					agent_id: Default::default(),
-					command: AgentExecuteCommand::TransferToken {
-						token: Default::default(),
-						recipient: Default::default(),
-						amount: 0,
-					},
-				},
-			};
-			let result = OutboundQueue::validate(&message);
-			assert!(result.is_ok());
-			let ticket = result.unwrap();
-			assert_ok!(OutboundQueue::deliver(ticket.0));
+			let message = mock_governance_message::<Test>();
+			let (ticket, _) = OutboundQueue::validate(&message).unwrap();
+			OutboundQueue::deliver(ticket).unwrap();
 		}
-
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(
-			ExportOrigin::Sibling(1000.into()),
-		));
+		let footprint = MessageQueue::footprint(high_priority_queue);
 		assert_eq!(footprint.count, (max_messages) as u64);
 
-		// submit high priority message from bridge_hub
-		let message = Message {
-			origin: 1013.into(),
-			command: Command::Upgrade {
-				impl_address: H160::zero(),
-				impl_code_hash: H256::zero(),
-				initializer: None,
-			},
-		};
-		let result = OutboundQueue::validate(&message);
-		assert!(result.is_ok());
-		let ticket = result.unwrap();
-		assert_ok!(OutboundQueue::deliver(ticket.0));
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(ExportOrigin::Here));
-		println!("{:?}", footprint);
+		// submit low priority message
+		let message = mock_message(sibling_id);
+		let (ticket, _) = OutboundQueue::validate(&message).unwrap();
+		OutboundQueue::deliver(ticket).unwrap();
+		let footprint = MessageQueue::footprint(low_priority_queue);
 		assert_eq!(footprint.count, 1);
 
-		// run to next block high priority message and some of the low priority messages get
-		// executed
+		// run to next block; only high priority messages should have been processed
 		ServiceWeight::set(Some(Weight::MAX));
 		run_to_end_of_next_block();
-		let digest = System::digest();
-		let digest_items = digest.logs();
-		assert!(digest_items.len() == 1 && digest_items[0].as_other().is_some());
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(
-			ExportOrigin::Sibling(1000.into()),
-		));
-		assert_eq!(footprint.count, 41);
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(ExportOrigin::Here));
+		let footprint = MessageQueue::footprint(high_priority_queue);
+		assert_eq!(footprint.count, 40);
+
+		let footprint = MessageQueue::footprint(low_priority_queue);
+		assert_eq!(footprint.count, 1);
+
+		// move to the next block, some high priority messages get executed
+		ServiceWeight::set(Some(Weight::MAX));
+		run_to_end_of_next_block();
+		let footprint = MessageQueue::footprint(high_priority_queue);
+		assert_eq!(footprint.count, 20);
+
+		let footprint = MessageQueue::footprint(low_priority_queue);
+		assert_eq!(footprint.count, 1);
+
+		// move to the next block, some high priority messages get executed
+		ServiceWeight::set(Some(Weight::MAX));
+		run_to_end_of_next_block();
+		let footprint = MessageQueue::footprint(high_priority_queue);
 		assert_eq!(footprint.count, 0);
 
-		// move to the next block, some low priority messages get executed
-		ServiceWeight::set(Some(Weight::MAX));
-		run_to_end_of_next_block();
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(
-			ExportOrigin::Sibling(1000.into()),
-		));
-		assert_eq!(footprint.count, 21);
-
-		// move to the next block, some low priority messages get executed
-		ServiceWeight::set(Some(Weight::MAX));
-		run_to_end_of_next_block();
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(
-			ExportOrigin::Sibling(1000.into()),
-		));
+		let footprint = MessageQueue::footprint(low_priority_queue);
 		assert_eq!(footprint.count, 1);
 
-		// move to the next block, the last low priority messages get executed
+		// move to the next block, the last remaining pending message,
+		// a lower priority one, is processed
 		ServiceWeight::set(Some(Weight::MAX));
 		run_to_end_of_next_block();
-		let footprint = MessageQueue::footprint(AggregateMessageOrigin::Export(
-			ExportOrigin::Sibling(1000.into()),
-		));
+
+		let footprint = MessageQueue::footprint(low_priority_queue);
 		assert_eq!(footprint.count, 0);
 	});
 }
@@ -376,40 +216,17 @@ fn submit_high_priority_message_will_not_blocked_even_when_low_priority_queue_ge
 fn submit_upgrade_message_success_when_queue_halted() {
 	new_tester().execute_with(|| {
 		// halt the outbound queue
-		assert_ok!(OutboundQueue::set_operating_mode(
-			RuntimeOrigin::root(),
-			BasicOperatingMode::Halted
-		));
+		OutboundQueue::set_operating_mode(RuntimeOrigin::root(), BasicOperatingMode::Halted)
+			.unwrap();
 
 		// submit a high priority message from bridge_hub should success
-		let message = Message {
-			origin: 1013.into(),
-			command: Command::Upgrade {
-				impl_address: H160::zero(),
-				impl_code_hash: H256::zero(),
-				initializer: None,
-			},
-		};
-		let result = OutboundQueue::validate(&message);
-		assert!(result.is_ok());
-		let ticket = result.unwrap();
-		assert_ok!(OutboundQueue::deliver(ticket.0));
+		let message = mock_governance_message::<Test>();
+		let (ticket, _) = OutboundQueue::validate(&message).unwrap();
+		assert_ok!(OutboundQueue::deliver(ticket));
 
-		// submit a low priority message from asset_hub will fail
-		let message = Message {
-			origin: 1000.into(),
-			command: Command::AgentExecute {
-				agent_id: Default::default(),
-				command: AgentExecuteCommand::TransferToken {
-					token: Default::default(),
-					recipient: Default::default(),
-					amount: 0,
-				},
-			},
-		};
-		let result = OutboundQueue::validate(&message);
-		assert!(result.is_ok());
-		let ticket = result.unwrap();
-		assert_noop!(OutboundQueue::deliver(ticket.0), SendError::Halted);
+		// submit a low priority message from asset_hub will fail as pallet is halted
+		let message = mock_message(1000);
+		let (ticket, _) = OutboundQueue::validate(&message).unwrap();
+		assert_noop!(OutboundQueue::deliver(ticket), SendError::Halted);
 	});
 }

--- a/parachain/pallets/outbound-queue/src/test.rs
+++ b/parachain/pallets/outbound-queue/src/test.rs
@@ -49,10 +49,19 @@ fn submit_message_fail_too_large() {
 fn calculate_fees() {
 	new_tester().execute_with(|| {
 		let command = mock_message(1000).command;
-		let fee = OutboundQueue::calculate_fee(&command).unwrap();
-		// ((gas(2) * fee_per_gas(1)) + reward(1)) / xrate(1/10) = 30
-		assert_eq!(fee.remote, 30);
+		let fee = OutboundQueue::calculate_fee(&command);
+		assert_eq!(fee.remote, 31000000000);
+
+		println!("Total fee: {}", fee.total())
 	});
+}
+
+#[test]
+fn convert_from_ether_decimals() {
+	assert_eq!(
+		OutboundQueue::convert_from_ether_decimals(1_000_000_000_000_000_000),
+		1_000_000_000_0
+	);
 }
 
 #[test]

--- a/parachain/pallets/outbound-queue/src/types.rs
+++ b/parachain/pallets/outbound-queue/src/types.rs
@@ -60,7 +60,6 @@ impl From<CommittedMessage> for Token {
 	RuntimeDebug,
 	MaxEncodedLen,
 	TypeInfo,
-	Default,
 	Serialize,
 	Deserialize,
 )]

--- a/parachain/pallets/outbound-queue/src/types.rs
+++ b/parachain/pallets/outbound-queue/src/types.rs
@@ -1,0 +1,98 @@
+use codec::{Decode, Encode, MaxEncodedLen};
+use ethabi::Token;
+use frame_support::traits::ProcessMessage;
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sp_arithmetic::FixedU128;
+use sp_runtime::{FixedPointNumber, RuntimeDebug};
+use sp_std::prelude::*;
+
+use super::Pallet;
+
+use snowbridge_core::{ParaId, ETH, GWEI};
+pub use snowbridge_outbound_queue_merkle_tree::MerkleProof;
+
+pub type ProcessMessageOriginOf<T> = <Pallet<T> as ProcessMessage>::Origin;
+
+pub const LOG_TARGET: &str = "snowbridge-outbound-queue";
+
+/// Message which has been assigned a nonce and will be committed at the end of a block
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct CommittedMessage {
+	/// ID of source parachain
+	pub origin: ParaId,
+	/// Unique nonce to prevent replaying messages
+	pub nonce: u64,
+	/// Command to execute in the Gateway contract
+	pub command: u8,
+	/// Params for the command
+	pub params: Vec<u8>,
+	/// Maximum gas allowed for message dispatch
+	pub max_dispatch_gas: u128,
+	/// Maximum gas refund for message relayer
+	pub max_refund: u128,
+	/// Reward in ether for delivering this message, in addition to the gas refund
+	pub reward: u128,
+}
+
+/// Convert message into an ABI-encoded form for delivery to the InboundQueue contract on Ethereum
+impl From<CommittedMessage> for Token {
+	fn from(x: CommittedMessage) -> Token {
+		Token::Tuple(vec![
+			Token::Uint(u32::from(x.origin).into()),
+			Token::Uint(x.nonce.into()),
+			Token::Uint(x.command.into()),
+			Token::Bytes(x.params.to_vec()),
+			Token::Uint(x.max_dispatch_gas.into()),
+			Token::Uint(x.max_refund.into()),
+			Token::Uint(x.reward.into()),
+		])
+	}
+}
+
+pub const MAX_FEE_PER_GAS: u128 = 300 * GWEI;
+pub const MAX_REWARD: u128 = 1 * ETH;
+pub const MAX_EXCHANGE_RATE: FixedU128 = FixedU128::from_rational(1, 10_000);
+
+/// Configuration for fee calculations
+#[derive(
+	Encode,
+	Decode,
+	Copy,
+	Clone,
+	PartialEq,
+	RuntimeDebug,
+	MaxEncodedLen,
+	TypeInfo,
+	Serialize,
+	Deserialize,
+)]
+pub struct FeeConfigRecord {
+	/// ETH/DOT exchange rate
+	pub exchange_rate: FixedU128,
+	/// Ether fee per unit of gas
+	pub fee_per_gas: u128,
+	/// Ether reward for delivering message
+	pub reward: u128,
+}
+
+impl Default for FeeConfigRecord {
+	fn default() -> Self {
+		Self { exchange_rate: FixedU128::saturating_from_rational(1, 1), fee_per_gas: 1, reward: 0 }
+	}
+}
+
+impl FeeConfigRecord {
+	pub fn validate(&self) -> Result<(), ()> {
+		if self.exchange_rate < MAX_EXCHANGE_RATE {
+			return Err(())
+		}
+		if self.fee_per_gas == 0 || self.fee_per_gas > MAX_FEE_PER_GAS {
+			return Err(())
+		}
+		if self.reward > MAX_REWARD {
+			return Err(())
+		}
+		Ok(())
+	}
+}

--- a/parachain/pallets/outbound-queue/src/types.rs
+++ b/parachain/pallets/outbound-queue/src/types.rs
@@ -51,7 +51,7 @@ impl From<CommittedMessage> for Token {
 }
 
 pub const MAX_FEE_PER_GAS: u128 = 300 * GWEI;
-pub const MAX_REWARD: u128 = 1 * ETH;
+pub const MAX_REWARD: u128 = ETH;
 pub const MAX_EXCHANGE_RATE: FixedU128 = FixedU128::from_rational(1, 10_000);
 
 /// Configuration for fee calculations
@@ -82,16 +82,19 @@ impl Default for FeeConfigRecord {
 	}
 }
 
+#[derive(RuntimeDebug)]
+pub struct InvalidFeeConfig;
+
 impl FeeConfigRecord {
-	pub fn validate(&self) -> Result<(), ()> {
+	pub fn validate(&self) -> Result<(), InvalidFeeConfig> {
 		if self.exchange_rate < MAX_EXCHANGE_RATE {
-			return Err(())
+			return Err(InvalidFeeConfig)
 		}
 		if self.fee_per_gas == 0 || self.fee_per_gas > MAX_FEE_PER_GAS {
-			return Err(())
+			return Err(InvalidFeeConfig)
 		}
 		if self.reward > MAX_REWARD {
-			return Err(())
+			return Err(InvalidFeeConfig)
 		}
 		Ok(())
 	}

--- a/parachain/pallets/outbound-queue/src/weights.rs
+++ b/parachain/pallets/outbound-queue/src/weights.rs
@@ -32,8 +32,8 @@ use core::marker::PhantomData;
 /// Weight functions needed for `snowbridge_outbound_queue`.
 pub trait WeightInfo {
 	fn do_process_message() -> Weight;
-	fn commit_messages() -> Weight;
-	fn commit_one_message() -> Weight;
+	fn commit() -> Weight;
+	fn commit_single() -> Weight;
 }
 
 // For backwards compatibility and tests.
@@ -59,7 +59,7 @@ impl WeightInfo for () {
 	/// Proof Skipped: EthereumOutboundQueue MessageLeaves (max_values: Some(1), max_size: None, mode: Measured)
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
-	fn commit_messages() -> Weight {
+	fn commit() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1094`
 		//  Estimated: `2579`
@@ -69,7 +69,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 
-	fn commit_one_message() -> Weight {
+	fn commit_single() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1094`
 		//  Estimated: `2579`

--- a/parachain/primitives/core/Cargo.toml
+++ b/parachain/primitives/core/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Snowfork <contact@snowfork.com>"]
 edition = "2021"
 
 [dependencies]
-derivative = { version = "2.2.0", default-features = false, features = [ "use_core" ] }
-serde = { version = "1.0.188", optional = true, features = [ "derive" ] }
+serde = { version = "1.0.188", optional = true, features = [ "derive", "alloc" ], default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.9.0", default-features = false, features = [ "derive" ] }
 snowbridge-ethereum = { path = "../ethereum", default-features = false }
@@ -19,6 +18,8 @@ frame-system = { path = "../../../polkadot-sdk/substrate/frame/system", default-
 sp-runtime = { path = "../../../polkadot-sdk/substrate/primitives/runtime", default-features = false }
 sp-std = { path = "../../../polkadot-sdk/substrate/primitives/std", default-features = false }
 sp-core = { path = "../../../polkadot-sdk/substrate/primitives/core", default-features = false }
+sp-arithmetic = { path = "../../../polkadot-sdk/substrate/primitives/arithmetic", default-features = false }
+
 snowbridge-beacon-primitives = { path = "../../primitives/beacon", default-features = false }
 
 ethabi = { git = "https://github.com/Snowfork/ethabi-decode.git", package = "ethabi-decode", branch = "master", default-features = false }
@@ -29,7 +30,7 @@ hex = { package = "rustc-hex", version = "2.1.0", default-features = false }
 [features]
 default = ["std"]
 std = [
-    "serde",
+    "serde/std",
     "codec/std",
     "scale-info/std",
     "frame-support/std",
@@ -43,4 +44,5 @@ std = [
     "xcm/std",
     "ethabi/std",
 ]
+serde = ["dep:serde", "scale-info/serde"]
 runtime-benchmarks = []

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -29,4 +29,5 @@ where
 }
 
 pub const GWEI: u128 = 1_000_000_000;
+pub const METH: u128 = 1_000_000_000_000_000;
 pub const ETH: u128 = 1_000_000_000_000_000_000;

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -3,9 +3,6 @@
 //! # Core
 //!
 //! Common traits and types
-
-#![allow(dead_code)]
-#![allow(unused_variables)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod inbound;
@@ -30,3 +27,6 @@ where
 {
 	SiblingParaId::from(para_id).into_account_truncating()
 }
+
+pub const GWEI: u128 = 1_000_000_000;
+pub const ETH: u128 = 1_000_000_000_000_000_000;

--- a/parachain/primitives/core/src/operating_mode.rs
+++ b/parachain/primitives/core/src/operating_mode.rs
@@ -1,12 +1,10 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 use sp_runtime::RuntimeDebug;
 
 /// Basic operating modes for a bridges module (Normal/Halted).
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BasicOperatingMode {
 	/// Normal mode, when all operations are allowed.
 	Normal,

--- a/parachain/primitives/core/src/outbound.rs
+++ b/parachain/primitives/core/src/outbound.rs
@@ -285,10 +285,6 @@ pub enum SendError {
 	MessageTooLarge,
 	/// The bridge has been halted for maintenance
 	Halted,
-	/// An arithmetic error occurred while calculating fees
-	Overflow,
-	/// Too many enqueued messages
-	QueueFull,
 }
 
 pub trait GasMeter {
@@ -369,3 +365,5 @@ pub enum AggregateMessageOrigin {
 	/// Message is to be exported via a bridge
 	Export(ExportOrigin),
 }
+
+pub const ETHER_DECIMALS: u8 = 18;

--- a/parachain/primitives/core/src/outbound.rs
+++ b/parachain/primitives/core/src/outbound.rs
@@ -1,7 +1,6 @@
-use crate::ParaId;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::PalletError;
-pub use polkadot_parachain::primitives::Id as ParaId;
+pub use polkadot_parachain_primitives::primitives::Id as ParaId;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
 use sp_core::{RuntimeDebug, H256};
@@ -35,10 +34,9 @@ impl<T: Into<QueuedMessage>> From<T> for VersionedQueuedMessage {
 mod v1 {
 	use codec::{Decode, Encode};
 	use ethabi::Token;
-	use frame_support::RuntimeDebug;
-	pub use polkadot_parachain::primitives::Id as ParaId;
+	use polkadot_parachain_primitives::primitives::Id as ParaId;
 	use scale_info::TypeInfo;
-	use sp_core::{H160, H256, U256};
+	use sp_core::{RuntimeDebug, H160, H256, U256};
 	use sp_std::{borrow::ToOwned, vec, vec::Vec};
 
 	/// A message which can be accepted by the [`OutboundQueue`]

--- a/parachain/primitives/core/src/outbound.rs
+++ b/parachain/primitives/core/src/outbound.rs
@@ -1,49 +1,283 @@
 use crate::ParaId;
 use codec::{Decode, Encode, MaxEncodedLen};
-use derivative::Derivative;
-use ethabi::Token;
-use frame_support::{
-	traits::{tokens::Balance as BalanceT, Get},
-	BoundedVec, CloneNoBound, DebugNoBound, EqNoBound, PalletError, PartialEqNoBound,
-	RuntimeDebugNoBound,
-};
+use frame_support::PalletError;
+pub use polkadot_parachain::primitives::Id as ParaId;
 use scale_info::TypeInfo;
-use sp_core::{RuntimeDebug, H160, H256, U256};
-use sp_std::{borrow::ToOwned, vec, vec::Vec};
-use xcm::prelude::MultiLocation;
+use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
+use sp_core::{RuntimeDebug, H256};
 
-pub type MessageHash = H256;
-pub type FeeAmount = u128;
-pub type GasAmount = u128;
-pub type GasPriceInWei = u128;
+pub use v1::{AgentExecuteCommand, Command, Initializer, Message, OperatingMode, QueuedMessage};
 
-/// OutboundFee which covers the cost of execution on both BridgeHub and Ethereum
-#[derive(Copy, Clone, Default, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-pub struct Fees<Balance: BalanceT> {
-	/// Fee for processing the message locally
-	pub base: Balance,
-	/// Fee for processing the message remotely
-	pub delivery: Balance,
+/// Enqueued outbound messages need to be versioned to prevent data corruption
+/// or loss after forkless runtime upgrades
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(PartialEq))]
+pub enum VersionedQueuedMessage {
+	V1(QueuedMessage),
 }
 
-impl<Balance: BalanceT> Fees<Balance> {
-	pub fn total(&self) -> Balance {
-		self.base.saturating_add(self.delivery)
+impl TryFrom<VersionedQueuedMessage> for QueuedMessage {
+	type Error = ();
+	fn try_from(x: VersionedQueuedMessage) -> Result<Self, Self::Error> {
+		use VersionedQueuedMessage::*;
+		match x {
+			V1(x) => Ok(x),
+		}
 	}
 }
 
-/// A trait for enqueueing messages for delivery to Ethereum
-pub trait OutboundQueue {
+impl<T: Into<QueuedMessage>> From<T> for VersionedQueuedMessage {
+	fn from(x: T) -> Self {
+		VersionedQueuedMessage::V1(x.into())
+	}
+}
+
+mod v1 {
+	use codec::{Decode, Encode};
+	use ethabi::Token;
+	use frame_support::RuntimeDebug;
+	pub use polkadot_parachain::primitives::Id as ParaId;
+	use scale_info::TypeInfo;
+	use sp_core::{H160, H256, U256};
+	use sp_std::{borrow::ToOwned, vec, vec::Vec};
+
+	/// A message which can be accepted by the [`OutboundQueue`]
+	#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug)]
+	#[cfg_attr(feature = "std", derive(PartialEq))]
+	pub struct Message {
+		/// The parachain from which the message originated
+		pub origin: ParaId,
+		/// The stable ID for a receiving gateway contract
+		pub command: Command,
+	}
+
+	#[derive(Copy, Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+	pub enum OperatingMode {
+		Normal,
+		RejectingOutboundMessages,
+	}
+
+	/// A command which is executable by the Gateway contract on Ethereum
+	#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug)]
+	#[cfg_attr(feature = "std", derive(PartialEq))]
+	pub enum Command {
+		/// Execute a sub-command within an agent for a consensus system in Polkadot
+		AgentExecute {
+			/// The ID of the agent
+			agent_id: H256,
+			/// The sub-command to be executed
+			command: AgentExecuteCommand,
+		},
+		/// Upgrade the Gateway contract
+		Upgrade {
+			/// Address of the new implementation contract
+			impl_address: H160,
+			/// Codehash of the implementation contract
+			impl_code_hash: H256,
+			/// Optionally invoke an initializer in the implementation contract
+			initializer: Option<Initializer>,
+		},
+		/// Create an agent representing a consensus system on Polkadot
+		CreateAgent {
+			/// The ID of the agent, derived from the `MultiLocation` of the consensus system on
+			/// Polkadot
+			agent_id: H256,
+		},
+		/// Create bidirectional messaging channel to a parachain
+		CreateChannel {
+			/// The ID of the parachain
+			para_id: ParaId,
+			/// The agent ID of the parachain
+			agent_id: H256,
+		},
+		/// Update the configuration of a channel
+		UpdateChannel {
+			/// The ID of the parachain to which the channel belongs.
+			para_id: ParaId,
+			/// The new operating mode
+			mode: OperatingMode,
+			/// The new fee to charge users for outbound messaging to Polkadot
+			fee: u128,
+		},
+		/// Set the global operating mode of the Gateway contract
+		SetOperatingMode {
+			/// The new operating mode
+			mode: OperatingMode,
+		},
+		/// Transfer ether from an agent contract to a recipient account
+		TransferNativeFromAgent {
+			/// The agent ID
+			agent_id: H256,
+			/// The recipient of the ether
+			recipient: H160,
+			/// The amount to transfer
+			amount: u128,
+		},
+	}
+
+	impl Command {
+		/// Compute the enum variant index
+		pub fn index(&self) -> u8 {
+			match self {
+				Command::AgentExecute { .. } => 0,
+				Command::Upgrade { .. } => 1,
+				Command::CreateAgent { .. } => 2,
+				Command::CreateChannel { .. } => 3,
+				Command::UpdateChannel { .. } => 4,
+				Command::SetOperatingMode { .. } => 5,
+				Command::TransferNativeFromAgent { .. } => 6,
+			}
+		}
+
+		/// ABI-encode the Command.
+		pub fn abi_encode(&self) -> Vec<u8> {
+			match self {
+				Command::AgentExecute { agent_id, command } =>
+					ethabi::encode(&[Token::Tuple(vec![
+						Token::FixedBytes(agent_id.as_bytes().to_owned()),
+						Token::Bytes(command.abi_encode()),
+					])]),
+				Command::Upgrade { impl_address, impl_code_hash, initializer, .. } =>
+					ethabi::encode(&[Token::Tuple(vec![
+						Token::Address(*impl_address),
+						Token::FixedBytes(impl_code_hash.as_bytes().to_owned()),
+						initializer
+							.clone()
+							.map_or(Token::Bytes(vec![]), |i| Token::Bytes(i.params)),
+					])]),
+				Command::CreateAgent { agent_id } =>
+					ethabi::encode(&[Token::Tuple(vec![Token::FixedBytes(
+						agent_id.as_bytes().to_owned(),
+					)])]),
+				Command::CreateChannel { para_id, agent_id } => {
+					let para_id: u32 = (*para_id).into();
+					ethabi::encode(&[Token::Tuple(vec![
+						Token::Uint(U256::from(para_id)),
+						Token::FixedBytes(agent_id.as_bytes().to_owned()),
+					])])
+				},
+				Command::UpdateChannel { para_id, mode, fee } => {
+					let para_id: u32 = (*para_id).into();
+					ethabi::encode(&[Token::Tuple(vec![
+						Token::Uint(U256::from(para_id)),
+						Token::Uint(U256::from((*mode) as u64)),
+						Token::Uint(U256::from(*fee)),
+					])])
+				},
+				Command::SetOperatingMode { mode } =>
+					ethabi::encode(&[Token::Tuple(vec![Token::Uint(U256::from((*mode) as u64))])]),
+				Command::TransferNativeFromAgent { agent_id, recipient, amount } =>
+					ethabi::encode(&[Token::Tuple(vec![
+						Token::FixedBytes(agent_id.as_bytes().to_owned()),
+						Token::Address(*recipient),
+						Token::Uint(U256::from(*amount)),
+					])]),
+			}
+		}
+	}
+
+	/// Representation of a call to the initializer of an implementation contract.
+	/// The initializer has the following ABI signature: `initialize(bytes)`.
+	#[derive(Encode, Decode, TypeInfo, PartialEq, Clone, RuntimeDebug)]
+	pub struct Initializer {
+		/// ABI-encoded params of type `bytes` to pass to the initializer
+		pub params: Vec<u8>,
+		/// The initializer is allowed to consume this much gas at most.
+		pub maximum_required_gas: u64,
+	}
+
+	/// A Sub-command executable within an agent
+	#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
+	pub enum AgentExecuteCommand {
+		/// Transfer ERC20 tokens
+		TransferToken {
+			/// Address of the ERC20 token
+			token: H160,
+			/// The recipient of the tokens
+			recipient: H160,
+			/// The amount of tokens to transfer
+			amount: u128,
+		},
+	}
+
+	impl AgentExecuteCommand {
+		fn index(&self) -> u8 {
+			match self {
+				AgentExecuteCommand::TransferToken { .. } => 0,
+			}
+		}
+
+		/// ABI-encode the sub-command
+		pub fn abi_encode(&self) -> Vec<u8> {
+			match self {
+				AgentExecuteCommand::TransferToken { token, recipient, amount } =>
+					ethabi::encode(&[
+						Token::Uint(self.index().into()),
+						Token::Bytes(ethabi::encode(&[
+							Token::Address(*token),
+							Token::Address(*recipient),
+							Token::Uint(U256::from(*amount)),
+						])),
+					]),
+			}
+		}
+	}
+
+	/// Message which is awaiting processing in the MessageQueue pallet
+	#[derive(Encode, Decode, Clone, RuntimeDebug, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(PartialEq))]
+	pub struct QueuedMessage {
+		/// Message ID (usually hash of message)
+		pub id: H256,
+		/// ID of source parachain
+		pub origin: ParaId,
+		/// Command to execute in the Gateway contract
+		pub command: Command,
+	}
+}
+
+#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+/// Fee for delivering message
+pub struct Fee<Balance>
+where
+	Balance: BaseArithmetic + Unsigned + Copy,
+{
+	/// Fee to cover cost of processing the message locally
+	pub local: Balance,
+	/// Fee to cover cost processing the message remotely
+	pub remote: Balance,
+}
+
+impl<Balance> Fee<Balance>
+where
+	Balance: BaseArithmetic + Unsigned + Copy,
+{
+	pub fn total(&self) -> Balance {
+		self.local.saturating_add(self.remote)
+	}
+}
+
+impl<Balance> From<(Balance, Balance)> for Fee<Balance>
+where
+	Balance: BaseArithmetic + Unsigned + Copy,
+{
+	fn from((local, remote): (Balance, Balance)) -> Self {
+		Self { local, remote }
+	}
+}
+
+/// A trait for sending messages to Ethereum
+pub trait SendMessage {
 	type Ticket: Clone + Encode + Decode;
-	type Balance: BalanceT;
+	type Balance: BaseArithmetic + Unsigned + Copy;
 
 	/// Validate an outbound message and return a tuple:
-	/// 1. A ticket for submitting the message
-	/// 2. The OutboundFee
-	fn validate(message: &Message) -> Result<(Self::Ticket, Fees<Self::Balance>), SendError>;
+	/// 1. Ticket for submitting the message
+	/// 2. Delivery fee
+	fn validate(message: &Message) -> Result<(Self::Ticket, Fee<Self::Balance>), SendError>;
 
 	/// Submit the message ticket for eventual delivery to Ethereum
-	fn submit(ticket: Self::Ticket) -> Result<MessageHash, SendError>;
+	fn deliver(ticket: Self::Ticket) -> Result<H256, SendError>;
 }
 
 /// Reasons why sending to Ethereum could not be initiated
@@ -53,150 +287,10 @@ pub enum SendError {
 	MessageTooLarge,
 	/// The bridge has been halted for maintenance
 	Halted,
-}
-
-/// A message which can be accepted by the [`OutboundQueue`]
-#[derive(
-	Derivative, Encode, Decode, TypeInfo, PartialEqNoBound, EqNoBound, CloneNoBound, DebugNoBound,
-)]
-pub struct Message {
-	/// The parachain from which the message originated
-	pub origin: ParaId,
-	/// The stable ID for a receiving gateway contract
-	pub command: Command,
-}
-
-#[derive(Copy, Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-pub enum OperatingMode {
-	Normal,
-	RejectingOutboundMessages,
-}
-
-/// A command which is executable by the Gateway contract on Ethereum
-#[derive(
-	Derivative, Encode, Decode, TypeInfo, PartialEqNoBound, EqNoBound, CloneNoBound, DebugNoBound,
-)]
-pub enum Command {
-	/// Execute a sub-command within an agent for a consensus system in Polkadot
-	AgentExecute {
-		/// The ID of the agent
-		agent_id: H256,
-		/// The sub-command to be executed
-		command: AgentExecuteCommand,
-	},
-	/// Upgrade the Gateway contract
-	Upgrade {
-		/// Address of the new implementation contract
-		impl_address: H160,
-		/// Codehash of the implementation contract
-		impl_code_hash: H256,
-		/// Optionally invoke an initializer in the implementation contract
-		initializer: Option<Initializer>,
-	},
-	/// Create an agent representing a consensus system on Polkadot
-	CreateAgent {
-		/// The ID of the agent, derived from the `MultiLocation` of the consensus system on
-		/// Polkadot
-		agent_id: H256,
-	},
-	/// Create bidirectional messaging channel to a parachain
-	CreateChannel {
-		/// The ID of the parachain
-		para_id: ParaId,
-		/// The agent ID of the parachain
-		agent_id: H256,
-	},
-	/// Update the configuration of a channel
-	UpdateChannel {
-		/// The ID of the parachain to which the channel belongs.
-		para_id: ParaId,
-		/// The new operating mode
-		mode: OperatingMode,
-		/// The new fee to charge users for outbound messaging to Polkadot
-		fee: u128,
-	},
-	/// Set the global operating mode of the Gateway contract
-	SetOperatingMode {
-		/// The new operating mode
-		mode: OperatingMode,
-	},
-	/// Transfer ether from an agent contract to a recipient account
-	TransferNativeFromAgent {
-		/// The agent ID
-		agent_id: H256,
-		/// The recipient of the ether
-		recipient: H160,
-		/// The amount to transfer
-		amount: u128,
-	},
-}
-
-impl Command {
-	/// Compute the enum variant index
-	pub fn index(&self) -> u8 {
-		match self {
-			Command::AgentExecute { .. } => 0,
-			Command::Upgrade { .. } => 1,
-			Command::CreateAgent { .. } => 2,
-			Command::CreateChannel { .. } => 3,
-			Command::UpdateChannel { .. } => 4,
-			Command::SetOperatingMode { .. } => 5,
-			Command::TransferNativeFromAgent { .. } => 6,
-		}
-	}
-
-	/// ABI-encode the Command.
-	pub fn abi_encode(&self) -> Vec<u8> {
-		match self {
-			Command::AgentExecute { agent_id, command } => ethabi::encode(&[Token::Tuple(vec![
-				Token::FixedBytes(agent_id.as_bytes().to_owned()),
-				Token::Bytes(command.abi_encode()),
-			])]),
-			Command::Upgrade { impl_address, impl_code_hash, initializer, .. } =>
-				ethabi::encode(&[Token::Tuple(vec![
-					Token::Address(*impl_address),
-					Token::FixedBytes(impl_code_hash.as_bytes().to_owned()),
-					initializer.clone().map_or(Token::Bytes(vec![]), |i| Token::Bytes(i.params)),
-				])]),
-			Command::CreateAgent { agent_id } =>
-				ethabi::encode(&[Token::Tuple(vec![Token::FixedBytes(
-					agent_id.as_bytes().to_owned(),
-				)])]),
-			Command::CreateChannel { para_id, agent_id } => {
-				let para_id: u32 = (*para_id).into();
-				ethabi::encode(&[Token::Tuple(vec![
-					Token::Uint(U256::from(para_id)),
-					Token::FixedBytes(agent_id.as_bytes().to_owned()),
-				])])
-			},
-			Command::UpdateChannel { para_id, mode, fee } => {
-				let para_id: u32 = (*para_id).into();
-				ethabi::encode(&[Token::Tuple(vec![
-					Token::Uint(U256::from(para_id)),
-					Token::Uint(U256::from((*mode) as u64)),
-					Token::Uint(U256::from(*fee)),
-				])])
-			},
-			Command::SetOperatingMode { mode } =>
-				ethabi::encode(&[Token::Tuple(vec![Token::Uint(U256::from((*mode) as u64))])]),
-			Command::TransferNativeFromAgent { agent_id, recipient, amount } =>
-				ethabi::encode(&[Token::Tuple(vec![
-					Token::FixedBytes(agent_id.as_bytes().to_owned()),
-					Token::Address(*recipient),
-					Token::Uint(U256::from(*amount)),
-				])]),
-		}
-	}
-}
-
-/// Representation of a call to the initializer of an implementation contract.
-/// The initializer has the following ABI signature: `initialize(bytes)`.
-#[derive(Encode, Decode, TypeInfo, PartialEqNoBound, EqNoBound, CloneNoBound, DebugNoBound)]
-pub struct Initializer {
-	/// ABI-encoded params of type `bytes` to pass to the initializer
-	pub params: Vec<u8>,
-	/// The initializer is allowed to consume this much gas at most.
-	pub maximum_required_gas: u64,
+	/// An arithmetic error occurred while calculating fees
+	Overflow,
+	/// Too many enqueued messages
+	QueueFull,
 }
 
 pub trait GasMeter {
@@ -252,99 +346,10 @@ impl GasMeter for ConstantGasMeter {
 }
 
 impl GasMeter for () {
-	const MAXIMUM_BASE_GAS: u64 = 0;
+	const MAXIMUM_BASE_GAS: u64 = 1;
 
 	fn maximum_required(_: &Command) -> u64 {
-		0
-	}
-}
-
-/// A Sub-command executable within an agent
-#[derive(Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo)]
-pub enum AgentExecuteCommand {
-	/// Transfer ERC20 tokens
-	TransferToken {
-		/// Address of the ERC20 token
-		token: H160,
-		/// The recipient of the tokens
-		recipient: H160,
-		/// The amount of tokens to transfer
-		amount: u128,
-	},
-}
-
-impl AgentExecuteCommand {
-	fn index(&self) -> u8 {
-		match self {
-			AgentExecuteCommand::TransferToken { .. } => 0,
-		}
-	}
-
-	/// ABI-encode the sub-command
-	pub fn abi_encode(&self) -> Vec<u8> {
-		match self {
-			AgentExecuteCommand::TransferToken { token, recipient, amount } => ethabi::encode(&[
-				Token::Uint(self.index().into()),
-				Token::Bytes(ethabi::encode(&[
-					Token::Address(*token),
-					Token::Address(*recipient),
-					Token::Uint(U256::from(*amount)),
-				])),
-			]),
-		}
-	}
-}
-
-/// A message which can be accepted by the [`OutboundQueue`]
-#[derive(Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound)]
-pub struct OutboundQueueTicket<MaxMessageSize: Get<u32>> {
-	pub id: H256,
-	pub origin: ParaId,
-	pub message: BoundedVec<u8, MaxMessageSize>,
-}
-
-/// Message which is awaiting processing in the MessageQueue pallet
-#[derive(Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo)]
-pub struct EnqueuedMessage {
-	/// Message ID (usually hash of message)
-	pub id: H256,
-	/// ID of source parachain
-	pub origin: ParaId,
-	/// Command to execute in the Gateway contract
-	pub command: Command,
-}
-
-/// Message which has been assigned a nonce and will be committed at the end of a block
-#[derive(Encode, Decode, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo)]
-pub struct PreparedMessage {
-	/// ID of source parachain
-	pub origin: ParaId,
-	/// Unique nonce to prevent replaying messages
-	pub nonce: u64,
-	/// Command to execute in the Gateway contract
-	pub command: u8,
-	/// Params for the command
-	pub params: Vec<u8>,
-	/// Maximum gas allowed for message dispatch
-	pub max_dispatch_gas: u128,
-	/// Maximum gas refund for message relayer
-	pub max_refund: u128,
-	/// Reward in ether for delivering this message, in addition to the gas refund
-	pub reward: u128,
-}
-
-/// Convert message into an ABI-encoded form for delivery to the InboundQueue contract on Ethereum
-impl From<PreparedMessage> for Token {
-	fn from(x: PreparedMessage) -> Token {
-		Token::Tuple(vec![
-			Token::Uint(u32::from(x.origin).into()),
-			Token::Uint(x.nonce.into()),
-			Token::Uint(x.command.into()),
-			Token::Bytes(x.params.to_vec()),
-			Token::Uint(x.max_dispatch_gas.into()),
-			Token::Uint(x.max_refund.into()),
-			Token::Uint(x.reward.into()),
-		])
+		1
 	}
 }
 
@@ -354,24 +359,14 @@ impl From<u32> for AggregateMessageOrigin {
 	}
 }
 
-#[derive(Copy, Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct OriginInfo {
-	/// The location of this origin
-	pub location: MultiLocation,
-	/// The parachain hosting this origin
-	pub para_id: ParaId,
-	/// The deterministic ID of the agent for this origin
-	pub agent_id: H256,
-}
-
-#[derive(Encode, Decode, Clone, MaxEncodedLen, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Copy, MaxEncodedLen, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum ExportOrigin {
 	Here,
 	Sibling(ParaId),
 }
 
 /// Aggregate message origin for the `MessageQueue` pallet.
-#[derive(Encode, Decode, Clone, MaxEncodedLen, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Copy, MaxEncodedLen, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum AggregateMessageOrigin {
 	/// Message is to be exported via a bridge
 	Export(ExportOrigin),

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Snowfork <contact@snowfork.com>" ]
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.188", optional = true }
+serde = { version = "1.0.188", optional = true, features = [ "derive" ] }
 serde-big-array = { version = "0.3.2", optional = true, features = [ "const-generics" ] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.9.0", default-features = false, features = [ "derive" ] }
@@ -27,7 +27,6 @@ ethabi = { git = "https://github.com/snowfork/ethabi-decode.git", package = "eth
 [dev-dependencies]
 wasm-bindgen-test = "0.3.19"
 rand = "0.8.5"
-serde = { version = "1.0.188", features = [ "derive" ] }
 serde_json = "1.0.96"
 
 [features]

--- a/parachain/primitives/router/src/outbound/mod.rs
+++ b/parachain/primitives/router/src/outbound/mod.rs
@@ -5,11 +5,8 @@ use core::slice::Iter;
 
 use codec::{Decode, Encode};
 
-use frame_support::{ensure, traits::Get};
-use log;
-use snowbridge_core::outbound::{
-	AgentExecuteCommand, Command, Message, OutboundQueue as OutboundQueueTrait,
-};
+use frame_support::{ensure, log, traits::Get};
+use snowbridge_core::outbound::{AgentExecuteCommand, Command, Message, SendMessage};
 use sp_core::H256;
 use sp_std::{marker::PhantomData, prelude::*};
 use xcm::v3::prelude::*;
@@ -27,7 +24,7 @@ impl<UniversalLocation, GatewayLocation, OutboundQueue, AgentHashedDescription> 
 where
 	UniversalLocation: Get<InteriorMultiLocation>,
 	GatewayLocation: Get<MultiLocation>,
-	OutboundQueue: OutboundQueueTrait<Balance = u128>,
+	OutboundQueue: SendMessage<Balance = u128>,
 	OutboundQueue::Ticket: Encode + Decode,
 	AgentHashedDescription: ConvertLocation<H256>,
 {
@@ -127,13 +124,13 @@ where
 		};
 
 		// validate the message
-		let (ticket, fees) = OutboundQueue::validate(&outbound_message).map_err(|err| {
+		let (ticket, fee) = OutboundQueue::validate(&outbound_message).map_err(|err| {
 			log::error!(target: "xcm::ethereum_blob_exporter", "OutboundQueue validation of message failed. {err:?}");
 			SendError::Unroutable
 		})?;
 
 		// convert fee to MultiAsset
-		let fee = MultiAsset::from((MultiLocation::parent(), fees.total())).into();
+		let fee = MultiAsset::from((MultiLocation::parent(), fee.total())).into();
 
 		Ok(((ticket.encode(), XcmHash::default()), fee))
 	}
@@ -145,7 +142,7 @@ where
 				SendError::NotApplicable
 			})?;
 
-		let message_hash = OutboundQueue::submit(ticket).map_err(|_| {
+		let message_hash = OutboundQueue::deliver(ticket).map_err(|_| {
 			log::error!(target: "xcm::ethereum_blob_exporter", "OutboundQueue submit of message failed");
 			SendError::Transport("other transport error")
 		})?;
@@ -310,7 +307,7 @@ impl<'a, Call> XcmConverter<'a, Call> {
 mod tests {
 	use frame_support::parameter_types;
 	use hex_literal::hex;
-	use snowbridge_core::outbound::{Fees, MessageHash, SendError};
+	use snowbridge_core::outbound::{Fee, SendError};
 	use xcm::v3::prelude::SendError as XcmSendError;
 	use xcm_builder::{DescribeAllTerminal, DescribeFamily, HashedDescription};
 
@@ -330,28 +327,28 @@ mod tests {
 	const GATEWAY: [u8; 20] = hex!("D184c103F7acc340847eEE82a0B909E3358bc28d");
 
 	struct MockOkOutboundQueue;
-	impl OutboundQueueTrait for MockOkOutboundQueue {
+	impl SendMessage for MockOkOutboundQueue {
 		type Ticket = ();
 		type Balance = u128;
 
-		fn validate(_: &Message) -> Result<((), Fees<Self::Balance>), SendError> {
-			Ok(((), Fees { base: 1, delivery: 1 }))
+		fn validate(_: &Message) -> Result<((), Fee<Self::Balance>), SendError> {
+			Ok(((), Fee { local: 1, remote: 1 }))
 		}
 
-		fn submit(_: Self::Ticket) -> Result<MessageHash, SendError> {
-			Ok(MessageHash::zero())
+		fn deliver(_: Self::Ticket) -> Result<H256, SendError> {
+			Ok(H256::zero())
 		}
 	}
 	struct MockErrOutboundQueue;
-	impl OutboundQueueTrait for MockErrOutboundQueue {
+	impl SendMessage for MockErrOutboundQueue {
 		type Ticket = ();
 		type Balance = u128;
 
-		fn validate(_: &Message) -> Result<((), Fees<Self::Balance>), SendError> {
+		fn validate(_: &Message) -> Result<((), Fee<Self::Balance>), SendError> {
 			Err(SendError::MessageTooLarge)
 		}
 
-		fn submit(_: Self::Ticket) -> Result<MessageHash, SendError> {
+		fn deliver(_: Self::Ticket) -> Result<H256, SendError> {
 			Err(SendError::MessageTooLarge)
 		}
 	}

--- a/parachain/primitives/router/src/outbound/mod.rs
+++ b/parachain/primitives/router/src/outbound/mod.rs
@@ -5,7 +5,7 @@ use core::slice::Iter;
 
 use codec::{Decode, Encode};
 
-use frame_support::{ensure, log, traits::Get};
+use frame_support::{ensure, traits::Get};
 use snowbridge_core::outbound::{AgentExecuteCommand, Command, Message, SendMessage};
 use sp_core::H256;
 use sp_std::{marker::PhantomData, prelude::*};


### PR DESCRIPTION
The main change is improve the calculation of delivery fees. It turns out that the pallet does need to know the `ETH/DOT` exchange rate in order to calculate a fee that covers the additional delivery reward (on top of the refund). The previous fee calculation was incorrect and did not do this.

The fee config for the pallet can now be set by governance using the `set_fee_config` extrinsic.

Other Changes:
* Support the new `QueuePausedQuery` feature of the `MessageQueue` pallet improve implementation of priority message handling.
* Moved some code around to improve organisation and readability
* Improved tests
* Fee calculation code is a lot cleaner
* Improved documentation for all pallets.
* Outbound messages are versioned so that we can handle forkless upgrades without marking older messages emitted from MessageQueue as corrupted.

Fixes: SNO-635