### PR TITLE
Track registered native tokens

### DIFF
--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -66,6 +66,9 @@ interface IGateway {
      * Token Transfers
      */
 
+    error TokenAlreadyRegistered(address token);
+    error TokenNotRegistered(address token);
+
     /// @dev Send a message to the AssetHub parachain to register a new fungible asset
     ///      in the `ForeignAssets` pallet.
     function registerToken(address token) external payable;

--- a/contracts/src/storage/AssetsStorage.sol
+++ b/contracts/src/storage/AssetsStorage.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.22;
 
 library AssetsStorage {
     struct Layout {
+        mapping(address tokenAddress => bool) registeredNativeTokens;
         uint256 registerTokenFee;
         uint256 sendTokenFee;
     }


### PR DESCRIPTION
This is useful for implementing the "Polkadot-native assets on Ethereum" story post-launch. It allows the gateway to know whether a particular ERC20 token has been registered or not.