### PR TITLE
Fix asset hub fee

### DIFF
--- a/parachain/pallets/outbound-queue/src/mock.rs
+++ b/parachain/pallets/outbound-queue/src/mock.rs
@@ -83,7 +83,7 @@ impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Hashing = Keccak256;
 	type MessageQueue = MessageQueue;
-	type Decimals = ConstU8<10>;
+	type Decimals = ConstU8<12>;
 	type MaxMessagePayloadSize = ConstU32<1024>;
 	type MaxMessagesPerBlock = ConstU32<20>;
 	type OwnParaId = OwnParaId;

--- a/parachain/pallets/outbound-queue/src/test.rs
+++ b/parachain/pallets/outbound-queue/src/test.rs
@@ -50,7 +50,7 @@ fn calculate_fees() {
 	new_tester().execute_with(|| {
 		let command = mock_message(1000).command;
 		let fee = OutboundQueue::calculate_fee(&command);
-		assert_eq!(fee.remote, 22000000000);
+		assert_eq!(fee.remote, 2200000000000);
 
 		println!("Total fee: {}", fee.total())
 	});
@@ -60,7 +60,7 @@ fn calculate_fees() {
 fn convert_from_ether_decimals() {
 	assert_eq!(
 		OutboundQueue::convert_from_ether_decimals(1_000_000_000_000_000_000),
-		1_000_000_000_0
+		100_000_000_000_0
 	);
 }
 


### PR DESCRIPTION
The decimal precision in the tests do not match the decimals in the [rococo runtime config](https://github.com/Snowfork/polkadot-sdk/blob/snowbridge/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs#L538). Using the `calculate_fee` test to generate the user fee value for transfer token back to Ethereum, it generates a value that is too low.

Polkadot-sdk companion: https://github.com/Snowfork/polkadot-sdk/pull/21