### PR TITLE
Remove workspace flag from build script

### DIFF
--- a/web/packages/test/scripts/build-binary.sh
+++ b/web/packages/test/scripts/build-binary.sh
@@ -12,14 +12,16 @@ build_binaries() {
     fi
 
     echo "Building polkadot binary"
-    cargo build --release --workspace --locked --bin polkadot --bin polkadot-execute-worker --bin polkadot-prepare-worker
+    cargo build --release --locked --bin polkadot --bin polkadot-execute-worker --bin polkadot-prepare-worker
     cp target/release/polkadot $output_bin_dir/polkadot
     cp target/release/polkadot-execute-worker $output_bin_dir/polkadot-execute-worker
     cp target/release/polkadot-prepare-worker $output_bin_dir/polkadot-prepare-worker
 
     echo "Building polkadot-parachain binary"
-    cargo build --release --workspace --locked --bin polkadot-parachain $features
-    cp target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
+    cd cumulus/polkadot-parachain
+    cargo build --release --locked --bin polkadot-parachain $features
+    cp ../../target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
+    cd -
 
     popd
 }

--- a/web/packages/test/scripts/build-binary.sh
+++ b/web/packages/test/scripts/build-binary.sh
@@ -18,10 +18,8 @@ build_binaries() {
     cp target/release/polkadot-prepare-worker $output_bin_dir/polkadot-prepare-worker
 
     echo "Building polkadot-parachain binary"
-    cd cumulus/polkadot-parachain
-    cargo build --release --locked --bin polkadot-parachain $features
-    cp ../../target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
-    cd -
+    cargo build --release --locked -p polkadot-parachain-bin --bin polkadot-parachain $features
+    cp target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
 
     popd
 }

--- a/web/packages/test/scripts/build-binary.sh
+++ b/web/packages/test/scripts/build-binary.sh
@@ -11,8 +11,17 @@ build_binaries() {
         features=--features beacon-spec-mainnet
     fi
 
-    echo "Building polkadot binary"
-    cargo build --release --locked --bin polkadot --bin polkadot-execute-worker --bin polkadot-prepare-worker
+    check_local_changes "polkadot"
+    check_local_changes "substrate"
+
+  # Check that all 3 binaries are available and no changes made in the polkadot and substrate dirs
+    if [[ ! -e "target/release/polkadot" || ! -e "target/release/polkadot-execute-worker" || ! -e "target/release/polkadot-prepare-worker" || "$changes_detected" -eq 1 ]]; then
+        echo "Building polkadot binary, due to changes detected in polkadot or substrate, or binaries not found"
+        cargo build --release --locked --bin polkadot --bin polkadot-execute-worker --bin polkadot-prepare-worker
+    else
+        echo "No changes detected in polkadot or substrate and binaries are available, not rebuilding relaychain binaries."
+    fi
+
     cp target/release/polkadot $output_bin_dir/polkadot
     cp target/release/polkadot-execute-worker $output_bin_dir/polkadot-execute-worker
     cp target/release/polkadot-prepare-worker $output_bin_dir/polkadot-prepare-worker
@@ -22,6 +31,17 @@ build_binaries() {
     cp target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
 
     popd
+}
+
+changes_detected=0
+
+check_local_changes() {
+    local dir=$1
+    cd "$dir"
+    if git status --porcelain | grep .; then
+        changes_detected=1
+    fi
+    cd -
 }
 
 build_contracts() {


### PR DESCRIPTION
I added the `--workspace` flag to the build polkadot and build polkadot-parachain commands because it prevented recompilation if the source files did not change. However, building the workspace included compiling some dev features, like fuzzing, which lead to a compilation error (for which I added a temp fix here: https://github.com/Snowfork/polkadot-sdk/blob/snowbridge/substrate/frame/nomination-pools/src/lib.rs#L3409). 

This PR removes the `--workspace` flag. Unfortunately the binaries rebuild on every start-services run now, at least partially. Will optimize later, but for now this fixes the compilation error and I can revert the change in https://github.com/Snowfork/polkadot-sdk/blob/snowbridge/substrate/frame/nomination-pools/src/lib.rs#L3409.