### PR TITLE
Disable mainnet spec for e2e tests

### DIFF
--- a/web/packages/test/scripts/build-binary.sh
+++ b/web/packages/test/scripts/build-binary.sh
@@ -27,7 +27,7 @@ build_binaries() {
     cp target/release/polkadot-prepare-worker $output_bin_dir/polkadot-prepare-worker
 
     echo "Building polkadot-parachain binary"
-    cargo build --release --locked -p polkadot-parachain-bin --bin polkadot-parachain $features
+    cargo build --release --locked -p polkadot-parachain-bin --bin polkadot-parachain $features --no-default-features
     cp target/release/polkadot-parachain $output_bin_dir/polkadot-parachain
 
     popd


### PR DESCRIPTION
Resolves: [SNO-776](https://linear.app/snowfork/issue/SNO-776)
Polkadot-sdk companion: https://github.com/Snowfork/polkadot-sdk/pull/61