### PR TITLE
Init agents and channels with migration

### DIFF
--- a/parachain/pallets/system/src/benchmarking.rs
+++ b/parachain/pallets/system/src/benchmarking.rs
@@ -165,5 +165,9 @@ mod benchmarks {
 		Ok(())
 	}
 
-	impl_benchmark_test_suite!(SnowbridgeControl, crate::mock::new_test_ext(), crate::mock::Test);
+	impl_benchmark_test_suite!(
+		SnowbridgeControl,
+		crate::mock::new_test_ext(true),
+		crate::mock::Test
+	);
 }

--- a/parachain/pallets/system/src/benchmarking.rs
+++ b/parachain/pallets/system/src/benchmarking.rs
@@ -157,14 +157,6 @@ mod benchmarks {
 		Ok(())
 	}
 
-	#[benchmark]
-	fn force_initialize() -> Result<(), BenchmarkError> {
-		#[extrinsic_call]
-		_(RawOrigin::Root, 1013.into(), 1000.into());
-
-		Ok(())
-	}
-
 	impl_benchmark_test_suite!(
 		SnowbridgeControl,
 		crate::mock::new_test_ext(true),

--- a/parachain/pallets/system/src/benchmarking.rs
+++ b/parachain/pallets/system/src/benchmarking.rs
@@ -157,5 +157,13 @@ mod benchmarks {
 		Ok(())
 	}
 
+	#[benchmark]
+	fn force_initialize() -> Result<(), BenchmarkError> {
+		#[extrinsic_call]
+		_(RawOrigin::Root, 1013.into(), 1000.into());
+
+		Ok(())
+	}
+
 	impl_benchmark_test_suite!(SnowbridgeControl, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/parachain/pallets/system/src/lib.rs
+++ b/parachain/pallets/system/src/lib.rs
@@ -622,7 +622,10 @@ pub mod pallet {
 		}
 
 		/// Initializes agents and channels.
-		pub fn initialize(para_id: ParaId, asset_hub_para_id: ParaId) -> Result<(), DispatchError> {
+		pub(crate) fn initialize(
+			para_id: ParaId,
+			asset_hub_para_id: ParaId,
+		) -> Result<(), DispatchError> {
 			let bridge_hub_agent_id = agent_id_of::<T>(&MultiLocation::here())?;
 			// Agent for BridgeHub
 			Agents::<T>::insert(bridge_hub_agent_id, ());

--- a/parachain/pallets/system/src/lib.rs
+++ b/parachain/pallets/system/src/lib.rs
@@ -47,6 +47,7 @@ mod tests;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+pub mod migration;
 
 pub mod api;
 pub mod weights;
@@ -133,7 +134,10 @@ pub mod pallet {
 
 	use super::*;
 
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
@@ -256,34 +260,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			let bridge_hub_agent_id =
-				agent_id_of::<T>(&MultiLocation::here()).expect("infallible; qed");
-			// Agent for BridgeHub
-			Agents::<T>::insert(bridge_hub_agent_id, ());
-
-			// Primary governance channel
-			Channels::<T>::insert(
-				PRIMARY_GOVERNANCE_CHANNEL,
-				Channel { agent_id: bridge_hub_agent_id, para_id: self.para_id },
-			);
-
-			// Secondary governance channel
-			Channels::<T>::insert(
-				SECONDARY_GOVERNANCE_CHANNEL,
-				Channel { agent_id: bridge_hub_agent_id, para_id: self.para_id },
-			);
-
-			// Asset Hub
-			let asset_hub_location: MultiLocation =
-				ParentThen(X1(Parachain(self.asset_hub_para_id.into()))).into();
-			let asset_hub_agent_id =
-				agent_id_of::<T>(&asset_hub_location).expect("infallible; qed");
-			let asset_hub_channel_id: ChannelId = self.asset_hub_para_id.into();
-			Agents::<T>::insert(asset_hub_agent_id, ());
-			Channels::<T>::insert(
-				asset_hub_channel_id,
-				Channel { agent_id: asset_hub_agent_id, para_id: self.asset_hub_para_id },
-			);
+			Pallet::<T>::initialize(self.para_id, self.asset_hub_para_id).expect("infallible; qed");
 		}
 	}
 
@@ -641,6 +618,38 @@ pub mod pallet {
 				recipient,
 				amount,
 			});
+			Ok(())
+		}
+
+		/// Initializes agents and channels.
+		pub fn initialize(para_id: ParaId, asset_hub_para_id: ParaId) -> Result<(), DispatchError> {
+			let bridge_hub_agent_id = agent_id_of::<T>(&MultiLocation::here())?;
+			// Agent for BridgeHub
+			Agents::<T>::insert(bridge_hub_agent_id, ());
+
+			// Primary governance channel
+			Channels::<T>::insert(
+				PRIMARY_GOVERNANCE_CHANNEL,
+				Channel { agent_id: bridge_hub_agent_id, para_id },
+			);
+
+			// Secondary governance channel
+			Channels::<T>::insert(
+				SECONDARY_GOVERNANCE_CHANNEL,
+				Channel { agent_id: bridge_hub_agent_id, para_id },
+			);
+
+			// Asset Hub
+			let asset_hub_location: MultiLocation =
+				ParentThen(X1(Parachain(asset_hub_para_id.into()))).into();
+			let asset_hub_agent_id = agent_id_of::<T>(&asset_hub_location)?;
+			let asset_hub_channel_id: ChannelId = asset_hub_para_id.into();
+			Agents::<T>::insert(asset_hub_agent_id, ());
+			Channels::<T>::insert(
+				asset_hub_channel_id,
+				Channel { agent_id: asset_hub_agent_id, para_id: asset_hub_para_id },
+			);
+
 			Ok(())
 		}
 	}

--- a/parachain/pallets/system/src/lib.rs
+++ b/parachain/pallets/system/src/lib.rs
@@ -134,7 +134,7 @@ pub mod pallet {
 
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/parachain/pallets/system/src/lib.rs
+++ b/parachain/pallets/system/src/lib.rs
@@ -568,29 +568,6 @@ pub mod pallet {
 			});
 			Ok(())
 		}
-
-		/// Force initializes the pallet if not already initialized.
-		///
-		/// Creates 2 agents (BridgeHub and AssetHub).
-		/// Creates 3 channels (Primary and secondary governance channels, BridgeHub channel).
-		///
-		/// Privileged. Can only be called by root.
-		///
-		/// - `origin`: Must be root
-		/// - `own_para_id`: The parachain id of the parachain housing this pallet. Most likely
-		///   BridgeHub.
-		/// - `asset_hub_para_id`: The parachain id of AssetHub.
-		#[pallet::call_index(10)]
-		#[pallet::weight((T::WeightInfo::force_initialize(), DispatchClass::Operational))]
-		pub fn force_initialize(
-			origin: OriginFor<T>,
-			own_para_id: ParaId,
-			asset_hub_para_id: ParaId,
-		) -> DispatchResult {
-			ensure_root(origin)?;
-			Self::initialize(own_para_id, asset_hub_para_id)?;
-			Ok(())
-		}
 	}
 
 	impl<T: Config> Pallet<T> {

--- a/parachain/pallets/system/src/migration.rs
+++ b/parachain/pallets/system/src/migration.rs
@@ -8,28 +8,25 @@ use log;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
 
-pub mod v1 {
+pub mod v0 {
 	use frame_support::{pallet_prelude::*, weights::Weight};
 
 	use super::*;
 
-	// TODO(alistair): Remove logging
 	const LOG_TARGET: &str = "ethereum_system::migration";
 
-	pub struct MigrateToV1<T, BridgeHubParaId, AssetHubParaId>(
+	pub struct InitializeOnUpgrade<T, BridgeHubParaId, AssetHubParaId>(
 		sp_std::marker::PhantomData<(T, BridgeHubParaId, AssetHubParaId)>,
 	);
 	impl<T, BridgeHubParaId, AssetHubParaId> OnRuntimeUpgrade
-		for MigrateToV1<T, BridgeHubParaId, AssetHubParaId>
+		for InitializeOnUpgrade<T, BridgeHubParaId, AssetHubParaId>
 	where
 		T: Config,
 		BridgeHubParaId: Get<u32>,
 		AssetHubParaId: Get<u32>,
 	{
 		fn on_runtime_upgrade() -> Weight {
-			let current_version = Pallet::<T>::current_storage_version();
-			let onchain_version = Pallet::<T>::on_chain_storage_version();
-			if onchain_version == 0 && current_version == 1 {
+			if !Pallet::<T>::is_initialized() {
 				Pallet::<T>::initialize(
 					BridgeHubParaId::get().into(),
 					AssetHubParaId::get().into(),
@@ -37,62 +34,40 @@ pub mod v1 {
 				.expect("infallible; qed");
 				log::info!(
 					target: LOG_TARGET,
-					"Ethereum system initialized. current: {current_version:?} onchain: {onchain_version:?}"
+					"Ethereum system initialized."
 				);
-				T::DbWeight::get().reads_writes(1, 5)
+				T::DbWeight::get().reads(2) + T::WeightInfo::force_initialize()
 			} else {
 				log::info!(
 					target: LOG_TARGET,
-					"Migration already applied. This probably can be removed. current: {current_version:?} onchain: {onchain_version:?}"
+					"Ethereum system already initialized. Skipping."
 				);
-				T::DbWeight::get().reads(1)
+				T::DbWeight::get().reads(2)
 			}
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-			frame_support::ensure!(
-				Pallet::<T>::on_chain_storage_version() == 0,
-				"must upgrade linearly"
-			);
-			frame_support::ensure!(
-				!Channels::<T>::contains_key(PRIMARY_GOVERNANCE_CHANNEL),
-				"primary channel must not exist"
-			);
-			frame_support::ensure!(
-				!Channels::<T>::contains_key(SECONDARY_GOVERNANCE_CHANNEL),
-				"secondary channel must not exist"
-			);
-			log::info!(
-				target: LOG_TARGET,
-				"Pre upgrade version check successful."
-			);
+			if !Pallet::<T>::is_initialized() {
+				log::info!(
+					target: LOG_TARGET,
+					"Agents and channels not initialized. Initialization will run."
+				);
+			} else {
+				log::info!(
+					target: LOG_TARGET,
+					"Agents and channels are initialized. Initialization will not run."
+				);
+			}
 			Ok(vec![])
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(prev_count: Vec<u8>) -> Result<(), TryRuntimeError> {
-			let current_version = Pallet::<T>::current_storage_version();
-			let onchain_version = Pallet::<T>::on_chain_storage_version();
-
-			frame_support::ensure!(current_version == 1, "must_upgrade");
-			ensure!(
-				current_version == onchain_version,
-				"after migration, the current_version and onchain_version should be the same"
-			);
 			frame_support::ensure!(
-				Channels::<T>::contains_key(PRIMARY_GOVERNANCE_CHANNEL),
-				"primary channel must exist"
+				Pallet::<T>::is_initialized(),
+				"Agents and channels were not initialized."
 			);
-			frame_support::ensure!(
-				Channels::<T>::contains_key(SECONDARY_GOVERNANCE_CHANNEL),
-				"secondary channel must exist"
-			);
-			log::info!(
-				target: LOG_TARGET,
-				"Post upgrade version check successful."
-			);
-
 			Ok(())
 		}
 	}

--- a/parachain/pallets/system/src/migration.rs
+++ b/parachain/pallets/system/src/migration.rs
@@ -36,7 +36,7 @@ pub mod v0 {
 					target: LOG_TARGET,
 					"Ethereum system initialized."
 				);
-				T::DbWeight::get().reads(2) + T::WeightInfo::force_initialize()
+				T::DbWeight::get().reads_writes(2, 5)
 			} else {
 				log::info!(
 					target: LOG_TARGET,

--- a/parachain/pallets/system/src/migration.rs
+++ b/parachain/pallets/system/src/migration.rs
@@ -39,7 +39,7 @@ pub mod v1 {
 					target: LOG_TARGET,
 					"Ethereum system initialized. current: {current_version:?} onchain: {onchain_version:?}"
 				);
-				T::DbWeight::get().reads(1)
+				T::DbWeight::get().reads_writes(1, 5)
 			} else {
 				log::info!(
 					target: LOG_TARGET,

--- a/parachain/pallets/system/src/migration.rs
+++ b/parachain/pallets/system/src/migration.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+//! Governance API for controlling the Ethereum side of the bridge
+use super::*;
+use frame_support::traits::OnRuntimeUpgrade;
+use log;
+
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+pub mod v1 {
+	use frame_support::{pallet_prelude::*, weights::Weight};
+
+	use super::*;
+
+	// TODO(alistair): Remove logging
+	const LOG_TARGET: &str = "ethereum_system::migration";
+
+	pub struct MigrateToV1<T, BridgeHubParaId, AssetHubParaId>(
+		sp_std::marker::PhantomData<(T, BridgeHubParaId, AssetHubParaId)>,
+	);
+	impl<T, BridgeHubParaId, AssetHubParaId> OnRuntimeUpgrade
+		for MigrateToV1<T, BridgeHubParaId, AssetHubParaId>
+	where
+		T: Config,
+		BridgeHubParaId: Get<u32>,
+		AssetHubParaId: Get<u32>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			let current_version = Pallet::<T>::current_storage_version();
+			let onchain_version = Pallet::<T>::on_chain_storage_version();
+			if onchain_version == 0 && current_version == 1 {
+				Pallet::<T>::initialize(
+					BridgeHubParaId::get().into(),
+					AssetHubParaId::get().into(),
+				)
+				.expect("infallible; qed");
+				log::info!(
+					target: LOG_TARGET,
+					"Ethereum system initialized. current: {current_version:?} onchain: {onchain_version:?}"
+				);
+				T::DbWeight::get().reads(1)
+			} else {
+				log::info!(
+					target: LOG_TARGET,
+					"Migration already applied. This probably can be removed. current: {current_version:?} onchain: {onchain_version:?}"
+				);
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			frame_support::ensure!(
+				Pallet::<T>::on_chain_storage_version() == 0,
+				"must upgrade linearly"
+			);
+			frame_support::ensure!(
+				!Channels::<T>::contains_key(PRIMARY_GOVERNANCE_CHANNEL),
+				"primary channel must not exist"
+			);
+			frame_support::ensure!(
+				!Channels::<T>::contains_key(SECONDARY_GOVERNANCE_CHANNEL),
+				"secondary channel must not exist"
+			);
+			log::info!(
+				target: LOG_TARGET,
+				"Pre upgrade version check successful."
+			);
+			Ok(vec![])
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(prev_count: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let current_version = Pallet::<T>::current_storage_version();
+			let onchain_version = Pallet::<T>::on_chain_storage_version();
+
+			frame_support::ensure!(current_version == 1, "must_upgrade");
+			ensure!(
+				current_version == onchain_version,
+				"after migration, the current_version and onchain_version should be the same"
+			);
+			frame_support::ensure!(
+				Channels::<T>::contains_key(PRIMARY_GOVERNANCE_CHANNEL),
+				"primary channel must exist"
+			);
+			frame_support::ensure!(
+				Channels::<T>::contains_key(SECONDARY_GOVERNANCE_CHANNEL),
+				"secondary channel must exist"
+			);
+			log::info!(
+				target: LOG_TARGET,
+				"Post upgrade version check successful."
+			);
+
+			Ok(())
+		}
+	}
+}

--- a/parachain/pallets/system/src/migration.rs
+++ b/parachain/pallets/system/src/migration.rs
@@ -63,7 +63,7 @@ pub mod v0 {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(prev_count: Vec<u8>) -> Result<(), TryRuntimeError> {
+		fn post_upgrade(_: Vec<u8>) -> Result<(), TryRuntimeError> {
 			frame_support::ensure!(
 				Pallet::<T>::is_initialized(),
 				"Agents and channels were not initialized."

--- a/parachain/pallets/system/src/mock.rs
+++ b/parachain/pallets/system/src/mock.rs
@@ -232,16 +232,18 @@ impl crate::Config for Test {
 }
 
 // Build genesis storage according to the mock runtime.
-pub fn new_test_ext() -> sp_io::TestExternalities {
+pub fn new_test_ext(genesis_build: bool) -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 
-	crate::GenesisConfig::<Test> {
-		para_id: OwnParaId::get(),
-		asset_hub_para_id: AssetHubParaId::get(),
-		_config: Default::default(),
+	if genesis_build {
+		crate::GenesisConfig::<Test> {
+			para_id: OwnParaId::get(),
+			asset_hub_para_id: AssetHubParaId::get(),
+			_config: Default::default(),
+		}
+		.assimilate_storage(&mut storage)
+		.unwrap();
 	}
-	.assimilate_storage(&mut storage)
-	.unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
 	let initial_amount = InitialFunding::get();

--- a/parachain/pallets/system/src/tests.rs
+++ b/parachain/pallets/system/src/tests.rs
@@ -636,7 +636,7 @@ fn force_initialize_initializes_correctly() {
 }
 
 #[test]
-fn force_initialize_with_genesis_build_initializes_correctly() {
+fn genesis_build_initializes_correctly() {
 	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		assert!(EthereumSystem::is_initialized(), "Ethereum uninitialized.");

--- a/parachain/pallets/system/src/tests.rs
+++ b/parachain/pallets/system/src/tests.rs
@@ -625,7 +625,7 @@ fn genesis_build_initializes_correctly() {
 }
 
 #[test]
-fn genesis_build_initializes_correctly() {
+fn no_genesis_build_is_uninitialized() {
 	new_test_ext(false).execute_with(|| {
 		assert!(!EthereumSystem::is_initialized(), "Ethereum initialized.");
 	});

--- a/parachain/pallets/system/src/tests.rs
+++ b/parachain/pallets/system/src/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 use crate::{mock::*, *};
-use frame_support::{assert_err, assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok};
 use hex_literal::hex;
 use snowbridge_core::{eth, sibling_sovereign_account_raw};
 use sp_core::H256;
@@ -618,27 +618,15 @@ fn charge_fee_for_upgrade() {
 }
 
 #[test]
-fn force_initialize_can_only_be_called_by_root() {
-	new_test_ext(false).execute_with(|| {
-		let origin = RuntimeOrigin::signed([14; 32].into());
-		assert_err!(EthereumSystem::force_initialize(origin, 1000.into(), 1013.into()), BadOrigin);
-	});
-}
-
-#[test]
-fn force_initialize_initializes_correctly() {
-	new_test_ext(false).execute_with(|| {
-		let origin = RuntimeOrigin::root();
-		assert!(!EthereumSystem::is_initialized(), "Ethereum uninitialized.");
-		assert_ok!(EthereumSystem::force_initialize(origin, 1000.into(), 1013.into()));
-		assert!(EthereumSystem::is_initialized(), "Ethereum initialized.");
+fn genesis_build_initializes_correctly() {
+	new_test_ext(true).execute_with(|| {
+		assert!(EthereumSystem::is_initialized(), "Ethereum uninitialized.");
 	});
 }
 
 #[test]
 fn genesis_build_initializes_correctly() {
-	new_test_ext(true).execute_with(|| {
-		let origin = RuntimeOrigin::root();
-		assert!(EthereumSystem::is_initialized(), "Ethereum uninitialized.");
+	new_test_ext(false).execute_with(|| {
+		assert!(!EthereumSystem::is_initialized(), "Ethereum initialized.");
 	});
 }

--- a/parachain/pallets/system/src/tests.rs
+++ b/parachain/pallets/system/src/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 use crate::{mock::*, *};
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_err, assert_noop, assert_ok};
 use hex_literal::hex;
 use snowbridge_core::{eth, sibling_sovereign_account_raw};
 use sp_core::H256;
@@ -9,7 +9,7 @@ use sp_runtime::{AccountId32, DispatchError::BadOrigin, TokenError};
 
 #[test]
 fn create_agent() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let agent_id = make_agent_id(origin_location);
@@ -29,7 +29,7 @@ fn create_agent() {
 
 #[test]
 fn test_agent_for_here() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_location = MultiLocation::here();
 		let agent_id = make_agent_id(origin_location);
 		assert_eq!(
@@ -41,7 +41,7 @@ fn test_agent_for_here() {
 
 #[test]
 fn create_agent_fails_on_funds_unavailable() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(2000)) };
 		let origin = make_xcm_origin(origin_location);
 		// Reset balance of sovereign_account to zero so to trigger the FundsUnavailable error
@@ -53,7 +53,7 @@ fn create_agent_fails_on_funds_unavailable() {
 
 #[test]
 fn create_agent_bad_origin() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		// relay chain location not allowed
 		assert_noop!(
 			EthereumSystem::create_agent(make_xcm_origin(MultiLocation {
@@ -85,7 +85,7 @@ fn create_agent_bad_origin() {
 
 #[test]
 fn upgrade_as_root() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let address: H160 = Default::default();
 		let code_hash: H256 = Default::default();
@@ -102,7 +102,7 @@ fn upgrade_as_root() {
 
 #[test]
 fn upgrade_as_signed_fails() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::signed(AccountId32::new([0; 32]));
 		let address: H160 = Default::default();
 		let code_hash: H256 = Default::default();
@@ -113,7 +113,7 @@ fn upgrade_as_signed_fails() {
 
 #[test]
 fn upgrade_with_params() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let address: H160 = Default::default();
 		let code_hash: H256 = Default::default();
@@ -125,7 +125,7 @@ fn upgrade_with_params() {
 
 #[test]
 fn set_operating_mode() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let mode = OperatingMode::RejectingOutboundMessages;
 
@@ -139,7 +139,7 @@ fn set_operating_mode() {
 
 #[test]
 fn set_operating_mode_as_signed_fails() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::signed([14; 32].into());
 		let mode = OperatingMode::RejectingOutboundMessages;
 
@@ -149,7 +149,7 @@ fn set_operating_mode_as_signed_fails() {
 
 #[test]
 fn set_pricing_parameters() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let mut params = Parameters::get();
 		params.rewards.local = 7;
@@ -162,7 +162,7 @@ fn set_pricing_parameters() {
 
 #[test]
 fn set_pricing_parameters_as_signed_fails() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::signed([14; 32].into());
 		let params = Parameters::get();
 
@@ -172,7 +172,7 @@ fn set_pricing_parameters_as_signed_fails() {
 
 #[test]
 fn set_pricing_parameters_invalid() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let mut params = Parameters::get();
 		params.rewards.local = 0;
@@ -186,7 +186,7 @@ fn set_pricing_parameters_invalid() {
 
 #[test]
 fn set_token_transfer_fees() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 
 		assert_ok!(EthereumSystem::set_token_transfer_fees(origin, 1, 1, eth(1)));
@@ -195,7 +195,7 @@ fn set_token_transfer_fees() {
 
 #[test]
 fn set_token_transfer_fees_root_only() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::signed([14; 32].into());
 
 		assert_noop!(EthereumSystem::set_token_transfer_fees(origin, 1, 1, 1.into()), BadOrigin);
@@ -204,7 +204,7 @@ fn set_token_transfer_fees_root_only() {
 
 #[test]
 fn set_token_transfer_fees_invalid() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 
 		assert_noop!(
@@ -216,7 +216,7 @@ fn set_token_transfer_fees_invalid() {
 
 #[test]
 fn create_channel() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
@@ -232,7 +232,7 @@ fn create_channel() {
 
 #[test]
 fn create_channel_fail_already_exists() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
@@ -253,7 +253,7 @@ fn create_channel_fail_already_exists() {
 
 #[test]
 fn create_channel_bad_origin() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		// relay chain location not allowed
 		assert_noop!(
 			EthereumSystem::create_channel(
@@ -306,7 +306,7 @@ fn create_channel_bad_origin() {
 
 #[test]
 fn update_channel() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
@@ -329,7 +329,7 @@ fn update_channel() {
 
 #[test]
 fn update_channel_bad_origin() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let mode = OperatingMode::Normal;
 
 		// relay chain location not allowed
@@ -381,7 +381,7 @@ fn update_channel_bad_origin() {
 
 #[test]
 fn update_channel_fails_not_exist() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(2000)) };
 		let origin = make_xcm_origin(origin_location);
 
@@ -395,7 +395,7 @@ fn update_channel_fails_not_exist() {
 
 #[test]
 fn force_update_channel() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_para_id = 2000;
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(origin_para_id)) };
 		let sovereign_account = sibling_sovereign_account::<Test>(origin_para_id.into());
@@ -425,7 +425,7 @@ fn force_update_channel() {
 
 #[test]
 fn force_update_channel_bad_origin() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let mode = OperatingMode::Normal;
 
 		// signed origin not allowed
@@ -442,7 +442,7 @@ fn force_update_channel_bad_origin() {
 
 #[test]
 fn transfer_native_from_agent() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(2000)) };
 		let recipient: H160 = [27u8; 20].into();
 		let amount = 103435;
@@ -465,7 +465,7 @@ fn transfer_native_from_agent() {
 
 #[test]
 fn force_transfer_native_from_agent() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let origin = RuntimeOrigin::root();
 		let location = MultiLocation { parents: 1, interior: X1(Parachain(2000)) };
 		let versioned_location: Box<VersionedMultiLocation> = Box::new(location.into());
@@ -494,7 +494,7 @@ fn force_transfer_native_from_agent() {
 
 #[test]
 fn force_transfer_native_from_agent_bad_origin() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let recipient: H160 = [27u8; 20].into();
 		let amount = 103435;
 
@@ -527,7 +527,7 @@ fn force_transfer_native_from_agent_bad_origin() {
 #[ignore]
 #[test]
 fn check_sibling_sovereign_account() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let para_id = 1001;
 		let sovereign_account = sibling_sovereign_account::<Test>(para_id.into());
 		let sovereign_account_raw = sibling_sovereign_account_raw(para_id.into());
@@ -542,7 +542,7 @@ fn check_sibling_sovereign_account() {
 
 #[test]
 fn charge_fee_for_create_agent() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let para_id: u32 = TestParaId::get();
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(para_id)) };
 		let origin = make_xcm_origin(origin_location);
@@ -571,7 +571,7 @@ fn charge_fee_for_create_agent() {
 
 #[test]
 fn charge_fee_for_transfer_native_from_agent() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let para_id: u32 = TestParaId::get();
 		let origin_location = MultiLocation { parents: 1, interior: X1(Parachain(para_id)) };
 		let recipient: H160 = [27u8; 20].into();
@@ -601,7 +601,7 @@ fn charge_fee_for_transfer_native_from_agent() {
 
 #[test]
 fn charge_fee_for_upgrade() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(true).execute_with(|| {
 		let para_id: u32 = TestParaId::get();
 		let origin = RuntimeOrigin::root();
 		let address: H160 = Default::default();
@@ -614,5 +614,31 @@ fn charge_fee_for_upgrade() {
 		let sovereign_account = sibling_sovereign_account::<Test>(para_id.into());
 		let sovereign_balance = Balances::balance(&sovereign_account);
 		assert_eq!(sovereign_balance, InitialFunding::get());
+	});
+}
+
+#[test]
+fn force_initialize_can_only_be_called_by_root() {
+	new_test_ext(false).execute_with(|| {
+		let origin = RuntimeOrigin::signed([14; 32].into());
+		assert_err!(EthereumSystem::force_initialize(origin, 1000.into(), 1013.into()), BadOrigin);
+	});
+}
+
+#[test]
+fn force_initialize_initializes_correctly() {
+	new_test_ext(false).execute_with(|| {
+		let origin = RuntimeOrigin::root();
+		assert!(!EthereumSystem::is_initialized(), "Ethereum uninitialized.");
+		assert_ok!(EthereumSystem::force_initialize(origin, 1000.into(), 1013.into()));
+		assert!(EthereumSystem::is_initialized(), "Ethereum initialized.");
+	});
+}
+
+#[test]
+fn force_initialize_with_genesis_build_initializes_correctly() {
+	new_test_ext(true).execute_with(|| {
+		let origin = RuntimeOrigin::root();
+		assert!(EthereumSystem::is_initialized(), "Ethereum uninitialized.");
 	});
 }

--- a/parachain/pallets/system/src/weights.rs
+++ b/parachain/pallets/system/src/weights.rs
@@ -42,6 +42,7 @@ pub trait WeightInfo {
 	fn force_transfer_native_from_agent() -> Weight;
 	fn set_token_transfer_fees() -> Weight;
 	fn set_pricing_parameters() -> Weight;
+	fn force_initialize() -> Weight;
 }
 
 // For backwards compatibility and tests.
@@ -245,5 +246,19 @@ impl WeightInfo for () {
 		Weight::from_parts(42_000_000, 3517)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+
+	/// Storage: `EthereumSystem::Agents` (r:0 w:2)
+	/// Proof: `EthereumSystem::Agents` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumSystem::Channels` (r:0 w:3)
+	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
+	fn force_initialize() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 11_000_000 picoseconds.
+		Weight::from_parts(11_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+			.saturating_add(RocksDbWeight::get().writes(5))
 	}
 }

--- a/parachain/pallets/system/src/weights.rs
+++ b/parachain/pallets/system/src/weights.rs
@@ -42,7 +42,6 @@ pub trait WeightInfo {
 	fn force_transfer_native_from_agent() -> Weight;
 	fn set_token_transfer_fees() -> Weight;
 	fn set_pricing_parameters() -> Weight;
-	fn force_initialize() -> Weight;
 }
 
 // For backwards compatibility and tests.
@@ -246,19 +245,5 @@ impl WeightInfo for () {
 		Weight::from_parts(42_000_000, 3517)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
-	}
-
-	/// Storage: `EthereumSystem::Agents` (r:0 w:2)
-	/// Proof: `EthereumSystem::Agents` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
-	/// Storage: `EthereumSystem::Channels` (r:0 w:3)
-	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
-	fn force_initialize() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(11_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(RocksDbWeight::get().writes(5))
 	}
 }

--- a/smoketest/src/helper.rs
+++ b/smoketest/src/helper.rs
@@ -2,16 +2,7 @@ use crate::{
 	constants::*,
 	contracts::i_gateway,
 	parachains::{
-		bridgehub::{
-			self,
-			api::{
-				runtime_types::{
-					bridge_hub_rococo_runtime::RuntimeCall as BHRuntimeCall,
-					snowbridge_core::outbound::v1::OperatingMode,
-				},
-				utility,
-			},
-		},
+		bridgehub::{self, api::runtime_types::snowbridge_core::outbound::v1::OperatingMode},
 		penpal::{
 			api::runtime_types as penpalTypes,
 			{self},


### PR DESCRIPTION
Polkadot-sdk: https://github.com/Snowfork/polkadot-sdk/pull/70

Adds a migration script that will initialize the agents and channels if not initialized by the genesis build.
Adds a new extrinsic which can be used to force initialization.

Tested the extrinsic manually and via unit tests. Tested the migration by doing a manual runtime upgrade and by using the `try-runtime` tool from Parity.

```
$ try-runtime  --runtime  gen.raw.wasm  on-runtime-upgrade  live --uri wss://rococo-bridge-hub-rpc.dwellir.com:443 2>&1 | grep ethereum_system
[2023-12-18T15:55:55Z INFO  ethereum_system::migration] Agents and channels not initialized. Initialization will run.
[2023-12-18T15:55:55Z INFO  ethereum_system::migration] Ethereum system initialized.
[2023-12-18T15:55:56Z INFO  ethereum_system::migration] Ethereum system initialized.
[2023-12-18T15:55:56Z INFO  ethereum_system::migration] Agents and channels are initialized. Initialization will not run.
[2023-12-18T15:55:56Z INFO  ethereum_system::migration] Ethereum system already initialized. Skipping.
```