### PR TITLE
Ensure commitPrevRandao called after submitInitial

### DIFF
--- a/contracts/src/BeefyClient.sol
+++ b/contracts/src/BeefyClient.sol
@@ -299,6 +299,10 @@ contract BeefyClient {
         bytes32 ticketID = createTicketID(msg.sender, commitmentHash);
         Ticket storage ticket = tickets[ticketID];
 
+        if (ticket.blockNumber == 0) {
+            revert InvalidTicket();
+        }
+
         if (ticket.prevRandao != 0) {
             revert PrevRandaoAlreadyCaptured();
         }

--- a/contracts/test/BeefyClient.t.sol
+++ b/contracts/test/BeefyClient.t.sol
@@ -437,6 +437,11 @@ contract BeefyClientTest is Test {
         assertEq(beefyClient.getValidatorCounter(true, finalValidatorProofs[1].index), 0);
     }
 
+    function testCommitPrevRandaoCalledInSequence() public {
+        vm.expectRevert(BeefyClient.InvalidTicket.selector);
+        commitPrevRandao();
+    }
+
     function testSubmitWithHandoverAnd3SignatureCount() public {
         //initialize with previous set
         BeefyClient.Commitment memory commitment = initialize(setId - 1);


### PR DESCRIPTION
Make sure to explicitly check that the ticket has been initialized before capturing PREVRANDAO.

In practice, we were protected because of this check, however its still good to be explicit:
https://github.com/Snowfork/snowbridge/blob/cdd922433ff509d1108ec2541946e5b230697fff/contracts/src/BeefyClient.sol#L316