### PR TITLE
Prep for crates io

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "rand 0.8.5",
  "ruint",
  "serde",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "c0391754c09fab4eae3404d19d0d297aa1c670c1775ab51d8a5312afeca23157"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -124,9 +124,9 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "syn-solidity",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -456,20 +456,6 @@ dependencies = [
 
 [[package]]
 name = "ark-scale"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bd73bb6ddb72630987d37fa963e99196896c0d0ea81b7c894567e74a2f83af"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "ark-scale"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f69c00b3b529be29528a6f2fd5fa7b1790f8bed81b9cdca17e326538545a179"
@@ -602,7 +588,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -961,7 +947,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#edd1e90b847e560bf60fc2e8712235ccfa11a9a9"
+source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -969,6 +955,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "fflonk",
+ "getrandom_or_panic",
  "merlin 3.0.0",
  "rand_chacha 0.3.1",
 ]
@@ -1025,7 +1012,7 @@ checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom 0.2.11",
  "once_cell",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1237,7 +1224,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1365,7 +1352,7 @@ source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3f
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
- "ark-scale 0.0.12",
+ "ark-scale",
  "ark-secret-scalar",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
@@ -1395,7 +1382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.41",
+ "syn 2.0.48",
  "termcolor",
  "toml",
  "walkdir",
@@ -1567,11 +1554,11 @@ dependencies = [
 
 [[package]]
 name = "ethabi-decode"
-version = "1.3.3"
-source = "git+https://github.com/snowfork/ethabi-decode.git?branch=master#6f63405bb33ef4365a1c62b72d499fa0f448118e"
+version = "1.4.0"
+source = "git+https://github.com/snowfork/ethabi-decode.git?branch=master#7d215837b626650bd9a076821e57ad488101301f"
 dependencies = [
  "ethereum-types",
- "tiny-keccak 1.5.0",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1586,7 +1573,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "scale-info",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1615,7 +1602,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1660,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "fflonk"
 version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#e141d4b6f42fb481aefe1b479788694945b6940d"
+source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -1794,7 +1781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1802,10 +1789,10 @@ name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1814,7 +1801,7 @@ version = "3.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1905,7 +1892,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2447,7 +2434,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2461,7 +2448,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2472,7 +2459,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2483,7 +2470,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3000,12 +2987,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
 dependencies = [
- "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -3040,14 +3026,14 @@ checksum = "9b698b0b09d40e9b7c1a47b132d66a8b54bcd20583d9b6d06e4535e383b4405c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -3089,9 +3075,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -3303,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#edd1e90b847e560bf60fc2e8712235ccfa11a9a9"
+source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -3614,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -3641,20 +3627,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -3779,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -3803,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -3826,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -3850,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum-beacon-client"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "bp-runtime",
  "byte-slice-cast",
@@ -3881,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-inbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3912,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -3937,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "array-bytes 4.2.0",
  "env_logger",
@@ -3951,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3965,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-rococo-common"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "log",
@@ -3974,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -3997,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4011,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-benchmarking",
@@ -4039,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -4076,10 +4062,10 @@ dependencies = [
  "Inflector",
  "blake2",
  "expander",
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4211,13 +4197,13 @@ version = "9.0.0"
 dependencies = [
  "quote",
  "sp-core-hashing",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.4.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -4230,7 +4216,7 @@ dependencies = [
  "ark-ed-on-bls12-377-ext",
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale 0.0.11",
+ "ark-scale",
  "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
@@ -4241,17 +4227,17 @@ version = "8.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4267,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -4403,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -4424,22 +4410,23 @@ version = "11.0.0"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "Inflector",
- "proc-macro-crate 1.3.1",
+ "expander",
+ "proc-macro-crate 3.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4482,7 +4469,7 @@ version = "8.0.0"
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 
 [[package]]
 name = "sp-storage"
@@ -4499,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4535,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "parity-scale-codec",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -4590,7 +4577,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4608,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#54ca4f131b82f45b0c2d1f316d65d7c97ad9a99b"
+source = "git+https://github.com/paritytech/polkadot-sdk#06fa111f58b0172c9f4ba7c209c8b6945787faeb"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -4690,6 +4677,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "staging-xcm"
 version = "1.0.0"
 dependencies = [
+ "array-bytes 6.1.0",
  "bounded-collections",
  "derivative",
  "environmental",
@@ -4803,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4821,7 +4809,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4887,7 +4875,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4898,15 +4886,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -4947,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -4969,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.0.2",
  "toml_datetime",
@@ -5676,7 +5655,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace.package]
+authors = ["Snowfork <contact@snowfork.com>"]
+edition = "2021"
+repository = "https://github.com/snowfork/snowbridge.git"
+
 [workspace]
 resolver = "2"
 members = [

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "snowbridge-ethereum-beacon-client"
 description = "Snowbridge Beacon Client Pallet"
-version = "0.0.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-ethereum-beacon-client"
 description = "Snowbridge Beacon Client Pallet"
-version = "1.0.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/ethereum-beacon-client/README.md
+++ b/parachain/pallets/ethereum-beacon-client/README.md
@@ -1,0 +1,3 @@
+# Ethereum Beacon Client
+
+The Ethereum Beacon Client is an on-chain light client that tracks Ethereum consensus using the beacon chain.

--- a/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.lock
+++ b/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.lock
@@ -3258,11 +3258,26 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowbridge-ethereum-beacon-client-fuzz"
-version = "0.0.0"
+version = "0.9.0"
 publish = false
 edition = "2021"
 

--- a/parachain/pallets/inbound-queue/Cargo.toml
+++ b/parachain/pallets/inbound-queue/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "snowbridge-inbound-queue"
 description = "Snowbridge Inbound Queue"
-version = "0.1.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/inbound-queue/Cargo.toml
+++ b/parachain/pallets/inbound-queue/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-inbound-queue"
 description = "Snowbridge Inbound Queue"
-version = "1.0.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/inbound-queue/README.md
+++ b/parachain/pallets/inbound-queue/README.md
@@ -1,0 +1,3 @@
+# Ethereum Inbound Queue
+
+Reads messages from Ethereum and sends it to intended destination on Polkadot, using XCM.

--- a/parachain/pallets/outbound-queue/Cargo.toml
+++ b/parachain/pallets/outbound-queue/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue"
 description = "Snowbridge Outbound Queue"
-version = "0.1.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/Cargo.toml
+++ b/parachain/pallets/outbound-queue/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-outbound-queue"
 description = "Snowbridge Outbound Queue"
-version = "1.0.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/README.md
+++ b/parachain/pallets/outbound-queue/README.md
@@ -1,0 +1,3 @@
+# Ethereum Outbound Queue
+
+Sends messages from an origin in the Polkadot ecosystem to Ethereum.

--- a/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
+++ b/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-outbound-queue-merkle-tree"
 description = "Snowbridge Outbound Queue Merkle Tree"
-version = "1.0.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
+++ b/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue-merkle-tree"
 description = "Snowbridge Outbound Queue Merkle Tree"
-version = "0.1.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/merkle-tree/README.md
+++ b/parachain/pallets/outbound-queue/merkle-tree/README.md
@@ -1,0 +1,4 @@
+# Snowbridge Outbound Queue Merkle Tree
+
+This crate implements a simple binary Merkle Tree utilities required for inter-op with Ethereum
+bridge & Solidity contract.

--- a/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
+++ b/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue-runtime-api"
 description = "Snowbridge Outbound Queue Runtime API"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
+++ b/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-outbound-queue-runtime-api"
 description = "Snowbridge Outbound Queue Runtime API"
-version = "1.0.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/runtime-api/README.md
+++ b/parachain/pallets/outbound-queue/runtime-api/README.md
@@ -1,0 +1,6 @@
+# Ethereum Outbound Queue Runtime API
+
+Provides an API:
+
+- to prove BEEFY messages
+- calculate delivery fee for delivering messages to Ethereum

--- a/parachain/pallets/system/Cargo.toml
+++ b/parachain/pallets/system/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-system"
 description = "Snowbridge System"
-version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/Cargo.toml
+++ b/parachain/pallets/system/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.1"
 authors = ["Snowfork <contact@snowfork.com>"]
 edition = "2021"
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/README.md
+++ b/parachain/pallets/system/README.md
@@ -1,1 +1,3 @@
-License: MIT-0
+# Ethereum System
+
+Contains management functions 

--- a/parachain/pallets/system/README.md
+++ b/parachain/pallets/system/README.md
@@ -1,3 +1,3 @@
 # Ethereum System
 
-Contains management functions 
+Contains management functions to manage functions on Ethereum. For example, creating agents and channels.

--- a/parachain/pallets/system/runtime-api/Cargo.toml
+++ b/parachain/pallets/system/runtime-api/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "snowbridge-system-runtime-api"
 description = "Snowbridge System Runtime API"
-version = "0.1.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
-homepage = "https://docs.snowbridge.network"
-readme = "README.md"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/runtime-api/Cargo.toml
+++ b/parachain/pallets/system/runtime-api/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Snowfork <contact@snowfork.com>"]
 repository = "https://github.com/Snowfork/snowbridge"
+homepage = "https://docs.snowbridge.network"
+readme = "README.md"
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/runtime-api/README.md
+++ b/parachain/pallets/system/runtime-api/README.md
@@ -1,0 +1,3 @@
+# Ethereum System Runtime API
+
+Provides an API for looking up an agent ID on Ethereum.

--- a/parachain/primitives/beacon/Cargo.toml
+++ b/parachain/primitives/beacon/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-beacon-primitives"
 description = "Snowbridge Beacon Primitives"
-version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/beacon/README.md
+++ b/parachain/primitives/beacon/README.md
@@ -1,0 +1,10 @@
+# Beacon Primitives
+
+Crate with low-level supporting functions for the beacon client, including:
+
+- bls12-381 signature handling to verify signatures on the beacon chain
+- merkle proofs
+- receipt verification
+- ssz types
+
+The code in this crate relates to the Ethereum consensus chain, commonly referred to as the beacon chain.

--- a/parachain/primitives/core/Cargo.toml
+++ b/parachain/primitives/core/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-core"
 description = "Snowbridge Core"
-version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/core/README.md
+++ b/parachain/primitives/core/README.md
@@ -1,0 +1,4 @@
+# Core Primitives
+
+Contains common code core to Snowbridge, such as inbound and outbound queue types, pricing structs, ringbuffer data
+types (used in the beacon client).

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-ethereum"
 description = "Snowbridge Ethereum"
-version = "0.1.0"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/ethereum/README.md
+++ b/parachain/primitives/ethereum/README.md
@@ -1,0 +1,4 @@
+# Ethereum Primitives
+
+Contains code necessary to decode RLP encoded data (like the Ethereum log), structs for Ethereum execution headers. The
+code in this crate relates to the Ethereum execution chain.

--- a/parachain/primitives/router/Cargo.toml
+++ b/parachain/primitives/router/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-router-primitives"
 description = "Snowbridge Router Primitives"
-version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/router/README.md
+++ b/parachain/primitives/router/README.md
@@ -1,0 +1,4 @@
+# Router Primitives
+
+Inbound and outbound router logic. Does XCM conversion to a lowered, simpler format the Ethereum contracts can
+understand.

--- a/parachain/runtime/rococo-common/Cargo.toml
+++ b/parachain/runtime/rococo-common/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-rococo-common"
 description = "Snowbridge Rococo Common"
-version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/rococo-common/README.md
+++ b/parachain/runtime/rococo-common/README.md
@@ -1,0 +1,3 @@
+# Rococo Common
+
+Common crate to contain Rococo runtime config.

--- a/parachain/runtime/runtime-common/Cargo.toml
+++ b/parachain/runtime/runtime-common/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-runtime-common"
 description = "Snowbridge Runtime Common"
-version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/runtime-common/README.md
+++ b/parachain/runtime/runtime-common/README.md
@@ -1,0 +1,3 @@
+# Runtime Common
+
+Common crate to contain runtime related structs and implementations.

--- a/parachain/runtime/tests/Cargo.toml
+++ b/parachain/runtime/tests/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "snowbridge-runtime-tests"
 description = "Snowbridge Runtime Tests"
-version = "0.1.0"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [workspace]

--- a/parachain/runtime/tests/README.md
+++ b/parachain/runtime/tests/README.md
@@ -1,0 +1,3 @@
+# Runtime Tests
+
+Tests runtime config and bridge functionality in the boundaries of a runtime.


### PR DESCRIPTION
Reference `authors`, `edition` and `repository` in the workspace. That way, we will reference the correct values in the polkadot-sdk subtree because in that instance the workspace values are references.

Adds some minimal readme's so the crates.io docs are not empty.