### PR TITLE
Prep for crates io 

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum-beacon-client"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "bp-runtime",
  "byte-slice-cast",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-inbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "array-bytes 4.2.0",
  "env_logger",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-rococo-common"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "log",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-benchmarking",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace.package]
+authors = ["Snowfork <contact@snowfork.com>"]
+edition = "2021"
+repository = "https://github.com/snowfork/snowbridge.git"
+
 [workspace]
 resolver = "2"
 members = [

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-ethereum-beacon-client"
 description = "Snowbridge Beacon Client Pallet"
-version = "0.0.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/ethereum-beacon-client/Cargo.toml
+++ b/parachain/pallets/ethereum-beacon-client/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-ethereum-beacon-client"
 description = "Snowbridge Beacon Client Pallet"
 version = "0.0.1"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/ethereum-beacon-client/README.md
+++ b/parachain/pallets/ethereum-beacon-client/README.md
@@ -1,0 +1,3 @@
+# Ethereum Beacon Client
+
+The Ethereum Beacon Client is an on-chain light client that tracks Ethereum consensus using the beacon chain.

--- a/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.lock
+++ b/parachain/pallets/ethereum-beacon-client/fuzz/Cargo.lock
@@ -2530,7 +2530,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum-beacon-client"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "bp-runtime",
  "byte-slice-cast",

--- a/parachain/pallets/inbound-queue/Cargo.toml
+++ b/parachain/pallets/inbound-queue/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-inbound-queue"
 description = "Snowbridge Inbound Queue"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/inbound-queue/Cargo.toml
+++ b/parachain/pallets/inbound-queue/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-inbound-queue"
 description = "Snowbridge Inbound Queue"
 version = "0.1.1"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/inbound-queue/README.md
+++ b/parachain/pallets/inbound-queue/README.md
@@ -1,0 +1,3 @@
+# Ethereum Inbound Queue
+
+Reads messages from Ethereum and sends it to intended destination on Polkadot, using XCM.

--- a/parachain/pallets/outbound-queue/Cargo.toml
+++ b/parachain/pallets/outbound-queue/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-outbound-queue"
 description = "Snowbridge Outbound Queue"
 version = "0.1.1"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/Cargo.toml
+++ b/parachain/pallets/outbound-queue/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue"
 description = "Snowbridge Outbound Queue"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/outbound-queue/README.md
+++ b/parachain/pallets/outbound-queue/README.md
@@ -1,0 +1,3 @@
+# Ethereum Outbound Queue
+
+Sends messages from an origin in the Polkadot ecosystem to Ethereum.

--- a/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
+++ b/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue-merkle-tree"
 description = "Snowbridge Outbound Queue Merkle Tree"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
+++ b/parachain/pallets/outbound-queue/merkle-tree/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-outbound-queue-merkle-tree"
 description = "Snowbridge Outbound Queue Merkle Tree"
 version = "0.1.1"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/merkle-tree/README.md
+++ b/parachain/pallets/outbound-queue/merkle-tree/README.md
@@ -1,0 +1,4 @@
+# Snowbridge Outbound Queue Merkle Tree
+
+This crate implements a simple binary Merkle Tree utilities required for inter-op with Ethereum
+bridge & Solidity contract.

--- a/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
+++ b/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-outbound-queue-runtime-api"
 description = "Snowbridge Outbound Queue Runtime API"
 version = "0.1.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
+++ b/parachain/pallets/outbound-queue/runtime-api/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-outbound-queue-runtime-api"
 description = "Snowbridge Outbound Queue Runtime API"
-version = "0.1.0"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/outbound-queue/runtime-api/README.md
+++ b/parachain/pallets/outbound-queue/runtime-api/README.md
@@ -2,5 +2,5 @@
 
 Provides an API:
 
-- to prove BEEFY messages
+- to generate merkle proofs for outbound messages
 - calculate delivery fee for delivering messages to Ethereum

--- a/parachain/pallets/outbound-queue/runtime-api/README.md
+++ b/parachain/pallets/outbound-queue/runtime-api/README.md
@@ -1,0 +1,6 @@
+# Ethereum Outbound Queue Runtime API
+
+Provides an API:
+
+- to prove BEEFY messages
+- calculate delivery fee for delivering messages to Ethereum

--- a/parachain/pallets/system/Cargo.toml
+++ b/parachain/pallets/system/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-system"
 description = "Snowbridge System"
 version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/Cargo.toml
+++ b/parachain/pallets/system/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-system"
 description = "Snowbridge System"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/system/README.md
+++ b/parachain/pallets/system/README.md
@@ -1,1 +1,3 @@
-License: MIT-0
+# Ethereum System
+
+Contains management functions to manage functions on Ethereum. For example, creating agents and channels.

--- a/parachain/pallets/system/runtime-api/Cargo.toml
+++ b/parachain/pallets/system/runtime-api/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-system-runtime-api"
 description = "Snowbridge System Runtime API"
-version = "0.1.0"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain/pallets/system/runtime-api/Cargo.toml
+++ b/parachain/pallets/system/runtime-api/Cargo.toml
@@ -2,9 +2,9 @@
 name = "snowbridge-system-runtime-api"
 description = "Snowbridge System Runtime API"
 version = "0.1.0"
-edition = "2021"
-authors = ["Snowfork <contact@snowfork.com>"]
-repository = "https://github.com/Snowfork/snowbridge"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/parachain/pallets/system/runtime-api/README.md
+++ b/parachain/pallets/system/runtime-api/README.md
@@ -1,0 +1,3 @@
+# Ethereum System Runtime API
+
+Provides an API for looking up an agent ID on Ethereum.

--- a/parachain/primitives/beacon/Cargo.toml
+++ b/parachain/primitives/beacon/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-beacon-primitives"
 description = "Snowbridge Beacon Primitives"
 version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/beacon/Cargo.toml
+++ b/parachain/primitives/beacon/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-beacon-primitives"
 description = "Snowbridge Beacon Primitives"
-version = "0.0.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 serde = { version = "1.0.188", optional = true, features = ["derive"] }

--- a/parachain/primitives/beacon/README.md
+++ b/parachain/primitives/beacon/README.md
@@ -1,0 +1,10 @@
+# Beacon Primitives
+
+Crate with low-level supporting functions for the beacon client, including:
+
+- bls12-381 signature handling to verify signatures on the beacon chain
+- merkle proofs
+- receipt verification
+- ssz types
+
+The code in this crate relates to the Ethereum consensus chain, commonly referred to as the beacon chain.

--- a/parachain/primitives/core/Cargo.toml
+++ b/parachain/primitives/core/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-core"
 description = "Snowbridge Core"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 serde = { version = "1.0.188", optional = true, features = ["alloc", "derive"], default-features = false }

--- a/parachain/primitives/core/Cargo.toml
+++ b/parachain/primitives/core/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-core"
 description = "Snowbridge Core"
 version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/core/README.md
+++ b/parachain/primitives/core/README.md
@@ -1,0 +1,4 @@
+# Core Primitives
+
+Contains common code core to Snowbridge, such as inbound and outbound queue types, pricing structs, ringbuffer data
+types (used in the beacon client).

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-ethereum"
 description = "Snowbridge Ethereum"
-version = "0.1.0"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 serde = { version = "1.0.188", optional = true, features = ["derive"] }

--- a/parachain/primitives/ethereum/Cargo.toml
+++ b/parachain/primitives/ethereum/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-ethereum"
 description = "Snowbridge Ethereum"
 version = "0.1.0"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/ethereum/README.md
+++ b/parachain/primitives/ethereum/README.md
@@ -1,0 +1,4 @@
+# Ethereum Primitives
+
+Contains code necessary to decode RLP encoded data (like the Ethereum log), structs for Ethereum execution headers. The
+code in this crate relates to the Ethereum execution chain.

--- a/parachain/primitives/router/Cargo.toml
+++ b/parachain/primitives/router/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-router-primitives"
 description = "Snowbridge Router Primitives"
 version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/primitives/router/Cargo.toml
+++ b/parachain/primitives/router/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-router-primitives"
 description = "Snowbridge Router Primitives"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 serde = { version = "1.0.188", optional = true, features = ["derive"] }

--- a/parachain/primitives/router/README.md
+++ b/parachain/primitives/router/README.md
@@ -1,0 +1,4 @@
+# Router Primitives
+
+Inbound and outbound router logic. Does XCM conversion to a lowered, simpler format the Ethereum contracts can
+understand.

--- a/parachain/runtime/kusama-common/Cargo.toml
+++ b/parachain/runtime/kusama-common/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-kusama-common"
 description = "Snowbridge Kusama Common"
-version = "0.0.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 log = { version = "0.4.20", default-features = false }

--- a/parachain/runtime/kusama-common/Cargo.toml
+++ b/parachain/runtime/kusama-common/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-kusama-common"
 description = "Snowbridge Kusama Common"
 version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/kusama-common/README.md
+++ b/parachain/runtime/kusama-common/README.md
@@ -1,0 +1,3 @@
+# Snowbridge Kusama Common
+
+Common crate to contain Snowbridge Kusama runtime config.

--- a/parachain/runtime/polkadot-common/Cargo.toml
+++ b/parachain/runtime/polkadot-common/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-polkadot-common"
 description = "Snowbridge Polkadot Common"
 version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/polkadot-common/Cargo.toml
+++ b/parachain/runtime/polkadot-common/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-polkadot-common"
 description = "Snowbridge Polkadot Common"
-version = "0.0.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 log = { version = "0.4.20", default-features = false }

--- a/parachain/runtime/polkadot-common/README.md
+++ b/parachain/runtime/polkadot-common/README.md
@@ -1,0 +1,3 @@
+# Snowbridge Polkadot Common
+
+Common crate to contain Snowbridge Polkadot runtime config.

--- a/parachain/runtime/rococo-common/Cargo.toml
+++ b/parachain/runtime/rococo-common/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-rococo-common"
 description = "Snowbridge Rococo Common"
-version = "0.0.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 log = { version = "0.4.20", default-features = false }

--- a/parachain/runtime/rococo-common/Cargo.toml
+++ b/parachain/runtime/rococo-common/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-rococo-common"
 description = "Snowbridge Rococo Common"
 version = "0.0.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/rococo-common/README.md
+++ b/parachain/runtime/rococo-common/README.md
@@ -1,0 +1,3 @@
+# Snowbridge Rococo Common
+
+Common crate to contain Snowbridge Rococo runtime config.

--- a/parachain/runtime/runtime-common/Cargo.toml
+++ b/parachain/runtime/runtime-common/Cargo.toml
@@ -2,8 +2,9 @@
 name = "snowbridge-runtime-common"
 description = "Snowbridge Runtime Common"
 version = "0.1.1"
-authors = ["Snowfork <contact@snowfork.com>"]
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/parachain/runtime/runtime-common/Cargo.toml
+++ b/parachain/runtime/runtime-common/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "snowbridge-runtime-common"
 description = "Snowbridge Runtime Common"
-version = "0.1.1"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 log = { version = "0.4.20", default-features = false }

--- a/parachain/runtime/runtime-common/README.md
+++ b/parachain/runtime/runtime-common/README.md
@@ -1,0 +1,3 @@
+# Snowbridge Runtime Common
+
+Common crate to contain runtime related structs and implementations for Snowbridge.

--- a/parachain/runtime/tests/Cargo.lock
+++ b/parachain/runtime/tests/Cargo.lock
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -9260,7 +9260,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -9282,7 +9282,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -9303,7 +9303,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-ethereum-beacon-client"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "bp-runtime",
  "byte-slice-cast",
@@ -9331,7 +9331,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-inbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -9407,7 +9407,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-rococo-common"
-version = "0.0.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "log",
@@ -9416,7 +9416,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -9438,7 +9438,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9452,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-tests"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "asset-hub-rococo-runtime",
  "assets-common",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system"
-version = "0.1.1"
+version = "0.9.0"
 dependencies = [
  "ethabi-decode",
  "frame-benchmarking",
@@ -9553,7 +9553,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",

--- a/parachain/runtime/tests/Cargo.toml
+++ b/parachain/runtime/tests/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "snowbridge-runtime-tests"
 description = "Snowbridge Runtime Tests"
-version = "0.1.0"
+version = "0.9.0"
 authors = ["Snowfork <contact@snowfork.com>"]
 edition = "2021"
 license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
 
 [workspace]
 

--- a/parachain/runtime/tests/README.md
+++ b/parachain/runtime/tests/README.md
@@ -1,0 +1,3 @@
+# Runtime Tests
+
+Tests runtime config and bridge functionality in the boundaries of a runtime.


### PR DESCRIPTION
Reference authors, edition and repository in the workspace. That way, we will reference the correct values in the polkadot-sdk subtree because in that instance the workspace values are references.

Adds some minimal readme's so the crates.io docs are not empty.

Polkadot-sdk companion: https://github.com/Snowfork/polkadot-sdk/pull/93