### PR TITLE
support `aarch64-linux` environments

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1704791454,
-        "narHash": "sha256-9Je6gU2cjU66ICL2MBRBNmGKHitB8KXvksEAoEcdSo0=",
+        "lastModified": 1705309865,
+        "narHash": "sha256-HkTSsjmR3DE1xKr1M0bBWKyTl4f616166Przd2mwNxw=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "d70197216f7bfe8d314a72153f47372fd685c594",
+        "rev": "883243b30a4b8dbb1b515b79b750e2caf7df1a79",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     outputs = { self, nixpkgs, flake-utils, foundry }:
 
     let
-        supportedSystems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+        supportedSystems = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
         overlays = [ foundry.overlay ];
     in
 


### PR DESCRIPTION
Adds `aarch64-linux` (eg. raspberry or asahi) as a supported system to the flake.