### PR TITLE
Sync beefy on demand

### DIFF
--- a/relayer/cmd/root.go
+++ b/relayer/cmd/root.go
@@ -10,9 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var dataDir string
-var configFile string
-
 var rootCmd = &cobra.Command{
 	Use:          "snowbridge-relay",
 	Short:        "Snowbridge Relay is a bridge between Ethereum and Polkadot",
@@ -32,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(generateBeaconDataCmd())
 	rootCmd.AddCommand(generateBeaconCheckpointCmd())
 	rootCmd.AddCommand(generateExecutionUpdateCmd())
+	rootCmd.AddCommand(syncBeefyCmd())
 }
 
 func Execute() {

--- a/relayer/cmd/run/parachain/command.go
+++ b/relayer/cmd/run/parachain/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"github.com/snowfork/snowbridge/relayer/chain/ethereum"
+	"github.com/snowfork/snowbridge/relayer/relays/beefy"
 	"github.com/snowfork/snowbridge/relayer/relays/parachain"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -62,7 +63,13 @@ func run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	relay, err := parachain.NewRelay(&config, keypair)
+	var beefyConfig beefy.Config
+	err = viper.Unmarshal(&beefyConfig)
+	if err != nil {
+		return err
+	}
+
+	relay, err := parachain.NewRelay(&config, &beefyConfig, keypair)
 	if err != nil {
 		return err
 	}

--- a/relayer/cmd/sync_beefy.go
+++ b/relayer/cmd/sync_beefy.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sirupsen/logrus"
+	"github.com/snowfork/snowbridge/relayer/chain/ethereum"
+	"github.com/snowfork/snowbridge/relayer/relays/beefy"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func syncBeefyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-beefy-on-demand",
+		Short: "Sync beefy update on demand by block number",
+		Args:  cobra.ExactArgs(0),
+		RunE:  SyncBeefyFn,
+	}
+
+	cmd.Flags().String("config", "/tmp/snowbridge/beefy-relay.json", "Path to configuration file")
+	cmd.MarkFlagRequired("config")
+	cmd.Flags().String("private-key", "", "Ethereum private key")
+	cmd.Flags().String("privateKeyFile", "", "The file from which to read the private key")
+	cmd.Flags().Uint64P("block", "b", 0, "Block number")
+	cmd.MarkFlagRequired("block")
+	return cmd
+}
+
+func SyncBeefyFn(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	log.SetOutput(logrus.WithFields(logrus.Fields{"logger": "stdlib"}).WriterLevel(logrus.InfoLevel))
+	logrus.SetLevel(logrus.DebugLevel)
+
+	configFile, err := cmd.Flags().GetString("config")
+	viper.SetConfigFile(configFile)
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	var config beefy.Config
+	err = viper.Unmarshal(&config)
+	if err != nil {
+		return err
+	}
+	privateKey, _ := cmd.Flags().GetString("private-key")
+	privateKeyFile, _ := cmd.Flags().GetString("privateKeyFile")
+	if privateKey == "" && privateKeyFile == "" {
+		return fmt.Errorf("missing private key")
+	}
+	keypair, err := ethereum.ResolvePrivateKey(privateKey, privateKeyFile)
+	if err != nil {
+		return err
+	}
+
+	relay, err := beefy.NewRelay(&config, keypair)
+	if err != nil {
+		return err
+	}
+	blockNumber, _ := cmd.Flags().GetUint64("block")
+	err = relay.SyncUpdate(ctx, blockNumber)
+	return err
+}

--- a/relayer/cmd/sync_beefy.go
+++ b/relayer/cmd/sync_beefy.go
@@ -60,6 +60,10 @@ func SyncBeefyFn(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	blockNumber, _ := cmd.Flags().GetUint64("block")
+	err = relay.Initialize(ctx)
+	if err != nil {
+		return err
+	}
 	err = relay.SyncUpdate(ctx, blockNumber)
 	return err
 }

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -245,7 +245,7 @@ func (li *PolkadotListener) generateNextBeefyUpdate(nextBlockNumber uint64) (Req
 		Validators:       validators,
 		SignedCommitment: *commitment,
 		Proof:            proof,
-		IsHandover:       nextValidatorSetID == validatorSetID+2,
+		IsHandover:       nextValidatorSetID == validatorSetID+1,
 	}
 
 	return request, nil

--- a/relayer/relays/parachain/main.go
+++ b/relayer/relays/parachain/main.go
@@ -84,6 +84,11 @@ func (relay *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 		return err
 	}
 
+	err = relay.beefyListener.beefyRelay.Initialize(ctx)
+	if err != nil {
+		return err
+	}
+
 	log.Info("Starting beefy listener")
 	err = relay.beefyListener.Start(ctx, eg)
 	if err != nil {

--- a/relayer/relays/parachain/scanner.go
+++ b/relayer/relays/parachain/scanner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/snowfork/go-substrate-rpc-client/v4/scale"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -35,16 +36,16 @@ type Scanner struct {
 //  3. Scan parachain blocks to figure out exactly which commitments need to be relayed.
 //  4. For all the parachain blocks with unsettled commitments, determine the relay chain block number in which the
 //     parachain block was included.
-func (s *Scanner) Scan(ctx context.Context, beefyBlockNumber uint64) ([]*Task, error) {
+func (s *Scanner) Scan(ctx context.Context, relayBlockNumber uint64) ([]*Task, error) {
 	// fetch last parachain header that was finalized *before* the BEEFY block
-	beefyBlockMinusOneHash, err := s.relayConn.API().RPC.Chain.GetBlockHash(uint64(beefyBlockNumber - 1))
+	relayBlockMinusOneHash, err := s.relayConn.API().RPC.Chain.GetBlockHash(uint64(relayBlockNumber - 1))
 	if err != nil {
-		return nil, fmt.Errorf("fetch block hash for block %v: %w", beefyBlockNumber, err)
+		return nil, fmt.Errorf("fetch block hash for block %v: %w", relayBlockNumber, err)
 	}
 	var paraHead types.Header
-	ok, err := s.relayConn.FetchParachainHead(beefyBlockMinusOneHash, s.paraID, &paraHead)
+	ok, err := s.relayConn.FetchParachainHead(relayBlockMinusOneHash, s.paraID, &paraHead)
 	if err != nil {
-		return nil, fmt.Errorf("fetch head for parachain %v at block %v: %w", s.paraID, beefyBlockMinusOneHash.Hex(), err)
+		return nil, fmt.Errorf("fetch head for parachain %v at block %v: %w", s.paraID, relayBlockMinusOneHash.Hex(), err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("parachain %v is not registered", s.paraID)

--- a/web/packages/test/config/beefy-relay.json
+++ b/web/packages/test/config/beefy-relay.json
@@ -5,7 +5,7 @@
     },
     "beefy-activation-block": 0,
     "fast-forward-depth": 20,
-    "update-period": 0
+    "update-period": 20
   },
   "sink": {
     "ethereum": {

--- a/web/packages/test/config/parachain-relay.json
+++ b/web/packages/test/config/parachain-relay.json
@@ -22,6 +22,7 @@
       "gas-limit": null
     },
     "contracts": {
+      "BeefyClient": null,
       "Gateway": null
     }
   }

--- a/web/packages/test/scripts/start-relayer.sh
+++ b/web/packages/test/scripts/start-relayer.sh
@@ -28,6 +28,7 @@ config_relayer() {
       .source.contracts.Gateway = $k1
     | .source.contracts.BeefyClient = $k2
     | .sink.contracts.Gateway = $k1
+    | .sink.contracts.BeefyClient = $k2
     | .source.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum."gas-limit" = $eth_gas_limit
@@ -46,6 +47,7 @@ config_relayer() {
       .source.contracts.Gateway = $k1
     | .source.contracts.BeefyClient = $k2
     | .sink.contracts.Gateway = $k1
+    | .sink.contracts.BeefyClient = $k2
     | .source.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum."gas-limit" = $eth_gas_limit
@@ -64,6 +66,7 @@ config_relayer() {
       .source.contracts.Gateway = $k1
     | .source.contracts.BeefyClient = $k2
     | .sink.contracts.Gateway = $k1
+    | .sink.contracts.BeefyClient = $k2
     | .source.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum."gas-limit" = $eth_gas_limit
@@ -82,6 +85,7 @@ config_relayer() {
       .source.contracts.Gateway = $k1
     | .source.contracts.BeefyClient = $k2
     | .sink.contracts.Gateway = $k1
+    | .sink.contracts.BeefyClient = $k2
     | .source.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum.endpoint = $eth_endpoint_ws
     | .sink.ethereum."gas-limit" = $eth_gas_limit


### PR DESCRIPTION
Move syncing beefy updates to the parachain relayer and sync only on demand when there is a message to relay.

In this way we can further decrease the cost without sacrificing the waiting time which is the downside of introducing https://github.com/Snowfork/snowbridge/pull/1098