### PR TITLE
TokenSent Event mislabels `sender` and `token` properties

### DIFF
--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -132,7 +132,7 @@ library Assets {
                 revert Unsupported();
             }
         }
-        emit IGateway.TokenSent(sender, token, destinationChain, destinationAddress, amount);
+        emit IGateway.TokenSent(token, sender, destinationChain, destinationAddress, amount);
     }
 
     function registerTokenCosts() external view returns (Costs memory costs) {

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -68,8 +68,8 @@ interface IGateway {
 
     /// @dev Emitted once the funds are locked and an outbound message is successfully queued.
     event TokenSent(
-        address indexed sender,
         address indexed token,
+        address indexed sender,
         ParaID indexed destinationChain,
         MultiAddress destinationAddress,
         uint128 amount

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -68,8 +68,8 @@ interface IGateway {
 
     /// @dev Emitted once the funds are locked and an outbound message is successfully queued.
     event TokenSent(
-        address indexed token,
         address indexed sender,
+        address indexed token,
         ParaID indexed destinationChain,
         MultiAddress destinationAddress,
         uint128 amount

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -595,7 +595,7 @@ contract GatewayTest is Test {
         fee = IGateway(address(gateway)).quoteSendTokenFee(address(token), destPara, 1);
 
         vm.expectEmit(true, true, false, true);
-        emit IGateway.TokenSent(address(this), address(token), destPara, recipientAddress32, 1);
+        emit IGateway.TokenSent(address(token), address(this), destPara, recipientAddress32, 1);
 
         // Expect the gateway to emit `OutboundMessageAccepted`
         vm.expectEmit(true, false, false, false);
@@ -618,7 +618,7 @@ contract GatewayTest is Test {
         fee = IGateway(address(gateway)).quoteSendTokenFee(address(token), destPara, 1);
 
         vm.expectEmit(true, true, false, true);
-        emit IGateway.TokenSent(address(this), address(token), destPara, recipientAddress32, 1);
+        emit IGateway.TokenSent(address(token), address(this), destPara, recipientAddress32, 1);
 
         // Expect the gateway to emit `OutboundMessageAccepted`
         vm.expectEmit(true, false, false, false);
@@ -641,7 +641,7 @@ contract GatewayTest is Test {
         fee = IGateway(address(gateway)).quoteSendTokenFee(address(token), destPara, 1);
 
         vm.expectEmit(true, true, false, true);
-        emit IGateway.TokenSent(address(this), address(token), destPara, recipientAddress20, 1);
+        emit IGateway.TokenSent(address(token), address(this), destPara, recipientAddress20, 1);
 
         // Expect the gateway to emit `OutboundMessageAccepted`
         vm.expectEmit(true, false, false, false);


### PR DESCRIPTION
`sender` needs to be the first property. `token` needs to be the seconds. 

See: https://github.com/Snowfork/snowbridge/blob/alistair/token-sent-correct-name/contracts/src/Assets.sol#L135