### PR TITLE
Permit non-consecutive increments in validator set

### DIFF
--- a/contracts/src/BeefyClient.sol
+++ b/contracts/src/BeefyClient.sol
@@ -253,7 +253,7 @@ contract BeefyClient {
             signatureUsageCount = currentValidatorSet.usageCounters.get(proof.index);
             currentValidatorSet.usageCounters.set(proof.index, signatureUsageCount.saturatingAdd(1));
             vset = currentValidatorSet;
-        } else if (commitment.validatorSetID == nextValidatorSet.id) {
+        } else if (commitment.validatorSetID >= nextValidatorSet.id) {
             signatureUsageCount = nextValidatorSet.usageCounters.get(proof.index);
             nextValidatorSet.usageCounters.set(proof.index, signatureUsageCount.saturatingAdd(1));
             vset = nextValidatorSet;

--- a/contracts/src/BeefyClient.sol
+++ b/contracts/src/BeefyClient.sol
@@ -345,7 +345,7 @@ contract BeefyClient {
 
         bool is_next_session = false;
         ValidatorSetState storage vset;
-        if (commitment.validatorSetID == nextValidatorSet.id) {
+        if (commitment.validatorSetID > currentValidatorSet.id) {
             is_next_session = true;
             vset = nextValidatorSet;
         } else if (commitment.validatorSetID == currentValidatorSet.id) {
@@ -359,7 +359,7 @@ contract BeefyClient {
         bytes32 newMMRRoot = ensureProvidesMMRRoot(commitment);
 
         if (is_next_session) {
-            if (leaf.nextAuthoritySetID != nextValidatorSet.id + 1) {
+            if (leaf.nextAuthoritySetID <= nextValidatorSet.id) {
                 revert InvalidMMRLeaf();
             }
             bool leafIsValid =


### PR DESCRIPTION
Changes the validator set successions to still be strictly increasing, but not necessarily consecutive.

This can greatly improve cost-efficiency of the bridge, but is also useful in recovery scenarios like https://github.com/paritytech/polkadot-sdk/issues/3080, where only one signed commitment would have to be crafted for a recovery, instead of one for every missed session.

### Rationale

For bridge security against collusion by validators, it's important that these validators are still bonded, but the timing of the signature itself is secondary. Only bonded validators are still slashable, and to a bonded validator, neither the probability of succeeding with an attack nor the probability of getting caught are influenced by the timing of the signature - it is in fact irrelevant whether they sign a payload while being part of a particular validator set `n` or if they happened to be part of set `n+m` later (as long as they are still bonded).

While it is important that BEEFY produces a commitment for every handover of validator sets, it would be beneficial to not relay a block every session unless the active identities have changed. 

For the BEEFY light client, while it will naturally still check a signed commitment against the authorities defined in the `currentValidatorSet` (read: validator set last known on Ethereum [VSLKOE]), as long as the signatures are still ordered as expected for the bitfield checks, the commitment can pass even if the commitment was signed outside of the VSLKOE's mandate within the BEEFY voting protocol. 

While the validator set does change over time, it is largely preserved from session to session. 
As such, even if some validators have rotated out, this change permits keeping the bridge alive so long as 2/3rds of the `currentValidatorSet` are still bonded and sign the commitment - either for recovery or cost optimization purposes.

### Next Steps

This change is a prerequisite to allowing relayers to skip sessions for block relaying:
https://github.com/Snowfork/snowbridge/blob/main/relayer/relays/beefy/polkadot-listener.go#L115-L125

For a cost-efficient bridge, the next step is to adjust the (common-good) relayer logic to only relay blocks if there has been a change in the keys of the upcoming validator set.

More aggressive approaches that additionally don't relay if only small quantities of keys have changed are possible too, but also require a more bespoke implementation. 

cc @AlistairStewart @bhargavbh
