### PR TITLE
Mandatory commitments only

### DIFF
--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -99,7 +99,7 @@ func (li *PolkadotListener) scanCommitments(
 				},
 				"validatorSetID":       currentValidatorSet,
 				"IsHandover":           validatorSetID == currentValidatorSet+1,
-				"Mandatory":            result.MandatoryCommitment,
+				"IsMandatory":          result.IsMandatory,
 				"lastSyncedBeefyBlock": lastSyncedBeefyBlock,
 			})
 

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -113,11 +113,6 @@ func (li *PolkadotListener) scanCommitments(
 				Proof:            result.MMRProof,
 			}
 
-			if !result.MandatoryCommitment {
-				logEntry.Info("Skipped due to not mandatory commitment.")
-				continue
-			}
-
 			if validatorSetID == currentValidatorSet+1 && validatorSetID == nextValidatorSetID-1 {
 				task.IsHandover = true
 				select {

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -99,6 +99,7 @@ func (li *PolkadotListener) scanCommitments(
 				},
 				"validatorSetID":       currentValidatorSet,
 				"IsHandover":           validatorSetID == currentValidatorSet+1,
+				"Mandatory":            result.MandatoryCommitment,
 				"lastSyncedBeefyBlock": lastSyncedBeefyBlock,
 			})
 
@@ -110,6 +111,11 @@ func (li *PolkadotListener) scanCommitments(
 				Validators:       validators,
 				SignedCommitment: result.SignedCommitment,
 				Proof:            result.MMRProof,
+			}
+
+			if !result.MandatoryCommitment {
+				logEntry.Info("Skipped due to not mandatory commitment.")
+				continue
 			}
 
 			if validatorSetID == currentValidatorSet+1 && validatorSetID == nextValidatorSetID-1 {

--- a/relayer/relays/beefy/scanner.go
+++ b/relayer/relays/beefy/scanner.go
@@ -180,12 +180,12 @@ func scanCommitments(ctx context.Context, api *gsrpc.SubstrateAPI, startBlock ui
 }
 
 type ScanSafeCommitmentsResult struct {
-	SignedCommitment    types.SignedCommitment
-	MMRProof            merkle.SimplifiedMMRProof
-	BlockHash           types.Hash
-	Depth               uint64
-	MandatoryCommitment bool
-	Error               error
+	SignedCommitment types.SignedCommitment
+	MMRProof         merkle.SimplifiedMMRProof
+	BlockHash        types.Hash
+	Depth            uint64
+	IsMandatory      bool
+	Error            error
 }
 
 func ScanSafeCommitments(ctx context.Context, meta *types.Metadata, api *gsrpc.SubstrateAPI, startBlock uint64) (<-chan ScanSafeCommitmentsResult, error) {


### PR DESCRIPTION
Adds the `IsMandatory` flag to `SafeScanCommitmentResult`. This is just appended to logging in this PR. 

But I used this flag to skip signed commitments that are not mandatory n order to test parity https://github.com/paritytech/polkadot-sdk/pull/3108 .
```go
	if !result.IsMandatory {
		logEntry.Info("Skipped due to not mandatory commitment.")
		continue
	}
```

We do not need code changes to support the fix. Leaving the IsMandatory field in here because I think its useful for logging. In the future we could use it to save costs by limiting submissions to the light client to only mandatory commitments.

Resolves: SNO-842