### PR TITLE
Fix e2e tests

### DIFF
--- a/smoketest/Cargo.lock
+++ b/smoketest/Cargo.lock
@@ -710,6 +710,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bounded-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,19 +1752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "expander"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
-dependencies = [
- "blake2",
- "fs-err",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,15 +1852,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
-]
-
-[[package]]
-name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -4410,7 +4400,6 @@ dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "serde",
- "sp-core 28.0.0",
  "staging-xcm",
  "subxt",
  "subxt-codegen",
@@ -4464,22 +4453,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 26.0.0",
+ "sp-core",
  "sp-io",
  "sp-std 12.0.0",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "16.0.0"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std 8.0.0",
- "static_assertions",
 ]
 
 [[package]]
@@ -4498,6 +4474,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-arithmetic"
+version = "23.0.0"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std 14.0.0",
+ "static_assertions",
+]
+
+[[package]]
 name = "sp-core"
 version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,7 +4496,7 @@ dependencies = [
  "bip39",
  "bitflags 1.3.2",
  "blake2",
- "bounded-collections",
+ "bounded-collections 0.1.9",
  "bs58",
  "dyn-clonable",
  "ed25519-zebra 3.1.0",
@@ -4531,58 +4520,12 @@ dependencies = [
  "secp256k1 0.24.3",
  "secrecy",
  "serde",
- "sp-core-hashing 13.0.0",
+ "sp-core-hashing",
  "sp-debug-derive 12.0.0",
- "sp-externalities 0.23.0",
- "sp-runtime-interface 22.0.0",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std 12.0.0",
- "sp-storage 17.0.0",
- "ss58-registry",
- "substrate-bip39",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f230cb12575455070da0fc174815958423a0b9a641d5e304a9457113c7cb4007"
-dependencies = [
- "array-bytes",
- "bip39",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra 3.1.0",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.10.5",
- "libsecp256k1",
- "log",
- "merlin 3.0.0",
- "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel 0.11.4",
- "secp256k1 0.28.2",
- "secrecy",
- "serde",
- "sp-core-hashing 15.0.0",
- "sp-debug-derive 14.0.0",
- "sp-externalities 0.25.0",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-storage",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -4606,29 +4549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core-hashing"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4990add7b2cefdeca883c0efa99bb4d912cb2196120e1500c0cc099553b0"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.8",
- "sha3",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "8.0.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "sp-debug-derive"
 version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,8 +4562,6 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4659,19 +4577,7 @@ dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std 12.0.0",
- "sp-storage 17.0.0",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63867ec85950ced90d4ab1bba902a47db1b1efdf2829f653945669b2bb470a9c"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-storage",
 ]
 
 [[package]]
@@ -4687,13 +4593,13 @@ dependencies = [
  "parity-scale-codec",
  "rustversion",
  "secp256k1 0.24.3",
- "sp-core 26.0.0",
- "sp-externalities 0.23.0",
+ "sp-core",
+ "sp-externalities",
  "sp-keystore",
- "sp-runtime-interface 22.0.0",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-std 12.0.0",
- "sp-tracing 14.0.0",
+ "sp-tracing",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -4707,8 +4613,8 @@ checksum = "1db18ab01b2684856904c973d2be7dbf9ab3607cf706a7bd6648812662e5e7c5"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 26.0.0",
- "sp-externalities 0.23.0",
+ "sp-core",
+ "sp-externalities",
  "thiserror",
 ]
 
@@ -4740,7 +4646,7 @@ dependencies = [
  "serde",
  "sp-application-crypto",
  "sp-arithmetic 21.0.0",
- "sp-core 26.0.0",
+ "sp-core",
  "sp-io",
  "sp-std 12.0.0",
  "sp-weights 25.0.0",
@@ -4756,31 +4662,12 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.23.0",
- "sp-runtime-interface-proc-macro 15.0.0",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
  "sp-std 12.0.0",
- "sp-storage 17.0.0",
- "sp-tracing 14.0.0",
- "sp-wasm-interface 18.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66b66d8cec3d785fa6289336c1d9cbd4305d5d84f7134378c4d79ed7983e6fb"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.25.0",
- "sp-runtime-interface-proc-macro 17.0.0",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
@@ -4798,20 +4685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaf6e85b2ec12a4b99cd6d8d57d083e30c94b7f1b0d8f93547121495aae6f0c"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "sp-state-machine"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,8 +4696,8 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "sp-core 26.0.0",
- "sp-externalities 0.23.0",
+ "sp-core",
+ "sp-externalities",
  "sp-panic-handler",
  "sp-std 12.0.0",
  "sp-trie",
@@ -4835,10 +4708,6 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "8.0.0"
-
-[[package]]
-name = "sp-std"
 version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54c78c5a66682568cc7b153603c5d01a2cc8f5c221c7b1e921517a0eef18ae05"
@@ -4846,8 +4715,6 @@ checksum = "54c78c5a66682568cc7b153603c5d01a2cc8f5c221c7b1e921517a0eef18ae05"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
 name = "sp-storage"
@@ -4864,20 +4731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb92d7b24033a8a856d6e20dd980b653cbd7af7ec471cc988b1b7c1d2e3a32b"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0",
- "sp-std 14.0.0",
-]
-
-[[package]]
 name = "sp-tracing"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4885,19 +4738,6 @@ checksum = "0d727cb5265641ffbb7d4e42c18b63e29f6cfdbd240aae3bcf093c3d6eb29a19"
 dependencies = [
  "parity-scale-codec",
  "sp-std 12.0.0",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0351810b9d074df71c4514c5228ed05c250607cba131c1c9d1526760ab69c05c"
-dependencies = [
- "parity-scale-codec",
- "sp-std 14.0.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -4920,7 +4760,7 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 26.0.0",
+ "sp-core",
  "sp-std 12.0.0",
  "thiserror",
  "tracing",
@@ -4943,34 +4783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef97172c42eb4c6c26506f325f48463e9bc29b2034a587f1b9e48c751229bee"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-std 14.0.0",
- "wasmtime",
-]
-
-[[package]]
-name = "sp-weights"
-version = "20.0.0"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 16.0.0",
- "sp-debug-derive 8.0.0",
- "sp-std 8.0.0",
-]
-
-[[package]]
 name = "sp-weights"
 version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,9 +4793,23 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic 21.0.0",
- "sp-core 26.0.0",
+ "sp-core",
  "sp-debug-derive 12.0.0",
  "sp-std 12.0.0",
+]
+
+[[package]]
+name = "sp-weights"
+version = "27.0.0"
+dependencies = [
+ "bounded-collections 0.2.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 23.0.0",
+ "sp-debug-derive 14.0.0",
+ "sp-std 14.0.0",
 ]
 
 [[package]]
@@ -5031,10 +4857,10 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-xcm"
-version = "1.0.0"
+version = "7.0.0"
 dependencies = [
  "array-bytes",
- "bounded-collections",
+ "bounded-collections 0.2.0",
  "derivative",
  "environmental",
  "impl-trait-for-tuples",
@@ -5042,7 +4868,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-weights 20.0.0",
+ "sp-weights 27.0.0",
  "xcm-procedural",
 ]
 
@@ -5123,8 +4949,8 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
- "sp-core 26.0.0",
- "sp-core-hashing 13.0.0",
+ "sp-core",
+ "sp-core-hashing",
  "sp-runtime",
  "subxt-lightclient",
  "subxt-macro",
@@ -5188,7 +5014,7 @@ dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing 13.0.0",
+ "sp-core-hashing",
  "thiserror",
 ]
 
@@ -5207,7 +5033,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy",
  "sha2 0.10.8",
- "sp-core-hashing 13.0.0",
+ "sp-core-hashing",
  "subxt",
  "thiserror",
  "zeroize",
@@ -6416,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "1.0.0"
+version = "7.0.0"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/smoketest/Cargo.toml
+++ b/smoketest/Cargo.toml
@@ -18,7 +18,6 @@ subxt-metadata = { git = "https://github.com/paritytech/subxt.git", tag = "v0.33
 subxt-codegen = { git = "https://github.com/paritytech/subxt.git", tag = "v0.33.0" }
 subxt-signer = { git = "https://github.com/paritytech/subxt.git", tag = "v0.33.0" }
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["abigen", "ws"] }
-sp-core = "28.0.0"
 lazy_static = "1.4.0"
 
 [dev-dependencies]

--- a/smoketest/make-bindings.sh
+++ b/smoketest/make-bindings.sh
@@ -13,7 +13,7 @@ forge bind --module --overwrite \
 # Install subxt
 command -v subxt || cargo install subxt-cli \
     --git https://github.com/paritytech/subxt.git \
-    --tag v0.27.1
+    --tag v0.33.0
 
 if ! lsof -Pi :11144 -sTCP:LISTEN -t >/dev/null; then
     echo "substrate nodes not running, please start with the e2e setup and rerun this script"

--- a/smoketest/src/helper.rs
+++ b/smoketest/src/helper.rs
@@ -46,13 +46,12 @@ use penpalTypes::{
 		VersionedXcm,
 	},
 };
-use sp_core::H160;
 use std::{ops::Deref, sync::Arc, time::Duration};
 use subxt::{
 	blocks::ExtrinsicEvents,
 	config::DefaultExtrinsicParams,
 	events::StaticEvent,
-	ext::sp_core::{sr25519::Pair, Pair as PairT},
+	ext::sp_core::{sr25519::Pair, Pair as PairT, H160},
 	tx::{PairSigner, TxPayload},
 	Config, OnlineClient, PolkadotConfig,
 };

--- a/smoketest/tests/send_token.rs
+++ b/smoketest/tests/send_token.rs
@@ -21,8 +21,7 @@ use snowbridge_smoketest::{
 		},
 	},
 };
-use sp_core::Encode;
-use subxt::utils::AccountId32;
+use subxt::{ext::codec::Encode, utils::AccountId32};
 
 #[tokio::test]
 async fn send_token() {

--- a/smoketest/tests/send_token_to_penpal.rs
+++ b/smoketest/tests/send_token_to_penpal.rs
@@ -24,8 +24,8 @@ use snowbridge_smoketest::{
 		penpal::{self, api::foreign_assets::events::Issued as PenpalIssued},
 	},
 };
-use sp_core::Encode;
 use subxt::{
+	ext::codec::Encode,
 	tx::PairSigner,
 	utils::{AccountId32, MultiAddress},
 	OnlineClient,
@@ -177,7 +177,7 @@ async fn ensure_penpal_asset_exists(penpal_client: &mut OnlineClient<PenpalConfi
 	let penpal_asset_address = penpal::api::storage().foreign_assets().asset(&penpal_asset_id);
 	let result = penpal_client
 		.storage()
-		.at(None)
+		.at_latest()
 		.await
 		.unwrap()
 		.fetch(&penpal_asset_address)

--- a/smoketest/tests/upgrade_gateway.rs
+++ b/smoketest/tests/upgrade_gateway.rs
@@ -34,8 +34,8 @@ use snowbridge_smoketest::{
 		},
 	},
 };
-use sp_core::{sr25519::Pair, Pair as PairT};
 use subxt::{
+	ext::sp_core::{sr25519::Pair, Pair as PairT},
 	tx::{PairSigner, TxPayload},
 	OnlineClient, PolkadotConfig,
 };


### PR DESCRIPTION
* Generate bindings with a matching version of `subxt`.
* Fix minor issues with updates to api.
* Removing `sp_core` to use the one bundled with `subxt`.