### PR TITLE
Changes required to enable contract upgrades

### DIFF
--- a/contracts/src/DeployGatewayLogic.sol
+++ b/contracts/src/DeployGatewayLogic.sol
@@ -8,7 +8,7 @@ import {ParaID} from "./Types.sol";
 import {Script} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 
-contract DeployGateway is Script {
+contract DeployGatewayLogic is Script {
     using stdJson for string;
 
     function setUp() public {}

--- a/contracts/src/DeployGatewayLogic.sol
+++ b/contracts/src/DeployGatewayLogic.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+pragma solidity 0.8.23;
+
+import {AgentExecutor} from "./AgentExecutor.sol";
+import {Gateway} from "./Gateway.sol";
+import {ParaID} from "./Types.sol";
+import {Script} from "forge-std/Script.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+contract DeployGateway is Script {
+    using stdJson for string;
+
+    function setUp() public {}
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.rememberKey(privateKey);
+        vm.startBroadcast(deployer);
+
+        address beefyClient = vm.envAddress("BEEFY_CLIENT_CONTRACT_ADDRESS");
+
+        ParaID bridgeHubParaID = ParaID.wrap(uint32(vm.envUint("BRIDGE_HUB_PARAID")));
+        bytes32 bridgeHubAgentID = vm.envBytes32("BRIDGE_HUB_AGENT_ID");
+
+        uint8 foreignTokenDecimals = uint8(vm.envUint("FOREIGN_TOKEN_DECIMALS"));
+
+        AgentExecutor executor = new AgentExecutor();
+        new Gateway(address(beefyClient), address(executor), bridgeHubParaID, bridgeHubAgentID, foreignTokenDecimals);
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -578,43 +578,47 @@ contract Gateway is IGateway, IInitializable {
             revert Unauthorized();
         }
 
-        Config memory config = abi.decode(data, (Config));
-
         CoreStorage.Layout storage core = CoreStorage.layout();
-        core.mode = config.mode;
 
-        // Initialize agent for BridgeHub
-        address bridgeHubAgent = address(new Agent(BRIDGE_HUB_AGENT_ID));
-        core.agents[BRIDGE_HUB_AGENT_ID] = bridgeHubAgent;
+        // Check if initialized and run initialization once.
+        if (core.channels[PRIMARY_GOVERNANCE_CHANNEL_ID].agent == address(0)) {
+            Config memory config = abi.decode(data, (Config));
 
-        // Initialize channel for primary governance track
-        core.channels[PRIMARY_GOVERNANCE_CHANNEL_ID] =
-            Channel({mode: OperatingMode.Normal, agent: bridgeHubAgent, inboundNonce: 0, outboundNonce: 0});
+            core.mode = config.mode;
 
-        // Initialize channel for secondary governance track
-        core.channels[SECONDARY_GOVERNANCE_CHANNEL_ID] =
-            Channel({mode: OperatingMode.Normal, agent: bridgeHubAgent, inboundNonce: 0, outboundNonce: 0});
+            // Initialize agent for BridgeHub
+            address bridgeHubAgent = address(new Agent(BRIDGE_HUB_AGENT_ID));
+            core.agents[BRIDGE_HUB_AGENT_ID] = bridgeHubAgent;
 
-        // Initialize agent for for AssetHub
-        address assetHubAgent = address(new Agent(config.assetHubAgentID));
-        core.agents[config.assetHubAgentID] = assetHubAgent;
+            // Initialize channel for primary governance track
+            core.channels[PRIMARY_GOVERNANCE_CHANNEL_ID] =
+                Channel({mode: OperatingMode.Normal, agent: bridgeHubAgent, inboundNonce: 0, outboundNonce: 0});
 
-        // Initialize channel for AssetHub
-        core.channels[config.assetHubParaID.into()] =
-            Channel({mode: OperatingMode.Normal, agent: assetHubAgent, inboundNonce: 0, outboundNonce: 0});
+            // Initialize channel for secondary governance track
+            core.channels[SECONDARY_GOVERNANCE_CHANNEL_ID] =
+                Channel({mode: OperatingMode.Normal, agent: bridgeHubAgent, inboundNonce: 0, outboundNonce: 0});
 
-        // Initialize pricing storage
-        PricingStorage.Layout storage pricing = PricingStorage.layout();
-        pricing.exchangeRate = config.exchangeRate;
-        pricing.deliveryCost = config.deliveryCost;
+            // Initialize agent for for AssetHub
+            address assetHubAgent = address(new Agent(config.assetHubAgentID));
+            core.agents[config.assetHubAgentID] = assetHubAgent;
 
-        // Initialize assets storage
-        AssetsStorage.Layout storage assets = AssetsStorage.layout();
+            // Initialize channel for AssetHub
+            core.channels[config.assetHubParaID.into()] =
+                Channel({mode: OperatingMode.Normal, agent: assetHubAgent, inboundNonce: 0, outboundNonce: 0});
 
-        assets.assetHubParaID = config.assetHubParaID;
-        assets.assetHubAgent = assetHubAgent;
-        assets.registerTokenFee = config.registerTokenFee;
-        assets.assetHubCreateAssetFee = config.assetHubCreateAssetFee;
-        assets.assetHubReserveTransferFee = config.assetHubReserveTransferFee;
+            // Initialize pricing storage
+            PricingStorage.Layout storage pricing = PricingStorage.layout();
+            pricing.exchangeRate = config.exchangeRate;
+            pricing.deliveryCost = config.deliveryCost;
+
+            // Initialize assets storage
+            AssetsStorage.Layout storage assets = AssetsStorage.layout();
+
+            assets.assetHubParaID = config.assetHubParaID;
+            assets.assetHubAgent = assetHubAgent;
+            assets.registerTokenFee = config.registerTokenFee;
+            assets.assetHubCreateAssetFee = config.assetHubCreateAssetFee;
+            assets.assetHubReserveTransferFee = config.assetHubReserveTransferFee;
+        }
     }
 }

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -483,6 +483,46 @@ contract GatewayTest is Test {
         assertEq(GatewayV2(address(gateway)).getValue(), 42);
     }
 
+    function testInitializerRunsOnlyOnce() public {
+        bytes32 agentID = keccak256("123");
+
+        testSetPricingParameters();
+        uint256 fee = IGateway(address(gateway)).quoteRegisterTokenFee();
+        assertEq(fee, 10000000000000000);
+
+        testCreateAgent();
+        assertNotEq(GatewayMock(address(gateway)).agentOf(agentID), address(0));
+
+        // Upgrade to this current logic contract
+        AgentExecutor executor = new AgentExecutor();
+        GatewayMock currentLogic =
+            new GatewayMock(address(0), address(executor), bridgeHubParaID, bridgeHubAgentID, foreignTokenDecimals);
+
+        Gateway.Config memory config = Gateway.Config({
+            mode: OperatingMode.Normal,
+            deliveryCost: outboundFee,
+            registerTokenFee: registerTokenFee,
+            assetHubParaID: assetHubParaID,
+            assetHubAgentID: assetHubAgentID,
+            assetHubCreateAssetFee: createTokenFee,
+            assetHubReserveTransferFee: sendTokenFee,
+            exchangeRate: exchangeRate
+        });
+        UpgradeParams memory params = UpgradeParams({
+            impl: address(currentLogic),
+            implCodeHash: address(currentLogic).codehash,
+            initParams: abi.encode(config)
+        });
+
+        // Expect the gateway to emit `Upgraded`
+        GatewayMock(address(gateway)).upgradePublic(abi.encode(params));
+
+        // Verify that storage was not overwritten
+        fee = IGateway(address(gateway)).quoteRegisterTokenFee();
+        assertEq(fee, 10000000000000000);
+        assertNotEq(GatewayMock(address(gateway)).agentOf(agentID), address(0));
+    }
+
     function testUpgradeGatewayMock() public {
         GatewayUpgradeMock newLogic = new GatewayUpgradeMock();
         uint256 d0 = 99;


### PR DESCRIPTION
The initialization code would run on every upgrade. This stops that behavior.
Resolves: SNO-870

Upgrades can now be done by:
1. Set the required parameters in the .envrc.
2. Deploy the gateway logic contract only.
```cmd
from_start_services=true sh -c "source ./scripts/deploy-contracts.sh && deploy_gateway_logic"
```
3. Run the Snowbridge control cli to create a pre-image: https://github.com/Snowfork/snowbridge/pull/1147
4. Run the opengov cli to create a proposal from pre-image: https://github.com/joepetrowski/opengov-cli