### PR TITLE
Refactor proxy with diamond pattern

### DIFF
--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 
 import {IERC20} from "./interfaces/IERC20.sol";
 import {IGateway} from "./interfaces/IGateway.sol";
+import {IGatewayOutbound} from "./interfaces/IGatewayOutbound.sol";
 
 import {SafeTokenTransferFrom} from "./utils/SafeTransfer.sol";
 
@@ -146,7 +147,7 @@ library Assets {
                 revert Unsupported();
             }
         }
-        emit IGateway.TokenSent(token, sender, destinationChain, destinationAddress, amount);
+        emit IGatewayOutbound.TokenSent(token, sender, destinationChain, destinationAddress, amount);
     }
 
     function registerTokenCosts() external view returns (Costs memory costs) {
@@ -182,7 +183,7 @@ library Assets {
         ticket.costs = _registerTokenCosts();
         ticket.payload = SubstrateTypes.RegisterToken(token, $.assetHubCreateAssetFee);
 
-        emit IGateway.TokenRegistrationSent(token);
+        emit IGatewayOutbound.TokenRegistrationSent(token);
     }
 
     // @dev Register a new fungible Polkadot token for an agent
@@ -195,7 +196,6 @@ library Assets {
             TokenInfo({isRegistered: true, isForeign: true, tokenID: tokenID, agentID: agentID, token: token});
         $.tokenRegistry[token] = info;
         $.tokenRegistryByID[tokenID] = info;
-        emit IGateway.TokenRegistered(tokenID, agentID, token);
     }
 
     // @dev Get token address by tokenID
@@ -258,7 +258,7 @@ library Assets {
             revert Unsupported();
         }
 
-        emit IGateway.TokenTransfered(token, sender, destinationChain, destinationAddress, amount);
+        emit IGatewayOutbound.TokenTransfered(token, sender, destinationChain, destinationAddress, amount);
     }
 
     function _burn(address agentExecutor, address agent, bytes32 tokenID, address sender, uint256 amount) internal {

--- a/contracts/src/DeployGatewayLogic.sol
+++ b/contracts/src/DeployGatewayLogic.sol
@@ -17,17 +17,7 @@ contract DeployGatewayLogic is Script {
         uint256 privateKey = vm.envUint("PRIVATE_KEY");
         address deployer = vm.rememberKey(privateKey);
         vm.startBroadcast(deployer);
-
-        address beefyClient = vm.envAddress("BEEFY_CLIENT_CONTRACT_ADDRESS");
-
-        ParaID bridgeHubParaID = ParaID.wrap(uint32(vm.envUint("BRIDGE_HUB_PARAID")));
-        bytes32 bridgeHubAgentID = vm.envBytes32("BRIDGE_HUB_AGENT_ID");
-
-        uint8 foreignTokenDecimals = uint8(vm.envUint("FOREIGN_TOKEN_DECIMALS"));
-
-        AgentExecutor executor = new AgentExecutor();
-        new Gateway(address(beefyClient), address(executor), bridgeHubParaID, bridgeHubAgentID, foreignTokenDecimals);
-
+        new Gateway();
         vm.stopBroadcast();
     }
 }

--- a/contracts/src/DeployScript.sol
+++ b/contracts/src/DeployScript.sol
@@ -60,9 +60,7 @@ contract DeployScript is Script {
         uint8 foreignTokenDecimals = uint8(vm.envUint("FOREIGN_TOKEN_DECIMALS"));
 
         AgentExecutor executor = new AgentExecutor();
-        Gateway gatewayLogic = new Gateway(
-            address(beefyClient), address(executor), bridgeHubParaID, bridgeHubAgentID, foreignTokenDecimals
-        );
+        Gateway gatewayLogic = new Gateway();
 
         bool rejectOutboundMessages = vm.envBool("REJECT_OUTBOUND_MESSAGES");
         OperatingMode defaultOperatingMode;
@@ -73,6 +71,11 @@ contract DeployScript is Script {
         }
 
         Gateway.Config memory config = Gateway.Config({
+            beefyClient: address(beefyClient),
+            agentExecutor: address(executor),
+            bridgeHubParaID: bridgeHubParaID,
+            bridgeHubAgentID: bridgeHubAgentID,
+            foreignTokenDecimals: foreignTokenDecimals,
             mode: defaultOperatingMode,
             deliveryCost: uint128(vm.envUint("DELIVERY_COST")),
             registerTokenFee: uint128(vm.envUint("REGISTER_TOKEN_FEE")),

--- a/contracts/src/DeployScript.sol
+++ b/contracts/src/DeployScript.sol
@@ -161,18 +161,24 @@ contract DeployScript is Script {
         // Deploy WETH for testing
         new WETH9();
 
+        new GatewayUpgradeMock();
+
+        _initialFund(address(gateway));
+
+        vm.stopBroadcast();
+    }
+
+    function _initialFund(address gateway) internal {
         // Fund the sovereign account for the BridgeHub parachain. Used to reward relayers
         // of messages originating from BridgeHub
         uint256 initialDeposit = vm.envUint("BRIDGE_HUB_INITIAL_DEPOSIT");
+        bytes32 bridgeHubAgentID = vm.envBytes32("BRIDGE_HUB_AGENT_ID");
+        bytes32 assetHubAgentID = vm.envBytes32("ASSET_HUB_AGENT_ID");
 
         address bridgeHubAgent = IGateway(address(gateway)).agentOf(bridgeHubAgentID);
         address assetHubAgent = IGateway(address(gateway)).agentOf(assetHubAgentID);
 
         payable(bridgeHubAgent).safeNativeTransfer(initialDeposit);
         payable(assetHubAgent).safeNativeTransfer(initialDeposit);
-
-        new GatewayUpgradeMock();
-
-        vm.stopBroadcast();
     }
 }

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -84,15 +84,6 @@ contract Gateway is IGateway, IInitializable {
         _;
     }
 
-    // handler functions are privileged from agent only
-    modifier onlyAgent(bytes32 agentID) {
-        bytes32 _agentID = _ensureAgentAddress(msg.sender);
-        if (_agentID != agentID) {
-            revert Unauthorized();
-        }
-        _;
-    }
-
     /// @dev Submit a message from Polkadot for verification and dispatch
     /// @param message A message produced by the OutboundQueue pallet on BridgeHub
     /// @param leafProof A message proof used to verify that the message is in the merkle tree committed by the OutboundQueue pallet
@@ -427,14 +418,6 @@ contract Gateway is IGateway, IInitializable {
     function _ensureAgent(bytes32 agentID) internal view returns (address agent) {
         agent = CoreStorage.layout().agents[agentID];
         if (agent == address(0)) {
-            revert AgentDoesNotExist();
-        }
-    }
-
-    /// @dev Ensure that the specified address is an valid agent
-    function _ensureAgentAddress(address agent) internal view returns (bytes32 agentID) {
-        agentID = CoreStorage.layout().agentAddresses[agent];
-        if (agentID == bytes32(0)) {
             revert AgentDoesNotExist();
         }
     }

--- a/contracts/src/GatewayOutbound.sol
+++ b/contracts/src/GatewayOutbound.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+pragma solidity 0.8.23;
+
+import {Assets} from "./Assets.sol";
+import {Agent} from "./Agent.sol";
+import {Channel, ChannelID, OperatingMode, ParaID, MultiAddress, Ticket, Costs, TokenInfo} from "./Types.sol";
+import {IGatewayOutbound} from "./interfaces/IGatewayOutbound.sol";
+import {IInitializable} from "./interfaces/IInitializable.sol";
+import {ERC1967} from "./utils/ERC1967.sol";
+import {Address} from "./utils/Address.sol";
+import {SafeNativeTransfer} from "./utils/SafeTransfer.sol";
+import {Call} from "./utils/Call.sol";
+import {Math} from "./utils/Math.sol";
+import {ScaleCodec} from "./utils/ScaleCodec.sol";
+
+import {CoreStorage} from "./storage/CoreStorage.sol";
+import {PricingStorage} from "./storage/PricingStorage.sol";
+
+import {UD60x18, ud60x18, convert} from "prb/math/src/UD60x18.sol";
+
+contract GatewayOutbound is IGatewayOutbound {
+    using Address for address;
+    using SafeNativeTransfer for address payable;
+
+    error Disabled();
+    error FeePaymentToLow();
+    error ChannelNotExist();
+
+    /**
+     * Assets
+     */
+    function isTokenRegistered(address token) external view returns (bool) {
+        return Assets.isTokenRegistered(token);
+    }
+
+    // Total fee for registering a token
+    function quoteRegisterTokenFee() external view returns (uint256) {
+        return _calculateFee(Assets.registerTokenCosts());
+    }
+
+    // Register an Ethereum-native token in the gateway and on AssetHub
+    function registerToken(address token) external payable {
+        _submitOutbound(Assets.registerToken(token));
+    }
+
+    // Total fee for sending a token
+    function quoteSendTokenFee(address token, ParaID destinationChain, uint128 destinationFee)
+        external
+        view
+        returns (uint256)
+    {
+        return _calculateFee(Assets.sendTokenCosts(token, destinationChain, destinationFee));
+    }
+
+    // Transfer ERC20 tokens to a Polkadot parachain
+    function sendToken(
+        address token,
+        ParaID destinationChain,
+        MultiAddress calldata destinationAddress,
+        uint128 destinationFee,
+        uint128 amount
+    ) external payable {
+        _submitOutbound(
+            Assets.sendToken(token, msg.sender, destinationChain, destinationAddress, destinationFee, amount)
+        );
+    }
+
+    // Transfer polkadot native tokens back
+    function transferToken(
+        address token,
+        ParaID destinationChain,
+        MultiAddress calldata destinationAddress,
+        uint128 destinationFee,
+        uint128 amount
+    ) external payable {
+        address executor = CoreStorage.layout().agentExecutor;
+        _submitOutbound(
+            Assets.transferToken(
+                executor, token, msg.sender, destinationChain, destinationAddress, destinationFee, amount
+            )
+        );
+    }
+
+    function getTokenInfo(bytes32 tokenID) external view returns (TokenInfo memory) {
+        return Assets.getTokenInfo(tokenID);
+    }
+
+    // Convert foreign currency to native currency (ROC/KSM/DOT -> ETH)
+    function _convertToNative(UD60x18 exchangeRate, UD60x18 multiplier, UD60x18 amount)
+        internal
+        view
+        returns (uint256)
+    {
+        uint8 foreignTokenDecimals = CoreStorage.layout().foreignTokenDecimals;
+        UD60x18 ethDecimals = convert(1e18);
+        UD60x18 foreignDecimals = convert(10).pow(convert(uint256(foreignTokenDecimals)));
+        UD60x18 nativeAmount = multiplier.mul(amount).mul(exchangeRate).div(foreignDecimals).mul(ethDecimals);
+        return convert(nativeAmount);
+    }
+
+    // Calculate the fee for accepting an outbound message
+    function _calculateFee(Costs memory costs) internal view returns (uint256) {
+        PricingStorage.Layout storage pricing = PricingStorage.layout();
+        UD60x18 amount = convert(pricing.deliveryCost + costs.foreign);
+        return costs.native + _convertToNative(pricing.exchangeRate, pricing.multiplier, amount);
+    }
+
+    // Submit an outbound message to Polkadot, after taking fees
+    function _submitOutbound(Ticket memory ticket) internal {
+        ChannelID channelID = ticket.dest.into();
+        Channel storage channel = __ensureChannel(channelID);
+
+        // Ensure outbound messaging is allowed
+        _ensureOutboundMessagingEnabled(channel);
+
+        uint256 fee = _calculateFee(ticket.costs);
+
+        // Ensure the user has enough funds for this message to be accepted
+        if (msg.value < fee) {
+            revert FeePaymentToLow();
+        }
+
+        channel.outboundNonce = channel.outboundNonce + 1;
+
+        // Deposit total fee into agent's contract
+        payable(channel.agent).safeNativeTransfer(fee);
+
+        // Reimburse excess fee payment
+        if (msg.value > fee) {
+            payable(msg.sender).safeNativeTransfer(msg.value - fee);
+        }
+
+        // Generate a unique ID for this message
+        bytes32 messageID = keccak256(abi.encodePacked(channelID, channel.outboundNonce));
+
+        emit IGatewayOutbound.OutboundMessageAccepted(channelID, channel.outboundNonce, messageID, ticket.payload);
+    }
+
+    /// @dev Outbound message can be disabled globally or on a per-channel basis.
+    function _ensureOutboundMessagingEnabled(Channel storage ch) internal view {
+        CoreStorage.Layout storage $ = CoreStorage.layout();
+        if ($.mode != OperatingMode.Normal || ch.mode != OperatingMode.Normal) {
+            revert Disabled();
+        }
+    }
+
+    function __ensureChannel(ChannelID channelID) internal view returns (Channel storage ch) {
+        ch = CoreStorage.layout().channels[channelID];
+        // A channel always has an agent specified.
+        if (ch.agent == address(0)) {
+            revert ChannelNotExist();
+        }
+    }
+}

--- a/contracts/src/GatewayOutbound.sol
+++ b/contracts/src/GatewayOutbound.sol
@@ -6,13 +6,7 @@ import {Assets} from "./Assets.sol";
 import {Agent} from "./Agent.sol";
 import {Channel, ChannelID, OperatingMode, ParaID, MultiAddress, Ticket, Costs, TokenInfo} from "./Types.sol";
 import {IGatewayOutbound} from "./interfaces/IGatewayOutbound.sol";
-import {IInitializable} from "./interfaces/IInitializable.sol";
-import {ERC1967} from "./utils/ERC1967.sol";
-import {Address} from "./utils/Address.sol";
 import {SafeNativeTransfer} from "./utils/SafeTransfer.sol";
-import {Call} from "./utils/Call.sol";
-import {Math} from "./utils/Math.sol";
-import {ScaleCodec} from "./utils/ScaleCodec.sol";
 
 import {CoreStorage} from "./storage/CoreStorage.sol";
 import {PricingStorage} from "./storage/PricingStorage.sol";
@@ -20,7 +14,6 @@ import {PricingStorage} from "./storage/PricingStorage.sol";
 import {UD60x18, ud60x18, convert} from "prb/math/src/UD60x18.sol";
 
 contract GatewayOutbound is IGatewayOutbound {
-    using Address for address;
     using SafeNativeTransfer for address payable;
 
     error Disabled();

--- a/contracts/src/GatewayOutbound.sol
+++ b/contracts/src/GatewayOutbound.sol
@@ -109,8 +109,10 @@ contract GatewayOutbound is IGatewayOutbound {
     // Submit an outbound message to Polkadot, after taking fees
     function _submitOutbound(Ticket memory ticket) internal {
         ChannelID channelID = ticket.dest.into();
-        Channel storage channel = __ensureChannel(channelID);
-
+        Channel storage channel = CoreStorage.layout().channels[channelID];
+        if (channel.agent == address(0)) {
+            revert ChannelNotExist();
+        }
         // Ensure outbound messaging is allowed
         _ensureOutboundMessagingEnabled(channel);
 
@@ -142,14 +144,6 @@ contract GatewayOutbound is IGatewayOutbound {
         CoreStorage.Layout storage $ = CoreStorage.layout();
         if ($.mode != OperatingMode.Normal || ch.mode != OperatingMode.Normal) {
             revert Disabled();
-        }
-    }
-
-    function __ensureChannel(ChannelID channelID) internal view returns (Channel storage ch) {
-        ch = CoreStorage.layout().channels[channelID];
-        // A channel always has an agent specified.
-        if (ch.agent == address(0)) {
-            revert ChannelNotExist();
         }
     }
 }

--- a/contracts/src/GatewayProxy.sol
+++ b/contracts/src/GatewayProxy.sol
@@ -10,6 +10,7 @@ contract GatewayProxy is IInitializable {
     error Unauthorized();
     error NativeCurrencyNotAccepted();
 
+    // Todo: construct the diamond for initialize, also need another function for update the diamond
     constructor(address implementation, bytes memory params) {
         // Store the address of the implementation contract
         ERC1967.store(implementation);
@@ -26,6 +27,7 @@ contract GatewayProxy is IInitializable {
     }
 
     fallback() external payable {
+        // Todo: load impl from the diamond
         address implementation = ERC1967.load();
         assembly {
             calldatacopy(0, 0, calldatasize())

--- a/contracts/src/Params.sol
+++ b/contracts/src/Params.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 
 import {ChannelID, OperatingMode} from "./Types.sol";
 import {UD60x18} from "prb/math/src/UD60x18.sol";
+import {DiamondStorage} from "./storage/DiamondStorage.sol";
 
 // Payload for AgentExecute
 struct AgentExecuteParams {
@@ -37,6 +38,8 @@ struct UpdateChannelParams {
 
 // Payload for Upgrade
 struct UpgradeParams {
+    /// @dev The facetCuts
+    DiamondStorage.FacetCut[] facetCuts;
     /// @dev The address of the implementation contract
     address impl;
     /// @dev the codehash of the new implementation contract.

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -15,9 +15,6 @@ interface IGateway {
     // Emitted when inbound message has been dispatched
     event InboundMessageDispatched(ChannelID indexed channelID, uint64 nonce, bytes32 indexed messageID, bool success);
 
-    // Emitted when an outbound message has been accepted for delivery to a Polkadot parachain
-    event OutboundMessageAccepted(ChannelID indexed channelID, uint64 nonce, bytes32 indexed messageID, bytes payload);
-
     // Emitted when an agent has been created for a consensus system on Polkadot
     event AgentCreated(bytes32 agentID, address agent);
 
@@ -39,8 +36,8 @@ interface IGateway {
     // Emitted when funds are withdrawn from an agent
     event AgentFundsWithdrawn(bytes32 indexed agentID, address indexed recipient, uint256 amount);
 
-    // Emitted when token registed
-    event TokenRegistered(bytes32 indexed tokenID, bytes32 agentID, address token);
+    // Emitted when foreign token registed
+    event ForeignTokenRegistered(bytes32 indexed tokenID, bytes32 agentID, address token);
 
     /**
      * Getters
@@ -69,65 +66,4 @@ interface IGateway {
 
     // @dev Emitted when the fees updated
     event TokenTransferFeesChanged();
-
-    /// @dev Emitted once the funds are locked and an outbound message is successfully queued.
-    event TokenSent(
-        address indexed token,
-        address indexed sender,
-        ParaID indexed destinationChain,
-        MultiAddress destinationAddress,
-        uint128 amount
-    );
-
-    /// @dev Emitted when a command is sent to register a new wrapped token on AssetHub
-    event TokenRegistrationSent(address token);
-
-    /// @dev Check whether a token is registered
-    function isTokenRegistered(address token) external view returns (bool);
-
-    /// @dev Quote a fee in Ether for registering a token, covering
-    /// 1. Delivery costs to BridgeHub
-    /// 2. XCM Execution costs on AssetHub
-    function quoteRegisterTokenFee() external view returns (uint256);
-
-    /// @dev Register an ERC20 token and create a wrapped derivative on AssetHub in the `ForeignAssets` pallet.
-    function registerToken(address token) external payable;
-
-    /// @dev Quote a fee in Ether for sending a token
-    /// 1. Delivery costs to BridgeHub
-    /// 2. XCM execution costs on destinationChain
-    function quoteSendTokenFee(address token, ParaID destinationChain, uint128 destinationFee)
-        external
-        view
-        returns (uint256);
-
-    /// @dev Send ERC20 tokens to parachain `destinationChain` and deposit into account `destinationAddress`
-    function sendToken(
-        address token,
-        ParaID destinationChain,
-        MultiAddress calldata destinationAddress,
-        uint128 destinationFee,
-        uint128 amount
-    ) external payable;
-
-    /// @dev Transfer polkadot native tokens back
-    function transferToken(
-        address token,
-        ParaID destinationChain,
-        MultiAddress calldata destinationAddress,
-        uint128 destinationFee,
-        uint128 amount
-    ) external payable;
-
-    /// @dev Get tokenInfo by tokenID
-    function getTokenInfo(bytes32 tokenID) external view returns (TokenInfo memory);
-
-    /// @dev Emitted once the polkadot native tokens are burnt and an outbound message is successfully queued.
-    event TokenTransfered(
-        address indexed token,
-        address indexed sender,
-        ParaID indexed destinationChain,
-        MultiAddress destinationAddress,
-        uint128 amount
-    );
 }

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -47,7 +47,6 @@ interface IGateway {
     function channelNoncesOf(ChannelID channelID) external view returns (uint64, uint64);
     function agentOf(bytes32 agentID) external view returns (address);
     function pricingParameters() external view returns (UD60x18, uint128);
-    function implementation() external view returns (address);
 
     /**
      * Messaging

--- a/contracts/src/interfaces/IGatewayOutbound.sol
+++ b/contracts/src/interfaces/IGatewayOutbound.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+pragma solidity 0.8.23;
+
+import {OperatingMode, InboundMessage, ParaID, ChannelID, MultiAddress} from "../Types.sol";
+import {UD60x18} from "prb/math/src/UD60x18.sol";
+import {TokenInfo} from "../storage/AssetsStorage.sol";
+
+interface IGatewayOutbound {
+    // Emitted when an outbound message has been accepted for delivery to a Polkadot parachain
+    event OutboundMessageAccepted(ChannelID indexed channelID, uint64 nonce, bytes32 indexed messageID, bytes payload);
+
+    /// @dev Emitted once the funds are locked and an outbound message is successfully queued.
+    event TokenSent(
+        address indexed token,
+        address indexed sender,
+        ParaID indexed destinationChain,
+        MultiAddress destinationAddress,
+        uint128 amount
+    );
+
+    /// @dev Emitted when a command is sent to register a new wrapped token on AssetHub
+    event TokenRegistrationSent(address token);
+
+    /// @dev Check whether a token is registered
+    function isTokenRegistered(address token) external view returns (bool);
+
+    /// @dev Quote a fee in Ether for registering a token, covering
+    /// 1. Delivery costs to BridgeHub
+    /// 2. XCM Execution costs on AssetHub
+    function quoteRegisterTokenFee() external view returns (uint256);
+
+    /// @dev Register an ERC20 token and create a wrapped derivative on AssetHub in the `ForeignAssets` pallet.
+    function registerToken(address token) external payable;
+
+    /// @dev Quote a fee in Ether for sending a token
+    /// 1. Delivery costs to BridgeHub
+    /// 2. XCM execution costs on destinationChain
+    function quoteSendTokenFee(address token, ParaID destinationChain, uint128 destinationFee)
+        external
+        view
+        returns (uint256);
+
+    /// @dev Send ERC20 tokens to parachain `destinationChain` and deposit into account `destinationAddress`
+    function sendToken(
+        address token,
+        ParaID destinationChain,
+        MultiAddress calldata destinationAddress,
+        uint128 destinationFee,
+        uint128 amount
+    ) external payable;
+
+    /// @dev Transfer polkadot native tokens back
+    function transferToken(
+        address token,
+        ParaID destinationChain,
+        MultiAddress calldata destinationAddress,
+        uint128 destinationFee,
+        uint128 amount
+    ) external payable;
+
+    /// @dev Get tokenInfo by tokenID
+    function getTokenInfo(bytes32 tokenID) external view returns (TokenInfo memory);
+
+    /// @dev Emitted once the polkadot native tokens are burnt and an outbound message is successfully queued.
+    event TokenTransfered(
+        address indexed token,
+        address indexed sender,
+        ParaID indexed destinationChain,
+        MultiAddress destinationAddress,
+        uint128 amount
+    );
+}

--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -14,6 +14,17 @@ library CoreStorage {
         mapping(bytes32 agentID => address) agents;
         // Agent addresses
         mapping(address agent => bytes32 agentID) agentAddresses;
+        /// The beefy client
+        address beefyClient;
+        /// The agent executor
+        address agentExecutor;
+        /// The bridgehub ParaID
+        ParaID bridgeHubParaID;
+        bytes4 bridgeHubParaIDEncoded;
+        /// The bridgehub agentID
+        bytes32 bridgeHubAgentID;
+        /// The decimals of relaychain token
+        uint8 foreignTokenDecimals;
     }
 
     bytes32 internal constant SLOT = keccak256("org.snowbridge.storage.core");

--- a/contracts/src/storage/DiamondStorage.sol
+++ b/contracts/src/storage/DiamondStorage.sol
@@ -15,6 +15,11 @@ library DiamondStorage {
         bytes4[] functionSelectors;
     }
 
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
     struct FacetAddressAndPosition {
         address facetAddress;
         uint16 functionSelectorPosition; // position in facetFunctionSelectors.functionSelectors array
@@ -182,5 +187,40 @@ library DiamondStorage {
             contractSize := extcodesize(_contract)
         }
         require(contractSize > 0, _errorMessage);
+    }
+
+    function facets() external view returns (Facet[] memory facets_) {
+        Layout storage ds = layout();
+        uint256 numFacets = ds.facetAddresses.length;
+        facets_ = new Facet[](numFacets);
+        for (uint256 i; i < numFacets; i++) {
+            address facetAddress_ = ds.facetAddresses[i];
+            facets_[i].facetAddress = facetAddress_;
+            facets_[i].functionSelectors = ds.facetFunctionSelectors[facetAddress_].functionSelectors;
+        }
+    }
+
+    /// @notice Gets all the function selectors provided by a facet.
+    /// @param _facet The facet address.
+    /// @return facetFunctionSelectors_
+    function facetFunctionSelectors(address _facet) external view returns (bytes4[] memory facetFunctionSelectors_) {
+        Layout storage ds = layout();
+        facetFunctionSelectors_ = ds.facetFunctionSelectors[_facet].functionSelectors;
+    }
+
+    /// @notice Get all the facet addresses used by a diamond.
+    /// @return facetAddresses_
+    function facetAddresses() external view returns (address[] memory facetAddresses_) {
+        Layout storage ds = layout();
+        facetAddresses_ = ds.facetAddresses;
+    }
+
+    /// @notice Gets the facet that supports the given selector.
+    /// @dev If facet is not found return address(0).
+    /// @param _functionSelector The function selector.
+    /// @return facetAddress_ The facet address.
+    function facetAddress(bytes4 _functionSelector) external view returns (address facetAddress_) {
+        Layout storage ds = layout();
+        facetAddress_ = ds.selectorToFacetAndPosition[_functionSelector].facetAddress;
     }
 }

--- a/contracts/src/storage/DiamondStorage.sol
+++ b/contracts/src/storage/DiamondStorage.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
+pragma solidity 0.8.23;
+
+library DiamondStorage {
+    enum FacetCutAction {
+        Add,
+        Replace,
+        Remove
+    }
+
+    struct FacetCut {
+        address facetAddress;
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    struct FacetAddressAndPosition {
+        address facetAddress;
+        uint16 functionSelectorPosition; // position in facetFunctionSelectors.functionSelectors array
+    }
+
+    struct FacetFunctionSelectors {
+        bytes4[] functionSelectors;
+        uint16 facetAddressPosition; // position of facetAddress in facetAddresses array
+    }
+
+    struct Layout {
+        // maps function selector to the facet address and
+        // the position of the selector in the facetFunctionSelectors.selectors array
+        mapping(bytes4 => FacetAddressAndPosition) selectorToFacetAndPosition;
+        // maps facet addresses to function selectors
+        mapping(address => FacetFunctionSelectors) facetFunctionSelectors;
+        // facet addresses
+        address[] facetAddresses;
+    }
+
+    bytes32 internal constant SLOT = keccak256("org.snowbridge.storage.diamond");
+
+    function layout() internal pure returns (Layout storage $) {
+        bytes32 slot = SLOT;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    event DiamondCut(FacetCut[] _diamondCut, address _init, bytes _calldata);
+
+    // Internal function version of diamondCut
+    function diamondCut(FacetCut[] memory _diamondCut, address _init, bytes memory _calldata) internal {
+        for (uint256 facetIndex; facetIndex < _diamondCut.length; facetIndex++) {
+            FacetCutAction action = _diamondCut[facetIndex].action;
+            if (action == FacetCutAction.Add) {
+                addFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else if (action == FacetCutAction.Replace) {
+                replaceFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else if (action == FacetCutAction.Remove) {
+                removeFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else {
+                revert("LibDiamondCut: Incorrect FacetCutAction");
+            }
+        }
+        emit DiamondCut(_diamondCut, _init, _calldata);
+        initializeDiamondCut(_init, _calldata);
+    }
+
+    function addFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamondCut: No selectors in facet to cut");
+        Layout storage ds = layout();
+        // uint16 selectorCount = uint16(diamondStorage().selectors.length);
+        require(_facetAddress != address(0), "LibDiamondCut: Add facet can't be address(0)");
+        uint16 selectorPosition = uint16(ds.facetFunctionSelectors[_facetAddress].functionSelectors.length);
+        // add new facet address if it does not exist
+        if (selectorPosition == 0) {
+            enforceHasContractCode(_facetAddress, "LibDiamondCut: New facet has no code");
+            ds.facetFunctionSelectors[_facetAddress].facetAddressPosition = uint16(ds.facetAddresses.length);
+            ds.facetAddresses.push(_facetAddress);
+        }
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            require(oldFacetAddress == address(0), "LibDiamondCut: Can't add function that already exists");
+            ds.facetFunctionSelectors[_facetAddress].functionSelectors.push(selector);
+            ds.selectorToFacetAndPosition[selector].facetAddress = _facetAddress;
+            ds.selectorToFacetAndPosition[selector].functionSelectorPosition = selectorPosition;
+            selectorPosition++;
+        }
+    }
+
+    function replaceFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamondCut: No selectors in facet to cut");
+        Layout storage ds = layout();
+        require(_facetAddress != address(0), "LibDiamondCut: Add facet can't be address(0)");
+        uint16 selectorPosition = uint16(ds.facetFunctionSelectors[_facetAddress].functionSelectors.length);
+        // add new facet address if it does not exist
+        if (selectorPosition == 0) {
+            enforceHasContractCode(_facetAddress, "LibDiamondCut: New facet has no code");
+            ds.facetFunctionSelectors[_facetAddress].facetAddressPosition = uint16(ds.facetAddresses.length);
+            ds.facetAddresses.push(_facetAddress);
+        }
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            require(oldFacetAddress != _facetAddress, "LibDiamondCut: Can't replace function with same function");
+            removeFunction(oldFacetAddress, selector);
+            // add function
+            ds.selectorToFacetAndPosition[selector].functionSelectorPosition = selectorPosition;
+            ds.facetFunctionSelectors[_facetAddress].functionSelectors.push(selector);
+            ds.selectorToFacetAndPosition[selector].facetAddress = _facetAddress;
+            selectorPosition++;
+        }
+    }
+
+    function removeFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamondCut: No selectors in facet to cut");
+        Layout storage ds = layout();
+        // if function does not exist then do nothing and return
+        require(_facetAddress == address(0), "LibDiamondCut: Remove facet address must be address(0)");
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            removeFunction(oldFacetAddress, selector);
+        }
+    }
+
+    function removeFunction(address _facetAddress, bytes4 _selector) internal {
+        Layout storage ds = layout();
+        require(_facetAddress != address(0), "LibDiamondCut: Can't remove function that doesn't exist");
+        // an immutable function is a function defined directly in a diamond
+        require(_facetAddress != address(this), "LibDiamondCut: Can't remove immutable function");
+        // replace selector with last selector, then delete last selector
+        uint256 selectorPosition = ds.selectorToFacetAndPosition[_selector].functionSelectorPosition;
+        uint256 lastSelectorPosition = ds.facetFunctionSelectors[_facetAddress].functionSelectors.length - 1;
+        // if not the same then replace _selector with lastSelector
+        if (selectorPosition != lastSelectorPosition) {
+            bytes4 lastSelector = ds.facetFunctionSelectors[_facetAddress].functionSelectors[lastSelectorPosition];
+            ds.facetFunctionSelectors[_facetAddress].functionSelectors[selectorPosition] = lastSelector;
+            ds.selectorToFacetAndPosition[lastSelector].functionSelectorPosition = uint16(selectorPosition);
+        }
+        // delete the last selector
+        ds.facetFunctionSelectors[_facetAddress].functionSelectors.pop();
+        delete ds.selectorToFacetAndPosition[_selector];
+
+        // if no more selectors for facet address then delete the facet address
+        if (lastSelectorPosition == 0) {
+            // replace facet address with last facet address and delete last facet address
+            uint256 lastFacetAddressPosition = ds.facetAddresses.length - 1;
+            uint256 facetAddressPosition = ds.facetFunctionSelectors[_facetAddress].facetAddressPosition;
+            if (facetAddressPosition != lastFacetAddressPosition) {
+                address lastFacetAddress = ds.facetAddresses[lastFacetAddressPosition];
+                ds.facetAddresses[facetAddressPosition] = lastFacetAddress;
+                ds.facetFunctionSelectors[lastFacetAddress].facetAddressPosition = uint16(facetAddressPosition);
+            }
+            ds.facetAddresses.pop();
+            delete ds.facetFunctionSelectors[_facetAddress].facetAddressPosition;
+        }
+    }
+
+    function initializeDiamondCut(address _init, bytes memory _calldata) internal {
+        if (_init == address(0)) {
+            require(_calldata.length == 0, "LibDiamondCut: _init is address(0) but_calldata is not empty");
+        } else {
+            require(_calldata.length > 0, "LibDiamondCut: _calldata is empty but _init is not address(0)");
+            if (_init != address(this)) {
+                enforceHasContractCode(_init, "LibDiamondCut: _init address has no code");
+            }
+            (bool success, bytes memory error) = _init.delegatecall(_calldata);
+            if (!success) {
+                if (error.length > 0) {
+                    // bubble up the error
+                    revert(string(error));
+                } else {
+                    revert("LibDiamondCut: _init function reverted");
+                }
+            }
+        }
+    }
+
+    function enforceHasContractCode(address _contract, string memory _errorMessage) internal view {
+        uint256 contractSize;
+        assembly {
+            contractSize := extcodesize(_contract)
+        }
+        require(contractSize > 0, _errorMessage);
+    }
+}

--- a/contracts/src/storage/DiamondStorage.sol
+++ b/contracts/src/storage/DiamondStorage.sol
@@ -15,11 +15,6 @@ library DiamondStorage {
         bytes4[] functionSelectors;
     }
 
-    struct Facet {
-        address facetAddress;
-        bytes4[] functionSelectors;
-    }
-
     struct FacetAddressAndPosition {
         address facetAddress;
         uint16 functionSelectorPosition; // position in facetFunctionSelectors.functionSelectors array
@@ -187,17 +182,6 @@ library DiamondStorage {
             contractSize := extcodesize(_contract)
         }
         require(contractSize > 0, _errorMessage);
-    }
-
-    function facets() external view returns (Facet[] memory facets_) {
-        Layout storage ds = layout();
-        uint256 numFacets = ds.facetAddresses.length;
-        facets_ = new Facet[](numFacets);
-        for (uint256 i; i < numFacets; i++) {
-            address facetAddress_ = ds.facetAddresses[i];
-            facets_[i].facetAddress = facetAddress_;
-            facets_[i].functionSelectors = ds.facetFunctionSelectors[facetAddress_].functionSelectors;
-        }
     }
 
     /// @notice Gets all the function selectors provided by a facet.

--- a/contracts/src/upgrades/rococo/GatewayV2.sol
+++ b/contracts/src/upgrades/rococo/GatewayV2.sol
@@ -9,11 +9,6 @@ import {PricingStorage} from "../../storage/PricingStorage.sol";
 
 contract GatewayV2 is Gateway {
     function initialize(bytes memory data) external override {
-        // Prevent initialization of storage in implementation contract
-        if (ERC1967.load() == address(0)) {
-            revert Unauthorized();
-        }
-
         PricingStorage.Layout storage pricing = PricingStorage.layout();
 
         if (pricing.multiplier != convert(0)) {

--- a/contracts/src/upgrades/rococo/GatewayV2.sol
+++ b/contracts/src/upgrades/rococo/GatewayV2.sol
@@ -8,14 +8,6 @@ import {UD60x18, convert} from "prb/math/src/UD60x18.sol";
 import {PricingStorage} from "../../storage/PricingStorage.sol";
 
 contract GatewayV2 is Gateway {
-    constructor(
-        address beefyClient,
-        address agentExecutor,
-        ParaID bridgeHubParaID,
-        bytes32 bridgeHubAgentID,
-        uint8 foreignTokenDecimals
-    ) Gateway(beefyClient, agentExecutor, bridgeHubParaID, bridgeHubAgentID, foreignTokenDecimals) {}
-
     function initialize(bytes memory data) external override {
         // Prevent initialization of storage in implementation contract
         if (ERC1967.load() == address(0)) {

--- a/contracts/test/mocks/GatewayMock.sol
+++ b/contracts/test/mocks/GatewayMock.sol
@@ -2,22 +2,15 @@
 pragma solidity 0.8.23;
 
 import {Gateway} from "../../src/Gateway.sol";
+import {GatewayOutbound} from "../../src/GatewayOutbound.sol";
 import {ParaID, OperatingMode} from "../../src/Types.sol";
 import {CoreStorage} from "../../src/storage/CoreStorage.sol";
 import {Verification} from "../../src/Verification.sol";
 
 import {UD60x18} from "prb/math/src/UD60x18.sol";
 
-contract GatewayMock is Gateway {
+contract GatewayMock is Gateway, GatewayOutbound {
     bool public commitmentsAreVerified;
-
-    constructor(
-        address beefyClient,
-        address agentExecutor,
-        ParaID bridgeHubParaID,
-        bytes32 bridgeHubHubAgentID,
-        uint8 foreignTokenDecimals
-    ) Gateway(beefyClient, agentExecutor, bridgeHubParaID, bridgeHubHubAgentID, foreignTokenDecimals) {}
 
     function agentExecutePublic(bytes calldata params) external {
         this.agentExecute(params);
@@ -51,18 +44,8 @@ contract GatewayMock is Gateway {
         commitmentsAreVerified = value;
     }
 
-    function _verifyCommitment(bytes32 commitment, Verification.Proof calldata proof)
-        internal
-        view
-        override
-        returns (bool)
-    {
-        if (BEEFY_CLIENT != address(0)) {
-            return super._verifyCommitment(commitment, proof);
-        } else {
-            // for unit tests, verification is set with commitmentsAreVerified
-            return commitmentsAreVerified;
-        }
+    function _verifyCommitment(bytes32, Verification.Proof calldata) internal view override returns (bool) {
+        return commitmentsAreVerified;
     }
 
     function setTokenTransferFeesPublic(bytes calldata params) external {


### PR DESCRIPTION
### Context

When implementing transfer polkadot assets it seems the `Gateway` code size exceeds 24576 bytes.

| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| Gateway               | 24.759    | -0.183      |
|...  |...  |...

Considering more features(e.g. Transacts) will be added soon, a single Gateway with all interfaces may not be ideal. So in this PR we change the proxy pattern from the previous EIP-1967 to [EIP-2535](https://eips.ethereum.org/EIPS/eip-2535)(the diamond way) and split outbound interfaces to a separate contract(facet).

Though it solves the issue of the contract size limit it's not perfect, it costs more gas and is more complicated.