### PR TITLE
Use v4 by default in local e2e testnet

### DIFF
--- a/web/packages/test/scripts/configure-substrate.sh
+++ b/web/packages/test/scripts/configure-substrate.sh
@@ -81,7 +81,7 @@ set_gateway() {
 }
 
 config_xcm_version() {
-    local call="0x1f04020109079edaa80203000000"
+    local call="0x1f04020109079edaa80204000000"
     send_governance_transact_from_relaychain $ASSET_HUB_PARAID "$call"
 }
 


### PR DESCRIPTION

Run tests and they pass.
```
(cd smoketest \
  && cargo test --no-run \
  && cargo test register_token -- --nocapture \
  && cargo test send_token -- --nocapture \
  && cargo test transfer_token -- --nocapture \
  && cargo test send_token_to_penpal -- --nocapture \
  && cargo test set_pricing_params -- --nocapture \
  && cargo test set_token_transfer_fees -- --nocapture \
  && cargo test upgrade_gateway -- --nocapture)
```
Used this change set on `polkadot-sdk` to make `send_token_to_penpal` pass.
```diff
--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -273,7 +273,7 @@ parameter_types! {
        /// by configuring the trusted asset from the `SystemAssetHub`.
        ///
        /// By default, it is configured as a `SystemAssetHubLocation` and can be modified using `System::set_storage`.
-       pub storage CustomizableAssetFromSystemAssetHub: Location = SystemAssetHubLocation::get();
+       pub storage CustomizableAssetFromSystemAssetHub: Location = (Parent, Parent).into();
 }
```