### PR TITLE
Separate endpoint for beacon state

### DIFF
--- a/relayer/cmd/generate_beacon_data.go
+++ b/relayer/cmd/generate_beacon_data.go
@@ -40,7 +40,7 @@ func generateBeaconFixtureCmd() *cobra.Command {
 		RunE:  generateBeaconTestFixture,
 	}
 
-	cmd.Flags().String("config", "", "Path to the beacon relay config")
+	cmd.Flags().String("config", "/tmp/snowbridge/beacon-relay.json", "Path to the beacon relay config")
 	cmd.Flags().Bool("wait_until_next_period", true, "Waiting until next period")
 	cmd.Flags().Uint32("nonce", 1, "Nonce of the inbound message")
 	return cmd
@@ -54,7 +54,7 @@ func generateBeaconCheckpointCmd() *cobra.Command {
 		RunE:  generateBeaconCheckpoint,
 	}
 
-	cmd.Flags().String("config", "", "Path to the beacon relay config")
+	cmd.Flags().String("config", "/tmp/snowbridge/beacon-relay.json", "Path to the beacon relay config")
 	cmd.Flags().Bool("export-json", false, "Export Json")
 
 	return cmd
@@ -68,7 +68,7 @@ func generateExecutionUpdateCmd() *cobra.Command {
 		RunE:  generateExecutionUpdate,
 	}
 
-	cmd.Flags().String("config", "", "Path to the beacon relay config")
+	cmd.Flags().String("config", "/tmp/snowbridge/beacon-relay.json", "Path to the beacon relay config")
 	cmd.Flags().Uint32("slot", 1, "slot number")
 	return cmd
 }
@@ -81,8 +81,8 @@ func generateInboundFixtureCmd() *cobra.Command {
 		RunE:  generateInboundFixture,
 	}
 
-	cmd.Flags().String("beacon-config", "", "Path to the beacon relay config")
-	cmd.Flags().String("execution-config", "", "Path to the beacon relay config")
+	cmd.Flags().String("beacon-config", "/tmp/snowbridge/beacon-relay.json", "Path to the beacon relay config")
+	cmd.Flags().String("execution-config", "/tmp/snowbridge/execution-relay-asset-hub.json", "Path to the beacon relay config")
 	cmd.Flags().Uint32("nonce", 1, "Nonce of the inbound message")
 	cmd.Flags().String("test_case", "register_token", "Inbound test case")
 	return cmd

--- a/relayer/cmd/generate_beacon_data.go
+++ b/relayer/cmd/generate_beacon_data.go
@@ -40,7 +40,7 @@ func generateBeaconFixtureCmd() *cobra.Command {
 		RunE:  generateBeaconTestFixture,
 	}
 
-	cmd.Flags().String("url", "http://127.0.0.1:9596", "Beacon URL")
+	cmd.Flags().String("config", "", "Path to the beacon relay config")
 	cmd.Flags().Bool("wait_until_next_period", true, "Waiting until next period")
 	cmd.Flags().Uint32("nonce", 1, "Nonce of the inbound message")
 	return cmd
@@ -54,7 +54,7 @@ func generateBeaconCheckpointCmd() *cobra.Command {
 		RunE:  generateBeaconCheckpoint,
 	}
 
-	cmd.Flags().String("url", "http://127.0.0.1:9596", "Beacon URL")
+	cmd.Flags().String("config", "", "Path to the beacon relay config")
 	cmd.Flags().Bool("export-json", false, "Export Json")
 
 	return cmd
@@ -68,7 +68,7 @@ func generateExecutionUpdateCmd() *cobra.Command {
 		RunE:  generateExecutionUpdate,
 	}
 
-	cmd.Flags().String("url", "http://127.0.0.1:9596", "Beacon URL")
+	cmd.Flags().String("config", "", "Path to the beacon relay config")
 	cmd.Flags().Uint32("slot", 1, "slot number")
 	return cmd
 }
@@ -81,7 +81,8 @@ func generateInboundFixtureCmd() *cobra.Command {
 		RunE:  generateInboundFixture,
 	}
 
-	cmd.Flags().String("url", "http://127.0.0.1:9596", "Beacon URL")
+	cmd.Flags().String("beacon-config", "", "Path to the beacon relay config")
+	cmd.Flags().String("execution-config", "", "Path to the beacon relay config")
 	cmd.Flags().Uint32("nonce", 1, "Nonce of the inbound message")
 	cmd.Flags().String("test_case", "register_token", "Inbound test case")
 	return cmd
@@ -112,12 +113,12 @@ const (
 // Only print the hex encoded call as output of this command
 func generateBeaconCheckpoint(cmd *cobra.Command, _ []string) error {
 	err := func() error {
-		endpoint, err := cmd.Flags().GetString("url")
+		config, err := cmd.Flags().GetString("config")
 		if err != nil {
 			return err
 		}
 
-		viper.SetConfigFile("web/packages/test/config/beacon-relay.json")
+		viper.SetConfigFile(config)
 
 		if err := viper.ReadInConfig(); err != nil {
 			return err
@@ -134,7 +135,7 @@ func generateBeaconCheckpoint(cmd *cobra.Command, _ []string) error {
 		store.Connect()
 		defer store.Close()
 
-		client := api.NewBeaconClient(endpoint)
+		client := api.NewBeaconClient(conf.Source.Beacon.Endpoint, conf.Source.Beacon.StateEndpoint)
 		s := syncer.New(client, &store, p)
 
 		checkPointScale, err := s.GetCheckpoint()
@@ -168,12 +169,12 @@ func generateBeaconTestFixture(cmd *cobra.Command, _ []string) error {
 	err := func() error {
 		ctx := context.Background()
 
-		endpoint, err := cmd.Flags().GetString("url")
+		config, err := cmd.Flags().GetString("config")
 		if err != nil {
 			return err
 		}
 
-		viper.SetConfigFile("/tmp/snowbridge/beacon-relay.json")
+		viper.SetConfigFile(config)
 		if err = viper.ReadInConfig(); err != nil {
 			return err
 		}
@@ -187,11 +188,14 @@ func generateBeaconTestFixture(cmd *cobra.Command, _ []string) error {
 		p := protocol.New(conf.Source.Beacon.Spec)
 
 		store := store.New(conf.Source.Beacon.DataStore.Location, conf.Source.Beacon.DataStore.MaxEntries, *p)
-		store.Connect()
+		err = store.Connect()
+		if err != nil {
+			return err
+		}
 		defer store.Close()
 
-		log.WithFields(log.Fields{"endpoint": endpoint}).Info("connecting to beacon API")
-		client := api.NewBeaconClient(endpoint)
+		log.WithFields(log.Fields{"endpoint": conf.Source.Beacon.Endpoint}).Info("connecting to beacon API")
+		client := api.NewBeaconClient(conf.Source.Beacon.Endpoint, conf.Source.Beacon.StateEndpoint)
 		s := syncer.New(client, &store, p)
 
 		viper.SetConfigFile("/tmp/snowbridge/execution-relay-asset-hub.json")
@@ -472,19 +476,25 @@ func writeRawDataFile(path string, fileContents string) error {
 
 func generateExecutionUpdate(cmd *cobra.Command, _ []string) error {
 	err := func() error {
-		endpoint, _ := cmd.Flags().GetString("url")
-		beaconSlot, _ := cmd.Flags().GetUint32("slot")
+		config, err := cmd.Flags().GetString("config")
+		if err != nil {
+			return err
+		}
+		beaconSlot, err := cmd.Flags().GetUint32("slot")
+		if err != nil {
+			return err
+		}
 
-		viper.SetConfigFile("web/packages/test/config/beacon-relay.json")
+		viper.SetConfigFile(config)
 		if err := viper.ReadInConfig(); err != nil {
 			return err
 		}
 		var conf beaconConf.Config
-		err := viper.Unmarshal(&conf)
+		err = viper.Unmarshal(&conf)
 		if err != nil {
 			return err
 		}
-		log.WithFields(log.Fields{"endpoint": endpoint}).Info("connecting to beacon API")
+		log.WithFields(log.Fields{"endpoint": conf.Source.Beacon.Endpoint}).Info("connecting to beacon API")
 
 		p := protocol.New(conf.Source.Beacon.Spec)
 
@@ -493,7 +503,7 @@ func generateExecutionUpdate(cmd *cobra.Command, _ []string) error {
 		defer store.Close()
 
 		// generate executionUpdate
-		client := api.NewBeaconClient(endpoint)
+		client := api.NewBeaconClient(conf.Source.Beacon.Endpoint, conf.Source.Beacon.StateEndpoint)
 		s := syncer.New(client, &store, p)
 		blockRoot, err := s.Client.GetBeaconBlockRoot(uint64(beaconSlot))
 		if err != nil {
@@ -656,45 +666,50 @@ func generateInboundFixture(cmd *cobra.Command, _ []string) error {
 	err := func() error {
 		ctx := context.Background()
 
-		endpoint, err := cmd.Flags().GetString("url")
+		beaconConfig, err := cmd.Flags().GetString("beacon-config")
 		if err != nil {
 			return err
 		}
 
-		viper.SetConfigFile("/tmp/snowbridge/beacon-relay.json")
+		executionConfig, err := cmd.Flags().GetString("execution-config")
+		if err != nil {
+			return err
+		}
+
+		viper.SetConfigFile(beaconConfig)
 		if err = viper.ReadInConfig(); err != nil {
 			return err
 		}
 
-		var conf beaconConf.Config
-		err = viper.Unmarshal(&conf)
+		var beaconConf beaconConf.Config
+		err = viper.Unmarshal(&beaconConf)
 		if err != nil {
 			return err
 		}
 
-		p := protocol.New(conf.Source.Beacon.Spec)
+		p := protocol.New(beaconConf.Source.Beacon.Spec)
 
-		store := store.New(conf.Source.Beacon.DataStore.Location, conf.Source.Beacon.DataStore.MaxEntries, *p)
+		store := store.New(beaconConf.Source.Beacon.DataStore.Location, beaconConf.Source.Beacon.DataStore.MaxEntries, *p)
 		store.Connect()
 		defer store.Close()
 
-		log.WithFields(log.Fields{"endpoint": endpoint}).Info("connecting to beacon API")
-		client := api.NewBeaconClient(endpoint)
+		log.WithFields(log.Fields{"endpoint": beaconConf.Source.Beacon.Endpoint}).Info("connecting to beacon API")
+		client := api.NewBeaconClient(beaconConf.Source.Beacon.Endpoint, beaconConf.Source.Beacon.StateEndpoint)
 		s := syncer.New(client, &store, p)
 
-		viper.SetConfigFile("/tmp/snowbridge/execution-relay-asset-hub.json")
+		viper.SetConfigFile(executionConfig)
 
 		if err = viper.ReadInConfig(); err != nil {
 			return err
 		}
 
-		var executionConfig executionConf.Config
-		err = viper.Unmarshal(&executionConfig, viper.DecodeHook(execution.HexHookFunc()))
+		var executionConf executionConf.Config
+		err = viper.Unmarshal(&executionConf, viper.DecodeHook(execution.HexHookFunc()))
 		if err != nil {
 			return fmt.Errorf("unable to parse execution relay config: %w", err)
 		}
 
-		ethconn := ethereum.NewConnection(&executionConfig.Source.Ethereum, nil)
+		ethconn := ethereum.NewConnection(&executionConf.Source.Ethereum, nil)
 		err = ethconn.Connect(ctx)
 		if err != nil {
 			return err
@@ -708,8 +723,8 @@ func generateInboundFixture(cmd *cobra.Command, _ []string) error {
 		}
 
 		// get inbound message data start
-		channelID := executionConfig.Source.ChannelID
-		address := common.HexToAddress(executionConfig.Source.Contracts.Gateway)
+		channelID := executionConf.Source.ChannelID
+		address := common.HexToAddress(executionConf.Source.Contracts.Gateway)
 		gatewayContract, err := contracts.NewGateway(address, ethconn.Client())
 		if err != nil {
 			return err

--- a/relayer/cmd/import_execution_header.go
+++ b/relayer/cmd/import_execution_header.go
@@ -114,7 +114,7 @@ func importExecutionHeaderFn(cmd *cobra.Command, _ []string) error {
 		store.Connect()
 		defer store.Close()
 
-		client := api.NewBeaconClient(lodestarEndpoint)
+		client := api.NewBeaconClient(lodestarEndpoint, lodestarEndpoint)
 		syncer := syncer.New(client, &store, p)
 
 		beaconHeaderHash := common.HexToHash(finalizedHeader)

--- a/relayer/cmd/store_beacon_state.go
+++ b/relayer/cmd/store_beacon_state.go
@@ -51,7 +51,7 @@ func storeBeaconStateInDB(cmd *cobra.Command, _ []string) error {
 
 	p := protocol.New(conf.Source.Beacon.Spec)
 	store := store.New(conf.Source.Beacon.DataStore.Location, conf.Source.Beacon.DataStore.MaxEntries, *p)
-	beaconClient := api.NewBeaconClient(conf.Source.Beacon.Endpoint)
+	beaconClient := api.NewBeaconClient(conf.Source.Beacon.Endpoint, conf.Source.Beacon.StateEndpoint)
 	syncer := syncer.New(beaconClient, &store, p)
 
 	err = store.Connect()

--- a/relayer/relays/beacon/config/config.go
+++ b/relayer/relays/beacon/config/config.go
@@ -26,9 +26,10 @@ type DataStore struct {
 }
 
 type BeaconConfig struct {
-	Endpoint  string       `mapstructure:"endpoint"`
-	Spec      SpecSettings `mapstructure:"spec"`
-	DataStore DataStore    `mapstructure:"datastore"`
+	Endpoint      string       `mapstructure:"endpoint"`
+	StateEndpoint string       `mapstructure:"stateEndpoint"`
+	Spec          SpecSettings `mapstructure:"spec"`
+	DataStore     DataStore    `mapstructure:"datastore"`
 }
 
 type SinkConfig struct {

--- a/relayer/relays/beacon/header/syncer/api/api.go
+++ b/relayer/relays/beacon/header/syncer/api/api.go
@@ -40,14 +40,16 @@ type BeaconAPI interface {
 }
 
 type BeaconClient struct {
-	httpClient http.Client
-	endpoint   string
+	httpClient    http.Client
+	endpoint      string
+	stateEndpoint string
 }
 
-func NewBeaconClient(endpoint string) *BeaconClient {
+func NewBeaconClient(endpoint, stateEndpoint string) *BeaconClient {
 	return &BeaconClient{
 		http.Client{},
 		endpoint,
+		stateEndpoint,
 	}
 }
 
@@ -398,7 +400,7 @@ func (b *BeaconClient) GetLatestFinalizedUpdate() (LatestFinalisedUpdateResponse
 
 func (b *BeaconClient) GetBeaconState(stateIdOrSlot string) ([]byte, error) {
 	var data []byte
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/eth/v2/debug/beacon/states/%s", b.endpoint, stateIdOrSlot), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/eth/v2/debug/beacon/states/%s", b.stateEndpoint, stateIdOrSlot), nil)
 	if err != nil {
 		return data, err
 	}

--- a/relayer/relays/beacon/header/syncer/syncer_test.go
+++ b/relayer/relays/beacon/header/syncer/syncer_test.go
@@ -21,7 +21,7 @@ import (
 const TestUrl = "https://lodestar-sepolia.chainsafe.io"
 
 func newTestRunner() *Syncer {
-	return New(api.NewBeaconClient(TestUrl), &mock.Store{}, protocol.New(config.SpecSettings{
+	return New(api.NewBeaconClient(TestUrl, TestUrl), &mock.Store{}, protocol.New(config.SpecSettings{
 		SlotsInEpoch:                 32,
 		EpochsPerSyncCommitteePeriod: 256,
 		DenebForkEpoch:               0,

--- a/relayer/relays/beacon/main.go
+++ b/relayer/relays/beacon/main.go
@@ -61,7 +61,7 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 	}
 	defer s.Close()
 
-	beaconAPI := api.NewBeaconClient(r.config.Source.Beacon.Endpoint)
+	beaconAPI := api.NewBeaconClient(r.config.Source.Beacon.Endpoint, r.config.Source.Beacon.StateEndpoint)
 	headers := header.New(
 		writer,
 		beaconAPI,

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -89,7 +89,7 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 	store.Connect()
 	defer store.Close()
 
-	beaconAPI := api.NewBeaconClient(r.config.Source.Beacon.Endpoint)
+	beaconAPI := api.NewBeaconClient(r.config.Source.Beacon.Endpoint, r.config.Source.Beacon.StateEndpoint)
 	beaconHeader := header.New(
 		writer,
 		beaconAPI,

--- a/web/packages/test/config/beacon-relay.json
+++ b/web/packages/test/config/beacon-relay.json
@@ -2,6 +2,7 @@
   "source": {
     "beacon": {
       "endpoint": "http://127.0.0.1:9596",
+      "stateEndpoint": "http://127.0.0.1:9596",
       "spec": {
         "syncCommitteeSize": 512,
         "slotsInEpoch": 32,


### PR DESCRIPTION
Configure a separate endpoint for the beacon state download, because Lodestar does not backfill ssz states if the node goes offline for a period longer than the weak subjectivity period. This is problematic because we should be able to get historic states. This enables us to switch to a different consensus node for ssz states, if necessary. If all is well, both the `endpoint` and `stateEndpoint` config values can point to Lodestar.