### PR TITLE
Instant rebalancing with fee asset always in WETH

### DIFF
--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -75,6 +75,8 @@ library Assets {
         AssetsStorage.Layout storage $ = AssetsStorage.layout();
         if ($.assetHubParaID == destinationChain) {
             costs.foreign = $.assetHubReserveTransferFee;
+            // We don't charge any extra fees beyond delivery costs
+            costs.native = 0;
         } else {
             // Reduce the ability for users to perform arbitrage by exploiting a
             // favourable exchange rate. For example supplying Ether
@@ -91,10 +93,10 @@ library Assets {
 
             // If the final destination chain is not AssetHub, then the fee needs to additionally
             // include the cost of executing an XCM on the final destination parachain.
-            costs.foreign = $.assetHubReserveTransferFee + destinationChainFee;
+            costs.foreign = $.assetHubReserveTransferFee;
+            // destinationChainFee always in WETH
+            costs.native = destinationChainFee;
         }
-        // We don't charge any extra fees beyond delivery costs
-        costs.native = 0;
     }
 
     function sendToken(
@@ -239,8 +241,9 @@ library Assets {
     }
 
     function _sendForeignTokenCosts(uint128 destinationChainFee) internal pure returns (Costs memory costs) {
-        costs.foreign = destinationChainFee;
-        costs.native = 0;
+        costs.foreign = 0;
+        // destinationChainFee always in WETH
+        costs.native = destinationChainFee;
     }
 
     // @dev Register a new fungible Polkadot token for an agent

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -955,7 +955,8 @@ contract GatewayTest is Test {
 
         ParaID destPara = assetHubParaID;
 
-        vm.prank(account1);
+        vm.startPrank(account1);
+        token.approve(address(gateway), 1);
 
         vm.expectEmit(true, true, false, true);
         emit IGateway.TokenSent(address(dotToken), account1, destPara, recipientAddress32, 1);
@@ -964,7 +965,7 @@ contract GatewayTest is Test {
         vm.expectEmit(true, false, false, false);
         emit IGateway.OutboundMessageAccepted(assetHubParaID.into(), 1, messageID, bytes(""));
 
-        IGateway(address(gateway)).sendToken{value: 0.1 ether}(address(dotToken), destPara, recipientAddress32, 1, 1);
+        IGateway(address(gateway)).sendToken{value: 1 ether}(address(dotToken), destPara, recipientAddress32, 2, 1);
     }
 
     function testSendNotRegisteredTokenWillFail() public {
@@ -986,7 +987,7 @@ contract GatewayTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(ERC20Lib.ERC20InsufficientBalance.selector, account1, 0, 1));
 
-        IGateway(address(gateway)).sendToken{value: 0.1 ether}(address(dotToken), destPara, recipientAddress32, 1, 1);
+        IGateway(address(gateway)).sendToken{value: 0.1 ether}(address(dotToken), destPara, recipientAddress32, 2, 1);
     }
 
     function testLegacyAgentExecutionForCompatibility() public {


### PR DESCRIPTION
This is a POC for an instant rebalancing with fee asset always in WETH based upon [discussion](https://snowfork.slack.com/archives/G01BGMGLAC9/p1714995738905699?thread_ts=1714699858.812779&cid=G01BGMGLAC9) in channel.

companion change on substrate side in https://github.com/Snowfork/polkadot-sdk/commit/64b1d4453e356866395a6284b3e6c05cc499557e

Destination parachain should be configured to 

- register WETH as sufficient 
- a custom `IsReserve` to allow AssetHub as trusted reserve for WETH
- a custom `Trader` allow to use WETH to pay fees for the xcm execution