### PR TITLE
Fix interim finalized update

### DIFF
--- a/relayer/cmd/import_beacon_state.go
+++ b/relayer/cmd/import_beacon_state.go
@@ -72,7 +72,7 @@ func importBeaconState(cmd *cobra.Command, _ []string) error {
 
 	p := protocol.New(conf.Source.Beacon.Spec)
 	store := store.New(conf.Source.Beacon.DataStore.Location, conf.Source.Beacon.DataStore.MaxEntries, *p)
-	beaconClient := api.NewBeaconClient(conf.Source.Beacon.Endpoint)
+	beaconClient := api.NewBeaconClient(conf.Source.Beacon.Endpoint, conf.Source.Beacon.StateEndpoint)
 	syncer := syncer.New(beaconClient, &store, p)
 
 	err = store.Connect()

--- a/relayer/relays/beacon/header/header_test.go
+++ b/relayer/relays/beacon/header/header_test.go
@@ -45,8 +45,7 @@ func TestSyncInterimFinalizedUpdate_WithDataFromAPI(t *testing.T) {
 	client.BlocksAtSlot = map[uint64]api.BeaconBlockResponse{
 		4571137: blockAtSlot4571137,
 	}
-	//4570730
-	//4578914
+
 	beaconStates := map[uint64]bool{
 		4571072: true,
 		4571136: true,

--- a/relayer/relays/beacon/header/header_test.go
+++ b/relayer/relays/beacon/header/header_test.go
@@ -45,7 +45,8 @@ func TestSyncInterimFinalizedUpdate_WithDataFromAPI(t *testing.T) {
 	client.BlocksAtSlot = map[uint64]api.BeaconBlockResponse{
 		4571137: blockAtSlot4571137,
 	}
-
+	//4570730
+	//4578914
 	beaconStates := map[uint64]bool{
 		4571072: true,
 		4571136: true,
@@ -68,7 +69,7 @@ func TestSyncInterimFinalizedUpdate_WithDataFromAPI(t *testing.T) {
 	)
 
 	// Find a checkpoint for a slot that is just out of the on-chain synced finalized header block roots range
-	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722)
+	err = h.syncInterimFinalizedUpdate(context.Background(), 4563072, 4571360)
 	require.NoError(t, err)
 }
 
@@ -131,7 +132,7 @@ func TestSyncInterimFinalizedUpdate_WithDataFromStore(t *testing.T) {
 	)
 
 	// Find a checkpoint for a slot that is just out of the on-chain synced finalized header block roots range
-	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722)
+	err = h.syncInterimFinalizedUpdate(context.Background(), 4563072, 4571360)
 	require.NoError(t, err)
 }
 
@@ -196,7 +197,7 @@ func TestSyncInterimFinalizedUpdate_WithDataFromStoreWithDifferentBlocks(t *test
 	)
 
 	// Find a checkpoint for a slot that is just out of the on-chain synced finalized header block roots range
-	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722)
+	err = h.syncInterimFinalizedUpdate(context.Background(), 4563072, 4571360)
 	require.NoError(t, err)
 }
 
@@ -241,7 +242,7 @@ func TestSyncInterimFinalizedUpdate_BeaconStateNotAvailableInAPIAndStore(t *test
 	)
 
 	// Find a checkpoint for a slot that is just out of the on-chain synced finalized header block roots range
-	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722)
+	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722, 4578922)
 	require.Error(t, err)
 }
 
@@ -279,6 +280,6 @@ func TestSyncInterimFinalizedUpdate_NoValidBlocksFound(t *testing.T) {
 	)
 
 	// Find a checkpoint for a slot that is just out of the on-chain synced finalized header block roots range
-	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722)
+	err = h.syncInterimFinalizedUpdate(context.Background(), 4570722, 4578922)
 	require.Errorf(t, err, "cannot find blocks at boundaries")
 }

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -516,7 +516,7 @@ func (s *Syncer) FindValidAttestedHeader(minSlot, maxSlot uint64) (uint64, error
 	if minSlot%32 == 0 {
 		slot = minSlot
 	} else {
-		slot = ((slot / s.protocol.Settings.SlotsInEpoch) + 1) * s.protocol.Settings.SlotsInEpoch
+		slot = ((minSlot / s.protocol.Settings.SlotsInEpoch) + 1) * s.protocol.Settings.SlotsInEpoch
 	}
 
 	for {

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -103,7 +103,7 @@ func (s *Syncer) GetSyncCommitteePeriodUpdate(period uint64, lastFinalizedSlot u
 	update, err := s.GetSyncCommitteePeriodUpdateFromEndpoint(period)
 	if err != nil {
 		log.WithFields(log.Fields{"period": period, "err": err}).Warn("fetch sync committee update period light client failed, trying building update manually")
-		update, err = s.GetFinalizedUpdateWithSyncCommittee(period, lastFinalizedSlot)
+		update, err = s.GetFinalizedUpdateWithSyncCommittee(period)
 		if err != nil {
 			return update, fmt.Errorf("build sync committee update: %w", err)
 		}
@@ -483,7 +483,6 @@ func (s *Syncer) GetHeaderUpdate(blockRoot common.Hash, checkpoint *cache.Proof)
 
 func (s *Syncer) getBeaconStateAtSlot(slot uint64) (state.BeaconState, error) {
 	var beaconState state.BeaconState
-	log.WithField("slot", slot).Info("downloading state at slot")
 	beaconData, err := s.getBeaconState(slot)
 	if err != nil {
 		return beaconState, fmt.Errorf("fetch beacon state: %w", err)
@@ -510,45 +509,20 @@ func (s *Syncer) UnmarshalBeaconState(slot uint64, data []byte) (state.BeaconSta
 	return beaconState, nil
 }
 
-// Sanity check the finalized and attested header are at 32 boundary blocks, so we can download the beacon state
-func (s *Syncer) FindLatestAttestedHeadersAtInterval(initialSlot, lowestSlot uint64) (uint64, error) {
-	slot := initialSlot
-
-	for {
-		finalizedSlot, attestedSlot, err := s.findValidUpdatePair(slot)
-		if err != nil {
-			if lowestSlot > slot {
-				return 0, fmt.Errorf("unable to find valid slot")
-			}
-
-			slot -= s.protocol.Settings.SlotsInEpoch
-
-			continue
-		}
-
-		log.WithFields(log.Fields{"attested": attestedSlot, "finalized": finalizedSlot}).Info("found boundary headers")
-		return attestedSlot, nil
-	}
-}
-
-// FindOldestAttestedHeaderAtInterval finds a set of headers (finalized and attested headers) that are at 32 boundary
-// blocks (with a sync committee super majority signature), so we can download the beacon state.
-func (s *Syncer) FindOldestAttestedHeaderAtInterval(initialSlot, highestSlot uint64) (uint64, error) {
-	// special case where the finalized beacon state is not set at genesis
-	if initialSlot == 0 {
-		initialSlot = 2 * s.protocol.Settings.SlotsInEpoch
-	}
-	slot := initialSlot
-
-	head, err := s.Client.GetHeaderAtHead()
-	if err != nil {
-		return 0, fmt.Errorf("get chain head: %w", err)
+// FindValidAttestedHeader Find a valid beacon header attested and finalized header pair.
+func (s *Syncer) FindValidAttestedHeader(minSlot, maxSlot uint64) (uint64, error) {
+	var slot uint64
+	// make sure the starting slot is in a multiple of 32
+	if minSlot%32 == 0 {
+		slot = minSlot
+	} else {
+		slot = ((slot / s.protocol.Settings.SlotsInEpoch) + 1) * s.protocol.Settings.SlotsInEpoch
 	}
 
 	for {
 		finalizedSlot, attestedSlot, err := s.findValidUpdatePair(slot)
 		if err != nil {
-			if highestSlot < slot || head.Slot < slot {
+			if slot > maxSlot {
 				return 0, fmt.Errorf("unable to find valid slot")
 			}
 
@@ -594,36 +568,32 @@ func (s *Syncer) findValidUpdatePair(slot uint64) (uint64, uint64, error) {
 	return finalizedHeader.Slot, attestedHeader.Slot, nil
 }
 
-func (s *Syncer) GetLatestPossibleFinalizedUpdate(attestedSlot uint64, boundary uint64) (scale.Update, error) {
-	attestedSlot, err := s.FindLatestAttestedHeadersAtInterval(attestedSlot, boundary)
+func (s *Syncer) GetFinalizedUpdateWithSyncCommittee(syncCommitteePeriod uint64) (scale.Update, error) {
+	minSlot := syncCommitteePeriod * s.protocol.SlotsPerHistoricalRoot
+	maxSlot := ((syncCommitteePeriod + 1) * s.protocol.SlotsPerHistoricalRoot) - s.protocol.Settings.SlotsInEpoch // just before the new sync committee boundary
+
+	attestedSlot, err := s.FindValidAttestedHeader(minSlot, maxSlot)
 	if err != nil {
 		return scale.Update{}, fmt.Errorf("cannot find blocks at boundaries: %w", err)
 	}
 
-	return s.GetFinalizedUpdateAtAttestedSlot(attestedSlot, boundary, false)
+	return s.GetFinalizedUpdateAtAttestedSlot(attestedSlot, maxSlot, true)
 }
 
-func (s *Syncer) GetFinalizedUpdateWithSyncCommittee(syncCommitteePeriod, lastFinalizedSlot uint64) (scale.Update, error) {
-	slot := (syncCommitteePeriod) * s.protocol.Settings.SlotsInEpoch * s.protocol.Settings.EpochsPerSyncCommitteePeriod
-
-	boundary := (syncCommitteePeriod + 1) * s.protocol.Settings.SlotsInEpoch * s.protocol.Settings.EpochsPerSyncCommitteePeriod
-
-	attestedSlot, err := s.FindOldestAttestedHeaderAtInterval(slot, boundary)
-	if err != nil {
-		return scale.Update{}, fmt.Errorf("cannot find blocks at boundaries: %w", err)
-	}
-
-	return s.GetFinalizedUpdateAtAttestedSlot(attestedSlot, boundary, true)
-}
-
-func (s *Syncer) GetFinalizedUpdateAtAttestedSlot(attestedSlot uint64, boundary uint64, fetchNextSyncCommittee bool) (scale.Update, error) {
+func (s *Syncer) GetFinalizedUpdateAtAttestedSlot(minSlot, maxSlot uint64, fetchNextSyncCommittee bool) (scale.Update, error) {
 	var update scale.Update
+
+	attestedSlot, err := s.FindValidAttestedHeader(minSlot, maxSlot)
+	if err != nil {
+		return scale.Update{}, fmt.Errorf("cannot find blocks at boundaries: %w", err)
+	}
 
 	// Try getting beacon data from the API first
 	data, err := s.getBeaconDataFromClient(attestedSlot)
 	if err != nil {
+		log.WithFields(log.Fields{"minSlot": minSlot, "maxSlot": maxSlot}).Info("attempting to find in beacon store")
 		// If it fails, using the beacon store and look for a relevant finalized update
-		data, err = s.getBeaconDataFromStore(attestedSlot, boundary, fetchNextSyncCommittee)
+		data, err = s.getBestMatchBeaconDataFromStore(minSlot, maxSlot)
 		if err != nil {
 			return update, fmt.Errorf("fetch beacon data from api and data store failure: %w", err)
 		}
@@ -732,7 +702,7 @@ func (s *Syncer) GetFinalizedUpdateAtAttestedSlot(attestedSlot uint64, boundary 
 }
 
 func (s *Syncer) getBlockHeaderAncestryProof(slot int, blockRoot common.Hash, blockRootTree *ssz.Node) ([]types.H256, error) {
-	maxSlotsPerHistoricalRoot := int(s.protocol.Settings.SlotsInEpoch * s.protocol.Settings.EpochsPerSyncCommitteePeriod)
+	maxSlotsPerHistoricalRoot := int(s.protocol.SlotsPerHistoricalRoot)
 	indexInArray := slot % maxSlotsPerHistoricalRoot
 	leafIndex := maxSlotsPerHistoricalRoot + indexInArray
 
@@ -793,25 +763,11 @@ func (s *Syncer) getBeaconDataFromClient(attestedSlot uint64) (finalizedUpdateCo
 	return response, nil
 }
 
-// Get the best, latest finalized and attested beacon states including the slot provided in the finalized state block
-// roots, from the Beacon store.
-func (s *Syncer) getBeaconDataFromStore(slot, boundary uint64, findMin bool) (finalizedUpdateContainer, error) {
-	response, err := s.getExactMatchFromStore(slot)
-	if err != nil {
-		response, err = s.getBestMatchBeaconDataFromStore(slot, boundary, findMin)
-		if err != nil {
-			return finalizedUpdateContainer{}, fmt.Errorf("unable to find exact slot or best other slot beacon data")
-		}
-	}
-
-	return response, nil
-}
-
-func (s *Syncer) getBestMatchBeaconDataFromStore(slot, boundary uint64, findMin bool) (finalizedUpdateContainer, error) {
+func (s *Syncer) getBestMatchBeaconDataFromStore(minSlot, maxSlot uint64) (finalizedUpdateContainer, error) {
 	var response finalizedUpdateContainer
 	var err error
 
-	data, err := s.store.FindBeaconStateWithinSyncPeriod(slot, boundary, findMin)
+	data, err := s.store.FindBeaconStateWithinRange(minSlot, maxSlot)
 	if err != nil {
 		return finalizedUpdateContainer{}, err
 	}
@@ -836,44 +792,11 @@ func (s *Syncer) getBestMatchBeaconDataFromStore(slot, boundary uint64, findMin 
 	return response, nil
 }
 
-func (s *Syncer) getExactMatchFromStore(slot uint64) (finalizedUpdateContainer, error) {
-	var response finalizedUpdateContainer
-	attestedStateData, err := s.store.GetBeaconStateData(slot)
-	if err != nil {
-		return finalizedUpdateContainer{}, err
-	}
-
-	response.AttestedSlot = slot
-	response.AttestedState, err = s.UnmarshalBeaconState(slot, attestedStateData)
-	if err != nil {
-		return finalizedUpdateContainer{}, err
-	}
-
-	response.FinalizedCheckPoint = *response.AttestedState.GetFinalizedCheckpoint()
-
-	response.FinalizedHeader, err = s.Client.GetHeaderByBlockRoot(common.BytesToHash(response.FinalizedCheckPoint.Root))
-	if err != nil {
-		return response, fmt.Errorf("fetch header: %w", err)
-	}
-
-	finalizedStateData, err := s.store.GetBeaconStateData(response.FinalizedHeader.Slot)
-	if err != nil {
-		return finalizedUpdateContainer{}, err
-	}
-
-	response.FinalizedState, err = s.UnmarshalBeaconState(response.FinalizedHeader.Slot, finalizedStateData)
-	if err != nil {
-		return finalizedUpdateContainer{}, err
-	}
-
-	return response, nil
-}
 func (s *Syncer) getBeaconState(slot uint64) ([]byte, error) {
 	data, err := s.Client.GetBeaconState(strconv.FormatUint(slot, 10))
 	if err != nil {
 		log.WithFields(log.Fields{"slot": slot, "err": err}).Warn("unable to download ssz state from api, trying store")
 		data, err = s.store.GetBeaconStateData(slot)
-		log.WithFields(log.Fields{"slot": slot, "err": err}).Warn("error after store is")
 		if err != nil {
 			return nil, fmt.Errorf("fetch beacon state from store: %w", err)
 		}

--- a/relayer/relays/beacon/header/syncer/syncer_test.go
+++ b/relayer/relays/beacon/header/syncer/syncer_test.go
@@ -39,11 +39,11 @@ func TestGetFinalizedUpdateAtSlot(t *testing.T) {
 	require.NoError(t, err)
 	lodestarUpdateJSON := lodestarUpdate.Payload.ToJSON()
 
-	attestedSlot, err := syncer.FindLatestAttestedHeadersAtInterval(uint64(lodestarUpdate.Payload.AttestedHeader.Slot), 9331)
+	attestedSlot, err := syncer.FindValidAttestedHeader(uint64(lodestarUpdate.Payload.AttestedHeader.Slot), 9331)
 	require.NoError(t, err)
 
 	// Manually construct the finalized update for the same block
-	manualUpdate, err := syncer.GetLatestPossibleFinalizedUpdate(attestedSlot, 9331)
+	manualUpdate, err := syncer.GetFinalizedUpdateAtAttestedSlot(attestedSlot, 9331, false)
 	require.NoError(t, err)
 	manualUpdateJSON := manualUpdate.Payload.ToJSON()
 
@@ -167,7 +167,7 @@ func TestFindAttestedAndFinalizedHeadersAtBoundary(t *testing.T) {
 		DenebForkEpoch:               0,
 	}))
 
-	attested, err := syncer.FindLatestAttestedHeadersAtInterval(8192, 100)
+	attested, err := syncer.FindValidAttestedHeader(8000, 8160)
 	assert.NoError(t, err)
 	assert.Equal(t, "8064", strconv.FormatUint(attested, 10))
 
@@ -197,7 +197,7 @@ func TestFindAttestedAndFinalizedHeadersAtBoundary(t *testing.T) {
 		DenebForkEpoch:               0,
 	}))
 
-	attested, err = syncer.FindLatestAttestedHeadersAtInterval(32768, 25076)
+	attested, err = syncer.FindValidAttestedHeader(32576, 32704)
 	assert.NoError(t, err)
 	assert.Equal(t, "32704", strconv.FormatUint(attested, 10))
 
@@ -227,7 +227,7 @@ func TestFindAttestedAndFinalizedHeadersAtBoundary(t *testing.T) {
 		DenebForkEpoch:               0,
 	}))
 
-	attested, err = syncer.FindLatestAttestedHeadersAtInterval(32768, 25076)
+	attested, err = syncer.FindValidAttestedHeader(25076, 32736)
 	assert.NoError(t, err)
 	assert.Equal(t, "32704", strconv.FormatUint(attested, 10))
 
@@ -251,6 +251,6 @@ func TestFindAttestedAndFinalizedHeadersAtBoundary(t *testing.T) {
 		DenebForkEpoch:               0,
 	}))
 
-	attested, err = syncer.FindLatestAttestedHeadersAtInterval(32768, 32540)
+	attested, err = syncer.FindValidAttestedHeader(32540, 32768)
 	assert.Error(t, err)
 }

--- a/relayer/relays/beacon/mock/mock_store.go
+++ b/relayer/relays/beacon/mock/mock_store.go
@@ -10,6 +10,10 @@ type Store struct {
 	BeaconStateData       map[uint64][]byte
 }
 
+func (m *Store) FindBeaconStateWithinRange(slot, boundary uint64) (store.StoredBeaconData, error) {
+	return m.StoredBeaconStateData, nil
+}
+
 func (m *Store) WriteEntry(attestedSlot, finalizedSlot uint64, attestedStateData, finalizedStateData []byte) error {
 	return nil
 }
@@ -28,8 +32,4 @@ func (m *Store) Connect() error {
 
 func (m *Store) Close() {
 
-}
-
-func (m *Store) FindBeaconStateWithinSyncPeriod(slot, boundary uint64, findMax bool) (store.StoredBeaconData, error) {
-	return m.StoredBeaconStateData, nil
 }

--- a/relayer/relays/beacon/mock/mock_writer.go
+++ b/relayer/relays/beacon/mock/mock_writer.go
@@ -15,6 +15,10 @@ type Writer struct {
 	LastFinalizedState state.FinalizedHeader
 }
 
+func (m *Writer) GetLastExecutionHeaderState() (state.ExecutionHeader, error) {
+	return state.ExecutionHeader{}, nil
+}
+
 func (m *Writer) GetLastFinalizedStateIndex() (types.U32, error) {
 	return 0, nil
 }

--- a/relayer/relays/beacon/protocol/protocol.go
+++ b/relayer/relays/beacon/protocol/protocol.go
@@ -8,11 +8,15 @@ import (
 )
 
 type Protocol struct {
-	Settings config.SpecSettings
+	Settings               config.SpecSettings
+	SlotsPerHistoricalRoot uint64
 }
 
 func New(setting config.SpecSettings) *Protocol {
-	return &Protocol{Settings: setting}
+	return &Protocol{
+		Settings:               setting,
+		SlotsPerHistoricalRoot: setting.SlotsInEpoch * setting.EpochsPerSyncCommitteePeriod,
+	}
 }
 
 func (p *Protocol) ComputeSyncPeriodAtSlot(slot uint64) uint64 {

--- a/relayer/relays/beacon/store/datastore_test.go
+++ b/relayer/relays/beacon/store/datastore_test.go
@@ -129,7 +129,7 @@ func TestPruneOldStates(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFindBeaconStateWithinSyncPeriodRange(t *testing.T) {
+func TestFindBeaconStateWithinRange(t *testing.T) {
 	_ = os.RemoveAll(TestDataStoreFile + BeaconStateDir)
 	_ = os.Remove(TestDataStoreFile + BeaconStoreName)
 
@@ -186,23 +186,23 @@ func TestFindBeaconStateWithinSyncPeriodRange(t *testing.T) {
 	require.NoError(t, err)
 
 	period568Start := uint64(568 * 256 * 32)
-	beaconData, err := store.FindBeaconStateWithinSyncPeriod(4644864, period568Start, true)
+	beaconData, err := store.FindBeaconStateWithinRange(4644864, period568Start)
 	require.NoError(t, err)
 
 	require.Equal(t, pair3AttestedSlot, beaconData.AttestedSlot)
 	require.Equal(t, pair3FinalizedSlot, beaconData.FinalizedSlot)
 
 	period558Start := uint64(558 * 256 * 32)
-	beaconData, err = store.FindBeaconStateWithinSyncPeriod(4570003, period558Start, false)
+	beaconData, err = store.FindBeaconStateWithinRange(4570003, period558Start)
 	require.NoError(t, err)
 
 	require.Equal(t, pair1AttestedSlot, beaconData.AttestedSlot)
 	require.Equal(t, pair1FinalizedSlot, beaconData.FinalizedSlot)
 
 	period559Start := uint64(559 * 256 * 32)
-	beaconData, err = store.FindBeaconStateWithinSyncPeriod(4570800, period559Start, false)
+	beaconData, err = store.FindBeaconStateWithinRange(4570800, period559Start)
 	require.NoError(t, err)
 
-	require.Equal(t, pair2AttestedSlot, beaconData.AttestedSlot)
-	require.Equal(t, pair2FinalizedSlot, beaconData.FinalizedSlot)
+	require.Equal(t, int(pair1AttestedSlot), int(beaconData.AttestedSlot))
+	require.Equal(t, int(pair1FinalizedSlot), int(beaconData.FinalizedSlot))
 }

--- a/web/packages/test/config/execution-relay.json
+++ b/web/packages/test/config/execution-relay.json
@@ -9,6 +9,7 @@
     "channel-id": null,
     "beacon": {
       "endpoint": "http://127.0.0.1:9596",
+      "stateEndpoint": "http://127.0.0.1:9596",
       "spec": {
         "slotsInEpoch": 32,
         "epochsPerSyncCommitteePeriod": 256,

--- a/web/packages/test/scripts/configure-substrate.sh
+++ b/web/packages/test/scripts/configure-substrate.sh
@@ -6,7 +6,7 @@ source scripts/xcm-helper.sh
 
 config_beacon_checkpoint() {
     pushd $root_dir
-    local check_point_hex=$($relay_bin generate-beacon-checkpoint --url $beacon_endpoint_http)
+    local check_point_hex=$($relay_bin generate-beacon-checkpoint --config $config_dir/beacon-relay.json)
     popd
     local transact_call="0x5200"$check_point_hex
     send_governance_transact_from_relaychain $BRIDGE_HUB_PARAID "$transact_call" 180000000000 900000


### PR DESCRIPTION
The interim finalized update code was buggy and overcomplicated - it tried to find the latest slot for the finalized header update and the oldest slot for the finalized header with a sync committee, which is unnecessary.

This PR simplifies the interim update (when the last 2 finalized headers are more than 8192 headers apart) by just providing a range of slots that will be sufficient and finding the first slot in the range that matches.