### PR TITLE
Sync beefy commitment on demand

### DIFF
--- a/relayer/cmd/root.go
+++ b/relayer/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(storeBeaconStateCmd())
 	rootCmd.AddCommand(importBeaconStateCmd())
 	rootCmd.AddCommand(listBeaconStateCmd())
+	rootCmd.AddCommand(syncBeefyCommitmentCmd())
 }
 
 func Execute() {

--- a/relayer/cmd/sync_beefy_commitment.go
+++ b/relayer/cmd/sync_beefy_commitment.go
@@ -20,7 +20,6 @@ func syncBeefyCommitmentCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String("config", "/tmp/snowbridge/beefy-relay.json", "Path to configuration file")
-	cmd.MarkFlagRequired("config")
 	cmd.Flags().String("private-key", "", "Ethereum private key")
 	cmd.Flags().String("privateKeyFile", "", "The file from which to read the private key")
 	cmd.Flags().Uint64P("relay-block", "b", 0, "Relay block number which contains a Parachain message")

--- a/relayer/cmd/sync_beefy_commitment.go
+++ b/relayer/cmd/sync_beefy_commitment.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sirupsen/logrus"
+	"github.com/snowfork/snowbridge/relayer/chain/ethereum"
+	"github.com/snowfork/snowbridge/relayer/relays/beefy"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func syncBeefyCommitmentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-latest-beefy-commitment",
+		Short: "Sync beefy commitment on demand",
+		Args:  cobra.ExactArgs(0),
+		RunE:  SyncBeefyCommitmentFn,
+	}
+
+	cmd.Flags().String("config", "/tmp/snowbridge/beefy-relay.json", "Path to configuration file")
+	cmd.MarkFlagRequired("config")
+	cmd.Flags().String("private-key", "", "Ethereum private key")
+	cmd.Flags().String("privateKeyFile", "", "The file from which to read the private key")
+	cmd.Flags().Uint64P("relay-block", "b", 0, "Relay block number which contains a Parachain message")
+	cmd.MarkFlagRequired("relay-block")
+	return cmd
+}
+
+func SyncBeefyCommitmentFn(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	log.SetOutput(logrus.WithFields(logrus.Fields{"logger": "stdlib"}).WriterLevel(logrus.InfoLevel))
+	logrus.SetLevel(logrus.DebugLevel)
+
+	configFile, err := cmd.Flags().GetString("config")
+	viper.SetConfigFile(configFile)
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	var config beefy.Config
+	err = viper.Unmarshal(&config)
+	if err != nil {
+		return err
+	}
+	privateKey, _ := cmd.Flags().GetString("private-key")
+	privateKeyFile, _ := cmd.Flags().GetString("privateKeyFile")
+	if privateKey == "" && privateKeyFile == "" {
+		return fmt.Errorf("missing private key")
+	}
+	keypair, err := ethereum.ResolvePrivateKey(privateKey, privateKeyFile)
+	if err != nil {
+		return err
+	}
+
+	relay, err := beefy.NewRelay(&config, keypair)
+	if err != nil {
+		return err
+	}
+	relayBlockNumber, _ := cmd.Flags().GetUint64("relay-block")
+	err = relay.SyncUpdate(ctx, relayBlockNumber)
+	return err
+}

--- a/relayer/cmd/sync_beefy_commitment.go
+++ b/relayer/cmd/sync_beefy_commitment.go
@@ -21,9 +21,9 @@ func syncBeefyCommitmentCmd() *cobra.Command {
 
 	cmd.Flags().String("config", "/tmp/snowbridge/beefy-relay.json", "Path to configuration file")
 	cmd.Flags().String("private-key", "", "Ethereum private key")
-	cmd.Flags().String("privateKeyFile", "", "The file from which to read the private key")
-	cmd.Flags().Uint64P("relay-block", "b", 0, "Relay block number which contains a Parachain message")
-	cmd.MarkFlagRequired("relay-block")
+	cmd.Flags().String("private-key-file", "", "The file from which to read the private key")
+	cmd.Flags().Uint64P("block-number", "b", 0, "Relay block number which contains a Parachain message")
+	cmd.MarkFlagRequired("block-number")
 	return cmd
 }
 
@@ -45,7 +45,7 @@ func SyncBeefyCommitmentFn(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	privateKey, _ := cmd.Flags().GetString("private-key")
-	privateKeyFile, _ := cmd.Flags().GetString("privateKeyFile")
+	privateKeyFile, _ := cmd.Flags().GetString("private-key-file")
 	if privateKey == "" && privateKeyFile == "" {
 		return fmt.Errorf("missing private key")
 	}
@@ -58,7 +58,7 @@ func SyncBeefyCommitmentFn(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	relayBlockNumber, _ := cmd.Flags().GetUint64("relay-block")
-	err = relay.SyncUpdate(ctx, relayBlockNumber)
+	blockNumber, _ := cmd.Flags().GetUint64("block-number")
+	err = relay.OneShotSync(ctx, blockNumber)
 	return err
 }

--- a/relayer/relays/beefy/ethereum-writer.go
+++ b/relayer/relays/beefy/ethereum-writer.go
@@ -40,11 +40,6 @@ func NewEthereumWriter(
 }
 
 func (wr *EthereumWriter) Start(ctx context.Context, eg *errgroup.Group, requests <-chan Request) error {
-	err := wr.initialize(ctx)
-	if err != nil {
-		return fmt.Errorf("initialize EthereumWriter: %w", err)
-	}
-
 	// launch task processor
 	eg.Go(func() error {
 		for {

--- a/relayer/relays/beefy/ethereum-writer.go
+++ b/relayer/relays/beefy/ethereum-writer.go
@@ -40,22 +40,10 @@ func NewEthereumWriter(
 }
 
 func (wr *EthereumWriter) Start(ctx context.Context, eg *errgroup.Group, requests <-chan Request) error {
-	address := common.HexToAddress(wr.config.Contracts.BeefyClient)
-	contract, err := contracts.NewBeefyClient(address, wr.conn.Client())
+	err := wr.initialize(ctx)
 	if err != nil {
-		return fmt.Errorf("create beefy client: %w", err)
+		return fmt.Errorf("initialize EthereumWriter: %w", err)
 	}
-	wr.contract = contract
-
-	callOpts := bind.CallOpts{
-		Context: ctx,
-	}
-	blockWaitPeriod, err := wr.contract.RandaoCommitDelay(&callOpts)
-	if err != nil {
-		return fmt.Errorf("create randao commit delay: %w", err)
-	}
-	wr.blockWaitPeriod = blockWaitPeriod.Uint64()
-	log.WithField("randaoCommitDelay", wr.blockWaitPeriod).Trace("Fetched randaoCommitDelay")
 
 	// launch task processor
 	eg.Go(func() error {
@@ -300,4 +288,25 @@ func (wr *EthereumWriter) doSubmitFinal(ctx context.Context, commitmentHash [32]
 		Info("Sent SubmitFinal transaction")
 
 	return tx, nil
+}
+
+func (wr *EthereumWriter) initialize(ctx context.Context) error {
+	address := common.HexToAddress(wr.config.Contracts.BeefyClient)
+	contract, err := contracts.NewBeefyClient(address, wr.conn.Client())
+	if err != nil {
+		return fmt.Errorf("create beefy client: %w", err)
+	}
+	wr.contract = contract
+
+	callOpts := bind.CallOpts{
+		Context: ctx,
+	}
+	blockWaitPeriod, err := wr.contract.RandaoCommitDelay(&callOpts)
+	if err != nil {
+		return fmt.Errorf("create randao commit delay: %w", err)
+	}
+	wr.blockWaitPeriod = blockWaitPeriod.Uint64()
+	log.WithField("randaoCommitDelay", wr.blockWaitPeriod).Trace("Fetched randaoCommitDelay")
+
+	return nil
 }

--- a/relayer/relays/beefy/main.go
+++ b/relayer/relays/beefy/main.go
@@ -126,9 +126,16 @@ func (relay *Relay) SyncUpdate(ctx context.Context, relayBlockNumber uint64) err
 		}).Info("New commitment already synced, just ignore")
 		return nil
 	}
+	if task.SignedCommitment.Commitment.ValidatorSetID > state.NextValidatorSetID {
+		log.WithFields(log.Fields{
+			"state": state,
+			"task":  task,
+		}).Error("Task unexpected, wait for mandatory updates to catch up")
+		return fmt.Errorf("Task unexpected")
+	}
 
 	// Submit the task
-	if task.SignedCommitment.Commitment.ValidatorSetID == state.CurrentValidatorSetID {
+	if task.SignedCommitment.Commitment.ValidatorSetID == state.CurrentValidatorSetID || task.SignedCommitment.Commitment.ValidatorSetID == state.NextValidatorSetID-1 {
 		task.ValidatorsRoot = state.CurrentValidatorSetRoot
 	} else {
 		task.ValidatorsRoot = state.NextValidatorSetRoot

--- a/relayer/relays/beefy/main.go
+++ b/relayer/relays/beefy/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/snowfork/snowbridge/relayer/chain/relaychain"
 	"github.com/snowfork/snowbridge/relayer/crypto/secp256k1"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -118,20 +117,24 @@ func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64) error {
 		return fmt.Errorf("fail to generate next beefy request: %w", err)
 	}
 
-	// Ignore commitment already synced
+	// Ignore commitment earlier than LatestBeefyBlock which is outdated
 	if task.SignedCommitment.Commitment.BlockNumber <= uint32(state.LatestBeefyBlock) {
-		log.WithFields(logrus.Fields{
-			"beefyBlockNumber": task.SignedCommitment.Commitment.BlockNumber,
-			"beefyBlockSynced": state.LatestBeefyBlock,
-		}).Info("New commitment already synced, just ignore")
+		log.WithFields(log.Fields{
+			"latestBeefyBlock":      state.LatestBeefyBlock,
+			"currentValidatorSetID": state.CurrentValidatorSetID,
+			"nextValidatorSetID":    state.NextValidatorSetID,
+			"blockNumberToSync":     task.SignedCommitment.Commitment.BlockNumber,
+		}).Info("Commitment outdated, just ignore")
 		return nil
 	}
 	if task.SignedCommitment.Commitment.ValidatorSetID > state.NextValidatorSetID {
 		log.WithFields(log.Fields{
-			"state": state,
-			"task":  task,
-		}).Error("Task unexpected, wait for mandatory updates to catch up")
-		return fmt.Errorf("Task unexpected")
+			"latestBeefyBlock":      state.LatestBeefyBlock,
+			"currentValidatorSetID": state.CurrentValidatorSetID,
+			"nextValidatorSetID":    state.NextValidatorSetID,
+			"validatorSetIDToSync":  task.SignedCommitment.Commitment.ValidatorSetID,
+		}).Warn("Task unexpected, wait for mandatory updates to catch up first")
+		return nil
 	}
 
 	// Submit the task

--- a/relayer/relays/beefy/main.go
+++ b/relayer/relays/beefy/main.go
@@ -138,7 +138,7 @@ func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64) error {
 	}
 
 	// Submit the task
-	if task.SignedCommitment.Commitment.ValidatorSetID == state.CurrentValidatorSetID || task.SignedCommitment.Commitment.ValidatorSetID == state.NextValidatorSetID-1 {
+	if task.SignedCommitment.Commitment.ValidatorSetID == state.CurrentValidatorSetID {
 		task.ValidatorsRoot = state.CurrentValidatorSetRoot
 	} else {
 		task.ValidatorsRoot = state.NextValidatorSetRoot

--- a/relayer/relays/beefy/main.go
+++ b/relayer/relays/beefy/main.go
@@ -81,7 +81,7 @@ func (relay *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 	return nil
 }
 
-func (relay *Relay) SyncUpdate(ctx context.Context, relayBlockNumber uint64) error {
+func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64) error {
 	// Initialize relaychainConn
 	err := relay.relaychainConn.Connect(ctx)
 	if err != nil {
@@ -103,17 +103,17 @@ func (relay *Relay) SyncUpdate(ctx context.Context, relayBlockNumber uint64) err
 		return fmt.Errorf("query beefy client state: %w", err)
 	}
 	// Ignore relay block already synced
-	if relayBlockNumber <= state.LatestBeefyBlock {
+	if blockNumber <= state.LatestBeefyBlock {
 		log.WithFields(log.Fields{
 			"validatorSetID": state.CurrentValidatorSetID,
 			"beefyBlock":     state.LatestBeefyBlock,
-			"relayBlock":     relayBlockNumber,
+			"relayBlock":     blockNumber,
 		}).Info("Relay block already synced, just ignore")
 		return nil
 	}
 
 	// generate beefy update for that specific relay block
-	task, err := relay.polkadotListener.generateBeefyUpdate(ctx, relayBlockNumber)
+	task, err := relay.polkadotListener.generateBeefyUpdate(ctx, blockNumber)
 	if err != nil {
 		return fmt.Errorf("fail to generate next beefy request: %w", err)
 	}

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -149,7 +149,7 @@ func (li *PolkadotListener) queryBeefyNextAuthoritySet(blockHash types.Hash) (Be
 	return nextAuthoritySet, nil
 }
 
-func (li *PolkadotListener) generateBeefyUpdateRequest(relayBlockNumber uint64) (Request, error) {
+func (li *PolkadotListener) generateBeefyUpdate(relayBlockNumber uint64) (Request, error) {
 	api := li.conn.API()
 	meta := li.conn.Metadata()
 	var request Request

--- a/relayer/relays/beefy/polkadot-listener.go
+++ b/relayer/relays/beefy/polkadot-listener.go
@@ -151,65 +151,66 @@ func (li *PolkadotListener) generateBeefyUpdate(ctx context.Context, relayBlockN
 	return request, nil
 }
 
-func (li *PolkadotListener) findLatestBeefyBlock(relayBlockNumber uint64) (types.Hash, error) {
+func (li *PolkadotListener) findNextBeefyBlock(blockNumber uint64) (types.Hash, error) {
 	api := li.conn.API()
-	var latestBeefyBlockNumber uint64
-	var latestBeefyBlockHash types.Hash
+	var nextBeefyBlockHash, finalizedBeefyBlockHash types.Hash
+	var err error
+	nextBeefyBlockNumber := blockNumber
 	for {
-		finalizedBeefyBlockHash, err := api.RPC.Beefy.GetFinalizedHead()
+		finalizedBeefyBlockHash, err = api.RPC.Beefy.GetFinalizedHead()
 		if err != nil {
-			return latestBeefyBlockHash, fmt.Errorf("fetch beefy finalized head: %w", err)
+			return nextBeefyBlockHash, fmt.Errorf("fetch beefy finalized head: %w", err)
 		}
-
 		finalizedBeefyBlockHeader, err := api.RPC.Chain.GetHeader(finalizedBeefyBlockHash)
 		if err != nil {
-			return latestBeefyBlockHash, fmt.Errorf("fetch block header: %w", err)
+			return nextBeefyBlockHash, fmt.Errorf("fetch block header: %w", err)
 		}
-
-		latestBeefyBlockNumber = uint64(finalizedBeefyBlockHeader.Number)
-		if latestBeefyBlockNumber < relayBlockNumber {
+		latestBeefyBlockNumber := uint64(finalizedBeefyBlockHeader.Number)
+		if latestBeefyBlockNumber <= nextBeefyBlockNumber {
+			// The relay block not finalized yet, just wait and retry
 			time.Sleep(6 * time.Second)
 			continue
-		}
-		latestBeefyBlockHash = finalizedBeefyBlockHash
-		break
-	}
-	return latestBeefyBlockHash, nil
-}
-
-func (li *PolkadotListener) findNextBeefyBlock(relayBlockNumber uint64) (types.Hash, error) {
-	api := li.conn.API()
-	nextBeefyBlockNumber := relayBlockNumber
-	var nextBeefyBlockHash types.Hash
-	var err error
-	for {
-		nextBeefyBlockHash, err = api.RPC.Chain.GetBlockHash(nextBeefyBlockNumber)
-		if err != nil {
-			return nextBeefyBlockHash, fmt.Errorf("fetch block hash: %w", err)
-		}
-		block, err := api.RPC.Chain.GetBlock(nextBeefyBlockHash)
-		if err != nil {
-			return nextBeefyBlockHash, fmt.Errorf("fetch block: %w", err)
-		}
-
-		var commitment *types.SignedCommitment
-		for j := range block.Justifications {
-			sc := types.OptionalSignedCommitment{}
-			if block.Justifications[j].EngineID() == "BEEF" {
-				err := types.DecodeFromBytes(block.Justifications[j].Payload(), &sc)
+		} else if latestBeefyBlockNumber <= nextBeefyBlockNumber+600 {
+			// The relay block has been finalized not long ago(1 hour), just return the finalized block
+			nextBeefyBlockHash = finalizedBeefyBlockHash
+			break
+		} else {
+			// The relay block has been finalized for a long time, in this case return the next block
+			// which contains a beefy justification
+			for {
+				if nextBeefyBlockNumber == latestBeefyBlockNumber {
+					nextBeefyBlockHash = finalizedBeefyBlockHash
+					break
+				}
+				nextBeefyBlockHash, err = api.RPC.Chain.GetBlockHash(nextBeefyBlockNumber)
 				if err != nil {
-					return nextBeefyBlockHash, fmt.Errorf("decode BEEFY signed commitment: %w", err)
+					return nextBeefyBlockHash, fmt.Errorf("fetch block hash: %w", err)
 				}
-				ok, value := sc.Unwrap()
-				if ok {
-					commitment = &value
+				block, err := api.RPC.Chain.GetBlock(nextBeefyBlockHash)
+				if err != nil {
+					return nextBeefyBlockHash, fmt.Errorf("fetch block: %w", err)
 				}
+
+				var commitment *types.SignedCommitment
+				for j := range block.Justifications {
+					sc := types.OptionalSignedCommitment{}
+					if block.Justifications[j].EngineID() == "BEEF" {
+						err := types.DecodeFromBytes(block.Justifications[j].Payload(), &sc)
+						if err != nil {
+							return nextBeefyBlockHash, fmt.Errorf("decode BEEFY signed commitment: %w", err)
+						}
+						ok, value := sc.Unwrap()
+						if ok {
+							commitment = &value
+						}
+					}
+				}
+				if commitment != nil {
+					return nextBeefyBlockHash, nil
+				}
+				nextBeefyBlockNumber++
 			}
 		}
-		if commitment != nil {
-			return nextBeefyBlockHash, nil
-		}
-		nextBeefyBlockNumber++
 	}
-
+	return nextBeefyBlockHash, nil
 }

--- a/relayer/relays/beefy/scanner.go
+++ b/relayer/relays/beefy/scanner.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	gsrpc "github.com/snowfork/go-substrate-rpc-client/v4"
 	"github.com/snowfork/go-substrate-rpc-client/v4/types"
 	"github.com/snowfork/snowbridge/relayer/crypto/keccak"
@@ -76,8 +75,6 @@ func scanBlocks(ctx context.Context, meta *types.Metadata, api *gsrpc.SubstrateA
 	}
 	current := startBlock
 	for {
-		log.Info("foo")
-
 		finalizedBlockNumber := uint64(finalizedHeader.Number)
 		if current > finalizedBlockNumber {
 			select {
@@ -111,7 +108,6 @@ func scanBlocks(ctx context.Context, meta *types.Metadata, api *gsrpc.SubstrateA
 		}
 
 		if sessionIndex > currentSessionIndex {
-			log.Info("BOO")
 			currentSessionIndex = sessionIndex
 		} else {
 			current++


### PR DESCRIPTION
A one-shot relayer at this moment and how we would integrate the one-shot relayer in future as follows from @vgeddes:

1. User on Polkadot signals that they want to speed up their message by depositing a fee in a special account on AssetHub/BridgeHub
2. An offchain service witnesses that deposit, and invokes the one-shot relayer 