### PR TITLE
API version 0.1.7

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/history.ts
+++ b/web/packages/api/src/history.ts
@@ -193,7 +193,7 @@ export const toPolkadotHistory = async (
     const results: ToPolkadotTransferResult[] = []
     for (const outboundMessage of ethOutboundMessages) {
         const result: ToPolkadotTransferResult = {
-            id: `${outboundMessage.transactionHash}-${outboundMessage.data.messageId}`,
+            id: outboundMessage.data.messageId,
             status: TransferStatus.Pending,
             info: {
                 when: new Date(outboundMessage.data.timestamp * 1000),
@@ -356,7 +356,7 @@ export const toEthereumHistory = async (
     const results: ToEthereumTransferResult[] = []
     for (const transfer of allTransfers) {
         const result: ToEthereumTransferResult = {
-            id: `${transfer.extrinsic_hash}-${transfer.data.messageId}`,
+            id: transfer.data.messageId,
             status: TransferStatus.Pending,
             info: {
                 when: new Date(transfer.block_timestamp * 1000),

--- a/web/packages/api/src/index.ts
+++ b/web/packages/api/src/index.ts
@@ -78,13 +78,20 @@ class PolkadotContext {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const contextFactory = async (config: Config): Promise<Context> => {
+interface ContextOverride {
+    ethereum?: AbstractProvider
+}
+
+export const contextFactory = async (config: Config, options: ContextOverride = {}): Promise<Context> => {
     let ethApi: AbstractProvider
-    if (config.ethereum.execution_url.startsWith("http")) {
-        ethApi = new ethers.JsonRpcProvider(config.ethereum.execution_url)
+    if(options.ethereum == null) {
+        if (config.ethereum.execution_url.startsWith("http")) {
+            ethApi = new ethers.JsonRpcProvider(config.ethereum.execution_url)
+        } else {
+            ethApi = new ethers.WebSocketProvider(config.ethereum.execution_url)
+        }
     } else {
-        ethApi = new ethers.WebSocketProvider(config.ethereum.execution_url)
+        ethApi = options.ethereum
     }
 
     const parasConnect: Promise<{ paraId: number; api: ApiPromise }>[] = []

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
* Allow override of ethereum provider to support passing in the Browser Provider (`window.ethereum`) directly.
* Use `messageId` as `Transfer.id`

Resolves: SNO-974