### PR TITLE
reduce polling interval

### DIFF
--- a/relayer/chain/ethereum/connection.go
+++ b/relayer/chain/ethereum/connection.go
@@ -140,7 +140,7 @@ func (co *Connection) waitForTransaction(ctx context.Context, tx *types.Transact
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(6 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
The beefy relayer is spamming Infura 2x a second, which I suspect is causing intermittent rate limiting errors.