### PR TITLE
Generate beefy test fixture by command

### DIFF
--- a/contracts/test/BeefyClientTestV2.t.sol
+++ b/contracts/test/BeefyClientTestV2.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {Strings} from "openzeppelin/utils/Strings.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+import {BeefyClient} from "../src/BeefyClient.sol";
+import {BeefyClientMock} from "./mocks/BeefyClientMock.sol";
+import {ScaleCodec} from "../src/utils/ScaleCodec.sol";
+import {Bitfield} from "../src/utils/Bitfield.sol";
+
+contract BeefyClientTestV2 is Test {
+    using stdJson for string;
+
+    BeefyClientMock beefyClient;
+    uint8 randaoCommitDelay;
+    uint8 randaoCommitExpiration;
+    uint256 minNumRequiredSignatures;
+    uint32 prevRandao;
+    bytes2 mmrRootID = bytes2("mh");
+
+    function setUp() public {
+        string memory root = vm.projectRoot();
+        string memory beefyCheckpointFile = string.concat(root, "/beefy-state.json");
+        string memory beefyCheckpointRaw = vm.readFile(beefyCheckpointFile);
+        uint64 startBlock = uint64(beefyCheckpointRaw.readUint(".startBlock"));
+
+        BeefyClient.ValidatorSet memory current = BeefyClient.ValidatorSet(
+            uint128(beefyCheckpointRaw.readUint(".current.id")),
+            uint128(beefyCheckpointRaw.readUint(".current.length")),
+            beefyCheckpointRaw.readBytes32(".current.root")
+        );
+        BeefyClient.ValidatorSet memory next = BeefyClient.ValidatorSet(
+            uint128(beefyCheckpointRaw.readUint(".next.id")),
+            uint128(beefyCheckpointRaw.readUint(".next.length")),
+            beefyCheckpointRaw.readBytes32(".next.root")
+        );
+
+        randaoCommitDelay = uint8(vm.envOr("RANDAO_COMMIT_DELAY", uint256(3)));
+        randaoCommitExpiration = uint8(vm.envOr("RANDAO_COMMIT_EXP", uint256(8)));
+        minNumRequiredSignatures = uint8(vm.envOr("MINIMUM_REQUIRED_SIGNATURES", uint256(16)));
+        prevRandao = uint32(vm.envOr("PREV_RANDAO", uint256(377)));
+
+        beefyClient = new BeefyClientMock(randaoCommitDelay, randaoCommitExpiration, minNumRequiredSignatures);
+        beefyClient.initialize_public(startBlock, current, next);
+    }
+
+    function testSubmit() public {
+        string memory beefyCommitmentFile = string.concat(vm.projectRoot(), "/test/data/initial-commitment.json");
+
+        string memory beefyCommitmentRaw = vm.readFile(beefyCommitmentFile);
+
+        uint32 blockNumber = uint32(beefyCommitmentRaw.readUint(".Commitment.BlockNumber"));
+        uint64 validatorSetID = uint32(beefyCommitmentRaw.readUint(".Commitment.ValidatorSetID"));
+        bytes32 mmrRoot = beefyCommitmentRaw.readBytes32(".Commitment.Payload[0].Data");
+
+        BeefyClient.PayloadItem[] memory payload = new BeefyClient.PayloadItem[](1);
+        payload[0] = BeefyClient.PayloadItem(mmrRootID, abi.encodePacked(mmrRoot));
+
+        BeefyClient.Commitment memory commitment = BeefyClient.Commitment(blockNumber, validatorSetID, payload);
+
+        uint256[] memory bitfield = beefyCommitmentRaw.readUintArray(".Bitfield");
+
+        BeefyClient.ValidatorProof memory proof = BeefyClient.ValidatorProof(
+            uint8(beefyCommitmentRaw.readUint(".Proof.V")),
+            beefyCommitmentRaw.readBytes32(".Proof.R"),
+            beefyCommitmentRaw.readBytes32(".Proof.S"),
+            beefyCommitmentRaw.readUint(".Proof.Index"),
+            beefyCommitmentRaw.readAddress(".Proof.Account"),
+            beefyCommitmentRaw.readBytes32Array(".Proof.Proof")
+        );
+
+        beefyClient.submitInitial(commitment, bitfield, proof);
+
+        // // mine random delay blocks
+        // vm.roll(block.number + randaoCommitDelay);
+
+        // vm.prevrandao(bytes32(uint256(prevRandao)));
+        // beefyClient.commitPrevRandao(commitHash);
+
+        // beefyClient.submitFinal(
+        //     commitment, bitfield, finalValidatorProofs, emptyLeaf, emptyLeafProofs, emptyLeafProofOrder
+        // );
+
+        // assertEq(beefyClient.latestBeefyBlock(), blockNumber);
+        // assertEq(beefyClient.getValidatorCounter(false, finalValidatorProofs[0].index), 1);
+        // assertEq(beefyClient.getValidatorCounter(true, finalValidatorProofs[0].index), 0);
+    }
+}

--- a/contracts/test/data/initial-commitment.json
+++ b/contracts/test/data/initial-commitment.json
@@ -1,0 +1,29 @@
+{
+  "Commitment": {
+    "BlockNumber": 19,
+    "ValidatorSetID": 1,
+    "Payload": [
+      {
+        "PayloadID": [
+          109,
+          104
+        ],
+        "Data": "0x2e34b07dabbeae0bab7865b2d94c23a361f8ade17d146c4eb122347308950154"
+      }
+    ]
+  },
+  "Bitfield": [
+    7
+  ],
+  "Proof": {
+    "V": 28,
+    "R": "0xad290474643644b339b9800c03640822808499631fcca5a643932cc80452b43c",
+    "S": "0x5d6a304e408593a4a2532cdae20479dee095622dfef72b479413c3c73189ec4d",
+    "Index": 0,
+    "Account": "0x601bcBb7509214E5F2C7c28b058fAF694410ac0e",
+    "Proof": [
+      "0x1de8d291b43cd08a720bb00a3a25f3fbf9e1c6149e56ace6cb993ccdc29970ce",
+      "0xe4c1c2b22a0aa25a23884213c0ad8fc664673c581b0b509cba38938de1b48edf"
+    ]
+  }
+}

--- a/relayer/cmd/sync_beefy_commitment.go
+++ b/relayer/cmd/sync_beefy_commitment.go
@@ -24,6 +24,7 @@ func syncBeefyCommitmentCmd() *cobra.Command {
 	cmd.Flags().String("private-key-file", "", "The file from which to read the private key")
 	cmd.Flags().Uint64P("block-number", "b", 0, "Relay block number which contains a Parachain message")
 	cmd.MarkFlagRequired("block-number")
+	cmd.Flags().Bool("export-json", false, "Export Json")
 	return cmd
 }
 
@@ -54,11 +55,16 @@ func SyncBeefyCommitmentFn(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	generateLog, err := cmd.Flags().GetBool("export-json")
+	if err != nil {
+		return err
+	}
+
 	relay, err := beefy.NewRelay(&config, keypair)
 	if err != nil {
 		return err
 	}
 	blockNumber, _ := cmd.Flags().GetUint64("block-number")
-	err = relay.OneShotSync(ctx, blockNumber)
+	err = relay.OneShotSync(ctx, blockNumber, generateLog)
 	return err
 }

--- a/relayer/relays/beefy/ethereum-writer.go
+++ b/relayer/relays/beefy/ethereum-writer.go
@@ -206,6 +206,13 @@ func (wr *EthereumWriter) doSubmitInitial(ctx context.Context, task *Request) (*
 		return nil, nil, err
 	}
 
+	if task.GenerateLog {
+		err = wr.generateSubmitInitial(msg)
+		if err != nil {
+			log.Warn(fmt.Errorf("Generate submitInitial: %w", err))
+		}
+	}
+
 	var tx *types.Transaction
 	tx, err = wr.contract.SubmitInitial(
 		wr.conn.MakeTxOpts(ctx),
@@ -257,6 +264,13 @@ func (wr *EthereumWriter) doSubmitFinal(ctx context.Context, commitmentHash [32]
 	logFields, err := wr.makeSubmitFinalLogFields(task, params)
 	if err != nil {
 		return nil, fmt.Errorf("logging params: %w", err)
+	}
+
+	if task.GenerateLog {
+		err = wr.generateSubmitFinal(params)
+		if err != nil {
+			log.Warn(fmt.Errorf("Generate submitFinal: %w", err))
+		}
 	}
 
 	tx, err := wr.contract.SubmitFinal(

--- a/relayer/relays/beefy/fixture-data-logger.go
+++ b/relayer/relays/beefy/fixture-data-logger.go
@@ -4,6 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	gsrpcTypes "github.com/snowfork/go-substrate-rpc-client/v4/types"
 	"github.com/snowfork/snowbridge/relayer/crypto/keccak"
+	"github.com/snowfork/snowbridge/relayer/relays/util"
 )
 
 func Hex(b []byte) string {
@@ -51,4 +52,17 @@ func (wr *EthereumWriter) makeSubmitFinalLogFields(
 	}
 
 	return fields, nil
+}
+
+func (wr *EthereumWriter) generateSubmitInitial(
+	task *InitialRequestParams,
+) error {
+	jsonTask := task.ToJSON()
+	return util.WriteJSONToFile(jsonTask, "contracts/test/data/initial-commitment.json")
+}
+
+func (wr *EthereumWriter) generateSubmitFinal(
+	task *FinalRequestParams,
+) error {
+	return util.WriteJSONToFile(*task, "contracts/test/data/final-commitment.json")
 }

--- a/relayer/relays/beefy/json/types.go
+++ b/relayer/relays/beefy/json/types.go
@@ -1,0 +1,31 @@
+package json
+
+import (
+	"math/big"
+)
+
+type InitialRequestJsonParams struct {
+	Commitment BeefyClientCommitment
+	Bitfield   []*big.Int
+	Proof      BeefyClientValidatorProof
+}
+
+type BeefyClientCommitment struct {
+	BlockNumber    uint32
+	ValidatorSetID uint64
+	Payload        []BeefyClientPayloadItem
+}
+
+type BeefyClientPayloadItem struct {
+	PayloadID [2]byte
+	Data      string
+}
+
+type BeefyClientValidatorProof struct {
+	V       uint8
+	R       string
+	S       string
+	Index   uint64
+	Account string
+	Proof   []string
+}

--- a/relayer/relays/beefy/main.go
+++ b/relayer/relays/beefy/main.go
@@ -80,7 +80,7 @@ func (relay *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 	return nil
 }
 
-func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64) error {
+func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64, generateLog bool) error {
 	// Initialize relaychainConn
 	err := relay.relaychainConn.Connect(ctx)
 	if err != nil {
@@ -143,6 +143,7 @@ func (relay *Relay) OneShotSync(ctx context.Context, blockNumber uint64) error {
 	} else {
 		task.ValidatorsRoot = state.NextValidatorSetRoot
 	}
+	task.GenerateLog = generateLog
 	err = relay.ethereumWriter.submit(ctx, task)
 	if err != nil {
 		return fmt.Errorf("fail to submit beefy update: %w", err)

--- a/relayer/relays/beefy/parameters.go
+++ b/relayer/relays/beefy/parameters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/snowfork/snowbridge/relayer/contracts"
 	"github.com/snowfork/snowbridge/relayer/crypto/keccak"
 	"github.com/snowfork/snowbridge/relayer/crypto/merkle"
+	"github.com/snowfork/snowbridge/relayer/relays/beefy/json"
 	"github.com/snowfork/snowbridge/relayer/relays/util"
 	"golang.org/x/exp/slices"
 )
@@ -240,5 +241,21 @@ func proofToLog(proof contracts.BeefyClientValidatorProof) logrus.Fields {
 		"Index":   proof.Index.Uint64(),
 		"Account": proof.Account.Hex(),
 		"Proof":   hexProof,
+	}
+}
+
+func (p InitialRequestParams) ToJSON() json.InitialRequestJsonParams {
+	payloadItem := json.BeefyClientPayloadItem{PayloadID: p.Commitment.Payload[0].PayloadID, Data: "0x" + hex.EncodeToString(p.Commitment.Payload[0].Data)}
+
+	hexProof := make([]string, len(p.Proof.Proof))
+	for i, proof := range p.Proof.Proof {
+		hexProof[i] = Hex(proof[:])
+	}
+	proof := json.BeefyClientValidatorProof{V: p.Proof.V, R: Hex(p.Proof.R[:]), S: Hex(p.Proof.S[:]), Index: p.Proof.Index.Uint64(), Account: p.Proof.Account.Hex(), Proof: hexProof}
+
+	return json.InitialRequestJsonParams{
+		Commitment: json.BeefyClientCommitment{BlockNumber: p.Commitment.BlockNumber, ValidatorSetID: p.Commitment.ValidatorSetID, Payload: []json.BeefyClientPayloadItem{payloadItem}},
+		Bitfield:   p.Bitfield,
+		Proof:      proof,
 	}
 }

--- a/relayer/relays/beefy/task.go
+++ b/relayer/relays/beefy/task.go
@@ -21,4 +21,5 @@ type Request struct {
 	ValidatorsRoot   [32]byte
 	SignedCommitment types.SignedCommitment
 	Proof            merkle.SimplifiedMMRProof
+	GenerateLog      bool
 }

--- a/relayer/relays/util/util.go
+++ b/relayer/relays/util/util.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -177,4 +179,24 @@ func ByteArrayToPublicKeyArray(pubkeys [][]byte) ([][48]byte, error) {
 		result = append(result, tmpPubkey)
 	}
 	return result, nil
+}
+
+func WriteJSONToFile(data interface{}, path string) error {
+	file, _ := json.MarshalIndent(data, "", "  ")
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+
+	defer f.Close()
+
+	_, err = f.Write(file)
+
+	if err != nil {
+		return fmt.Errorf("write to file: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Context 

Currently the beefy test fixture is some mock data and it's challenging to generate the data. Since beefy is already enabled on polkadot,  seems make more sense to just use the data from production.

Another use case is to test the compatibility with `polkadot-sdk`, after updating from upperstream repo we make an E2E test, if syncing beefy still works then it should be fine for the upgrade.

Resolves: https://linear.app/snowfork/issue/SNO-1057