### PR TITLE
API Release 0.1.14

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/environment.ts
+++ b/web/packages/api/src/environment.ts
@@ -1,9 +1,9 @@
 export type Config = {
     BEACON_HTTP_API: string
-    ETHEREUM_WS_API: (secret: string) => string
-    RELAY_CHAIN_WS_URL: string
-    ASSET_HUB_WS_URL: string
-    BRIDGE_HUB_WS_URL: string
+    ETHEREUM_API: (secret: string) => string
+    RELAY_CHAIN_URL: string
+    ASSET_HUB_URL: string
+    BRIDGE_HUB_URL: string
     GATEWAY_CONTRACT: string
     BEEFY_CONTRACT: string
     ASSET_HUB_PARAID: number
@@ -113,10 +113,10 @@ export const SNOWBRIDGE_ENV: { [id: string]: SnowbridgeEnvironment } = {
         ],
         config: {
             BEACON_HTTP_API: "http://127.0.0.1:9596",
-            ETHEREUM_WS_API: () => "ws://127.0.0.1:8546",
-            RELAY_CHAIN_WS_URL: "ws://127.0.0.1:9944",
-            ASSET_HUB_WS_URL: "ws://127.0.0.1:12144",
-            BRIDGE_HUB_WS_URL: "ws://127.0.0.1:11144",
+            ETHEREUM_API: () => "ws://127.0.0.1:8546",
+            RELAY_CHAIN_URL: "ws://127.0.0.1:9944",
+            ASSET_HUB_URL: "ws://127.0.0.1:12144",
+            BRIDGE_HUB_URL: "ws://127.0.0.1:11144",
             PARACHAINS: ["ws://127.0.0.1:13144"],
             GATEWAY_CONTRACT: "0xEDa338E4dC46038493b885327842fD3E301CaB39",
             BEEFY_CONTRACT: "0x992B9df075935E522EC7950F37eC8557e86f6fdb",
@@ -252,11 +252,11 @@ export const SNOWBRIDGE_ENV: { [id: string]: SnowbridgeEnvironment } = {
         ],
         config: {
             BEACON_HTTP_API: "https://lodestar-sepolia.chainsafe.io",
-            ETHEREUM_WS_API: (key) => `https://eth-sepolia.g.alchemy.com/v2/${key}`,
-            RELAY_CHAIN_WS_URL: "wss://rococo-rpc.polkadot.io",
-            ASSET_HUB_WS_URL: "wss://rococo-asset-hub-rpc.polkadot.io",
-            BRIDGE_HUB_WS_URL: "wss://rococo-bridge-hub-rpc.polkadot.io",
-            PARACHAINS: ["wss://rococo-muse-rpc.polkadot.io"],
+            ETHEREUM_API: (key) => `https://eth-sepolia.g.alchemy.com/v2/${key}`,
+            RELAY_CHAIN_URL: "https://rococo-rpc.polkadot.io",
+            ASSET_HUB_URL: "https://rococo-asset-hub-rpc.polkadot.io",
+            BRIDGE_HUB_URL: "https://rococo-bridge-hub-rpc.polkadot.io",
+            PARACHAINS: ["https://rococo-muse-rpc.polkadot.io"],
             GATEWAY_CONTRACT: "0x5b4909ce6ca82d2ce23bd46738953c7959e710cd",
             BEEFY_CONTRACT: "0x27e5e17ac995d3d720c311e1e9560e28f5855fb1",
             ASSET_HUB_PARAID: 1000,
@@ -426,11 +426,11 @@ export const SNOWBRIDGE_ENV: { [id: string]: SnowbridgeEnvironment } = {
         ],
         config: {
             BEACON_HTTP_API: "https://lodestar-mainnet.chainsafe.io",
-            ETHEREUM_WS_API: (key) => `https://eth-mainnet.g.alchemy.com/v2/${key}`,
-            RELAY_CHAIN_WS_URL: "wss://polkadot-rpc.dwellir.com",
-            ASSET_HUB_WS_URL: "wss://asset-hub-polkadot-rpc.dwellir.com",
-            BRIDGE_HUB_WS_URL: "wss://bridge-hub-polkadot-rpc.dwellir.com",
-            PARACHAINS: ["wss://polkadot-mythos-rpc.polkadot.io"],
+            ETHEREUM_API: (key) => `https://eth-mainnet.g.alchemy.com/v2/${key}`,
+            RELAY_CHAIN_URL: "https://polkadot-rpc.dwellir.com",
+            ASSET_HUB_URL: "https://asset-hub-polkadot-rpc.dwellir.com",
+            BRIDGE_HUB_URL: "https://bridge-hub-polkadot-rpc.dwellir.com",
+            PARACHAINS: ["https://polkadot-mythos-rpc.polkadot.io"],
             GATEWAY_CONTRACT: "0x27ca963c279c93801941e1eb8799c23f407d68e7",
             BEEFY_CONTRACT: "0x6eD05bAa904df3DE117EcFa638d4CB84e1B8A00C",
             ASSET_HUB_PARAID: 1000,

--- a/web/packages/api/src/index.ts
+++ b/web/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 // import '@polkadot/api-augment/polkadot'
-import { ApiPromise, WsProvider } from "@polkadot/api"
+import { ApiPromise, HttpProvider, WsProvider } from "@polkadot/api"
 import { AbstractProvider, JsonRpcProvider, WebSocketProvider } from "ethers"
 import {
     BeefyClient,
@@ -97,13 +97,13 @@ export const contextFactory = async (config: Config): Promise<Context> => {
 
     const [relaychainApi, assetHubApi, bridgeHubApi] = await Promise.all([
         ApiPromise.create({
-            provider: new WsProvider(config.polkadot.url.relaychain),
+            provider: config.polkadot.url.relaychain.startsWith("http") ? new HttpProvider(config.polkadot.url.relaychain) : new WsProvider(config.polkadot.url.relaychain),
         }),
         ApiPromise.create({
-            provider: new WsProvider(config.polkadot.url.assetHub),
+            provider: config.polkadot.url.assetHub.startsWith("http") ? new HttpProvider(config.polkadot.url.assetHub) : new WsProvider(config.polkadot.url.assetHub),
         }),
         ApiPromise.create({
-            provider: new WsProvider(config.polkadot.url.bridgeHub),
+            provider: config.polkadot.url.bridgeHub.startsWith("http") ? new HttpProvider(config.polkadot.url.bridgeHub) : new WsProvider(config.polkadot.url.bridgeHub),
         }),
     ])
 
@@ -136,7 +136,7 @@ export const contextFactory = async (config: Config): Promise<Context> => {
 
 export const addParachainConnection = async (url: string) => {
     const api = await ApiPromise.create({
-        provider: new WsProvider(url),
+        provider: url.startsWith("http") ? new HttpProvider(url) : new WsProvider(url),
     })
     const paraId = (await api.query.parachainInfo.parachainId()).toPrimitive() as number
     console.log(`${url} added with parachain id: ${paraId}`)

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/operations/src/global_transfer_history.ts
+++ b/web/packages/operations/src/global_transfer_history.ts
@@ -25,9 +25,9 @@ const monitor = async () => {
         },
         polkadot: {
             url: {
-                bridgeHub: config.BRIDGE_HUB_WS_URL,
-                assetHub: config.ASSET_HUB_WS_URL,
-                relaychain: config.RELAY_CHAIN_WS_URL,
+                bridgeHub: config.BRIDGE_HUB_URL,
+                assetHub: config.ASSET_HUB_URL,
+                relaychain: config.RELAY_CHAIN_URL,
                 parachains: config.PARACHAINS,
             },
         },

--- a/web/packages/operations/src/monitor.ts
+++ b/web/packages/operations/src/monitor.ts
@@ -19,14 +19,14 @@ export const monitor = async (): Promise<status.AllMetrics> => {
 
     const context = await contextFactory({
         ethereum: {
-            execution_url: config.ETHEREUM_WS_API(infuraKey),
+            execution_url: config.ETHEREUM_API(infuraKey),
             beacon_url: config.BEACON_HTTP_API,
         },
         polkadot: {
             url: {
-                bridgeHub: config.BRIDGE_HUB_WS_URL,
-                assetHub: config.ASSET_HUB_WS_URL,
-                relaychain: config.RELAY_CHAIN_WS_URL,
+                bridgeHub: 'https://rococo-bridge-hub-rpc.polkadot.io', //config.BRIDGE_HUB_URL,
+                assetHub: 'https://rococo-asset-hub-rpc.polkadot.io', //config.ASSET_HUB_URL,
+                relaychain: 'https://rococo-rpc.polkadot.io', //config.RELAY_CHAIN_URL,
             },
         },
         appContracts: {

--- a/web/packages/operations/src/transfer_token.ts
+++ b/web/packages/operations/src/transfer_token.ts
@@ -22,14 +22,14 @@ const monitor = async () => {
 
     const context = await contextFactory({
         ethereum: {
-            execution_url: config.ETHEREUM_WS_API(process.env.REACT_APP_INFURA_KEY || ""),
+            execution_url: config.ETHEREUM_API(process.env.REACT_APP_INFURA_KEY || ""),
             beacon_url: config.BEACON_HTTP_API,
         },
         polkadot: {
             url: {
-                bridgeHub: config.BRIDGE_HUB_WS_URL,
-                assetHub: config.ASSET_HUB_WS_URL,
-                relaychain: config.RELAY_CHAIN_WS_URL,
+                bridgeHub: config.BRIDGE_HUB_URL,
+                assetHub: config.ASSET_HUB_URL,
+                relaychain: config.RELAY_CHAIN_URL,
                 parachains: config.PARACHAINS,
             },
         },


### PR DESCRIPTION
* Veriable naming house keeping.
* Allow using HTTP provider instead of websockets.
* Using HTTP instead of websockets by default for rococo and polkadot environements.