### PR TITLE
Handle beacon state unavailable error

### DIFF
--- a/relayer/relays/beacon/header/header.go
+++ b/relayer/relays/beacon/header/header.go
@@ -102,8 +102,8 @@ func (h *Header) Sync(ctx context.Context, eg *errgroup.Group) error {
 				log.WithFields(logFields).WithError(err).Warn("SyncCommittee latency found")
 			case errors.Is(err, ErrExecutionHeaderNotImported):
 				log.WithFields(logFields).WithError(err).Warn("ExecutionHeader not imported")
-			case errors.Is(err, syncer.ErrBeaconStateAvailableYet):
-				log.WithFields(logFields).WithError(err).Warn("beacon state not available for finalized state yet")
+			case errors.Is(err, syncer.ErrBeaconStateUnavailable):
+				log.WithFields(logFields).WithError(err).Warn("beacon state not available yet")
 			case err != nil:
 				return err
 			}
@@ -427,7 +427,7 @@ func (h *Header) populateFinalizedCheckpoint(slot uint64) error {
 	}
 
 	blockRootsProof, err := h.syncer.GetBlockRoots(slot)
-	if err != nil && !errors.Is(err, syncer.ErrBeaconStateAvailableYet) {
+	if err != nil && !errors.Is(err, syncer.ErrBeaconStateUnavailable) {
 		return fmt.Errorf("fetch block roots for slot %d: %w", slot, err)
 	}
 

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	ErrCommitteeUpdateHeaderInDifferentSyncPeriod = errors.New("sync committee in different sync period")
-	ErrBeaconStateAvailableYet                    = errors.New("beacon state object not available yet")
+	ErrBeaconStateUnavailable                     = errors.New("beacon state object not available yet")
 )
 
 type Syncer struct {
@@ -943,7 +943,7 @@ func (s *Syncer) getBeaconState(slot uint64) ([]byte, error) {
 	if err != nil {
 		data, err = s.store.GetBeaconStateData(slot)
 		if err != nil {
-			return nil, fmt.Errorf("fetch beacon state from store: %w", err)
+			return nil, ErrBeaconStateUnavailable
 		}
 	}
 	return data, nil

--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -939,11 +939,17 @@ func (s *Syncer) getBestMatchBeaconDataFromStore(minSlot, maxSlot uint64) (final
 }
 
 func (s *Syncer) getBeaconState(slot uint64) ([]byte, error) {
-	data, err := s.Client.GetBeaconState(strconv.FormatUint(slot, 10))
-	if err != nil {
-		data, err = s.store.GetBeaconStateData(slot)
-		if err != nil {
+	data, apiErr := s.Client.GetBeaconState(strconv.FormatUint(slot, 10))
+	if apiErr != nil {
+		var storeErr error
+		data, storeErr = s.store.GetBeaconStateData(slot)
+		// If the API returns a 404 (not a server error), treat it as a temporary error.
+		if storeErr != nil && errors.Is(apiErr, api.ErrNotFound) {
 			return nil, ErrBeaconStateUnavailable
+		} else if storeErr != nil {
+			// Otherwise if the API returns an unexpected error and the state cannot be found in the store, treat it
+			// as an error.
+			return nil, fmt.Errorf("fetch beacon state from api (%w) and store (%w) failed", apiErr, storeErr)
 		}
 	}
 	return data, nil

--- a/relayer/relays/beacon/header/syncer/syncer_test.go
+++ b/relayer/relays/beacon/header/syncer/syncer_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -253,4 +254,40 @@ func TestFindAttestedAndFinalizedHeadersAtBoundary(t *testing.T) {
 
 	attested, err = syncer.FindValidAttestedHeader(32540, 32768)
 	assert.Error(t, err)
+}
+
+func TestGetBeaconState(t *testing.T) {
+	mockAPI := mock.API{}
+	mockStore := mock.Store{}
+
+	syncer := New(&mockAPI, &mockStore, protocol.New(config.SpecSettings{
+		SlotsInEpoch:                 32,
+		EpochsPerSyncCommitteePeriod: 256,
+		DenebForkEpoch:               0,
+	}))
+
+	// Unexpected error
+	mockAPI.ReturnBeaconStateError = errors.New("some error")
+	_, err := syncer.getBeaconState(8160)
+	require.Error(t, err)
+
+	// Beacon state not found in API
+	mockAPI.ReturnBeaconStateError = api.ErrNotFound
+	_, err = syncer.getBeaconState(8160)
+	require.ErrorIs(t, err, ErrBeaconStateUnavailable)
+
+	// Beacon state found in API
+	mockAPI.BeaconStates = map[uint64]bool{4570752: true}
+	mockAPI.ReturnBeaconStateError = nil
+	_, err = syncer.getBeaconState(4570752)
+	require.NoError(t, err)
+
+	// Beacon state found in Store
+	mockAPI.BeaconStates = map[uint64]bool{}
+	mockAPI.ReturnBeaconStateError = api.ErrNotFound
+	beaconData, err := testutil.LoadFile("4570752.ssz")
+	require.NoError(t, err)
+	mockStore.BeaconStateData = map[uint64][]byte{4570752: beaconData}
+	_, err = syncer.getBeaconState(4570752)
+	require.NoError(t, err)
 }

--- a/relayer/relays/beacon/mock/mock_api.go
+++ b/relayer/relays/beacon/mock/mock_api.go
@@ -15,6 +15,7 @@ type API struct {
 	BlocksAtSlot                      map[uint64]api.BeaconBlockResponse
 	Header                            map[common.Hash]api.BeaconHeader
 	BeaconStates                      map[uint64]bool
+	ReturnBeaconStateError            error
 }
 
 func (m *API) GetHeaderAtHead() (api.BeaconHeader, error) {
@@ -77,7 +78,7 @@ func (m *API) GetBeaconState(stateIdOrSlot string) ([]byte, error) {
 
 	_, ok := m.BeaconStates[slot]
 	if !ok {
-		return nil, api.ErrNotFound
+		return nil, m.ReturnBeaconStateError
 	}
 
 	data, err := testutil.LoadFile(stateIdOrSlot + ".ssz")


### PR DESCRIPTION
When the beacon API returns a 404 when retrieving a beacon state, treat it as a temporary error and wait for a while to try again.

Resolves: [SNO-1062](https://linear.app/snowfork/issue/SNO-1062)