### PR TITLE
Handle beacon state download error

### DIFF
--- a/relayer/relays/beacon/header/syncer/syncer.go
+++ b/relayer/relays/beacon/header/syncer/syncer.go
@@ -943,13 +943,9 @@ func (s *Syncer) getBeaconState(slot uint64) ([]byte, error) {
 	if apiErr != nil {
 		var storeErr error
 		data, storeErr = s.store.GetBeaconStateData(slot)
-		// If the API returns a 404 (not a server error), treat it as a temporary error.
-		if storeErr != nil && errors.Is(apiErr, api.ErrNotFound) {
+		if storeErr != nil {
+			log.WithFields(log.Fields{"apiError": apiErr, "storeErr": storeErr}).Warn("fetch beacon state from api and store failed")
 			return nil, ErrBeaconStateUnavailable
-		} else if storeErr != nil {
-			// Otherwise if the API returns an unexpected error and the state cannot be found in the store, treat it
-			// as an error.
-			return nil, fmt.Errorf("fetch beacon state from api (%w) and store (%w) failed", apiErr, storeErr)
 		}
 	}
 	return data, nil

--- a/relayer/relays/beacon/header/syncer/syncer_test.go
+++ b/relayer/relays/beacon/header/syncer/syncer_test.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -266,14 +265,9 @@ func TestGetBeaconState(t *testing.T) {
 		DenebForkEpoch:               0,
 	}))
 
-	// Unexpected error
-	mockAPI.ReturnBeaconStateError = errors.New("some error")
-	_, err := syncer.getBeaconState(8160)
-	require.Error(t, err)
-
 	// Beacon state not found in API
 	mockAPI.ReturnBeaconStateError = api.ErrNotFound
-	_, err = syncer.getBeaconState(8160)
+	_, err := syncer.getBeaconState(8160)
 	require.ErrorIs(t, err, ErrBeaconStateUnavailable)
 
 	// Beacon state found in API


### PR DESCRIPTION
The `REGEN_ERROR_NO_SEED_STATE` Lodestar log error may be returning a `500` instead of a `404`, which means https://github.com/Snowfork/snowbridge/pull/1241 will not work, so I need to catch all beacon state download errors.