### PR TITLE
Fix Ethereum relayer paging bug

### DIFF
--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -141,12 +141,6 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 				return fmt.Errorf("find events: %w", err)
 			}
 
-			log.WithFields(log.Fields{"blockNumber": blockNumber, "startNonce": paraNonce + 1}).Info("event query options")
-
-			for _, checkEv := range events {
-				log.WithFields(log.Fields{"msgNonce": checkEv.Nonce, "blockNumber": checkEv.Raw.BlockNumber}).Info("found event with nonce")
-			}
-
 			for _, ev := range events {
 				inboundMsg, err := r.makeInboundMessage(ctx, headerCache, ev)
 				if err != nil {

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -144,7 +144,7 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 			log.WithFields(log.Fields{"blockNumber": blockNumber, "startNonce": paraNonce + 1}).Info("event query options")
 
 			for _, checkEv := range events {
-				log.WithFields(log.Fields{"msgNonce": checkEv.Nonce}).Info("found event with nonce")
+				log.WithFields(log.Fields{"msgNonce": checkEv.Nonce, "blockNumber": checkEv.Raw.BlockNumber}).Info("found event with nonce")
 			}
 
 			for _, ev := range events {
@@ -300,6 +300,8 @@ func (r *Relay) findEvents(
 			Context: ctx,
 		}
 
+		log.WithFields(log.Fields{"begin": begin, "end": blockNumber, "BlocksPerQuery": BlocksPerQuery}).Info("looping through events")
+
 		done, events, err := r.findEventsWithFilter(&opts, channelID, start)
 		if err != nil {
 			return nil, fmt.Errorf("filter events: %w", err)
@@ -316,9 +318,21 @@ func (r *Relay) findEvents(
 		}
 	}
 
+	eventsBeforeSort := []uint64{}
+	for _, checkEv := range allEvents {
+		eventsBeforeSort = append(eventsBeforeSort, checkEv.Nonce)
+	}
+	log.WithFields(log.Fields{"eventsBeforeSort": eventsBeforeSort}).Info("events before sort")
+
 	sort.SliceStable(allEvents, func(i, j int) bool {
 		return allEvents[i].Nonce < allEvents[j].Nonce
 	})
+
+	eventsAfterSort := []uint64{}
+	for _, checkEv := range allEvents {
+		eventsAfterSort = append(eventsAfterSort, checkEv.Nonce)
+	}
+	log.WithFields(log.Fields{"eventsAfterSort": eventsAfterSort}).Info("events after sort")
 
 	return allEvents, nil
 }

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -141,6 +141,12 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 				return fmt.Errorf("find events: %w", err)
 			}
 
+			log.WithFields(log.Fields{"blockNumber": blockNumber, "startNonce": paraNonce + 1}).Info("event query options")
+
+			for _, checkEv := range events {
+				log.WithFields(log.Fields{"msgNonce": checkEv.Nonce}).Info("found event with nonce")
+			}
+
 			for _, ev := range events {
 				inboundMsg, err := r.makeInboundMessage(ctx, headerCache, ev)
 				if err != nil {


### PR DESCRIPTION
The last iteration of filtering Ethereum events was breaking out of the iterator prematurely. 

### Illustration:
**Event page size:** 4
**Parachain:** 9
**Ethereum nonce:** 16

**Iterate through events:** Nonces 16, 15, 14, 13 events successfully retrieved
**Iterate through events:** Last page, found nonce 10. Skips nonce 11, 12.

Changed the code to only break once no more items have been found. Marks the last page when the start nonce is found.

More evidence from logs added (gap between nonce 211 and 234):
```
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.83406722Z","blockNumber":6183828,"level":"info","message":"found event with nonce","msgNonce":211}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.834077199Z","blockNumber":6185781,"level":"info","message":"found event with nonce","msgNonce":234}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.834083379Z","blockNumber":6185820,"level":"info","message":"found event with nonce","msgNonce":235}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.83408975Z","blockNumber":6185860,"level":"info","message":"found event with nonce","msgNonce":236}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.834096147Z","blockNumber":6188931,"level":"info","message":"found event with nonce","msgNonce":237}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.834104723Z","blockNumber":6189168,"level":"info","message":"found event with nonce","msgNonce":238}
Jun 27 13:09:49 ip-172-31-41-212 start-execution-relayer.sh[3948065]: {"@timestamp":"2024-06-27T13:09:49.834123017Z","blockNumber":6189220,"level":"info","message":"found event with nonce","msgNonce":239}
```