### PR TITLE
Halt bridge commands

### DIFF
--- a/control/preimage/src/main.rs
+++ b/control/preimage/src/main.rs
@@ -340,7 +340,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 && !params.inbound_queue
                 && !params.outbound_queue
                 && !params.ethereum_client
-                && !params.assethub_max_price
+                && !params.assethub_max_fee
             {
                 halt_all = true;
             }


### PR DESCRIPTION
Command to halt the bridge. Bridge can be halted in its entirety:

```
cargo run --bin snowbridge-preimage -- --bridge-hub-api wss://polkadot-bridge-hub-rpc.polkadot.io --asset-hub-api wss://polkadot-asset-hub-rpc.polkadot.io halt-bridge --all
```
Leaving out the `-all` flag will also halt the whole bridge:
```
cargo run --bin snowbridge-preimage -- --bridge-hub-api wss://polkadot-bridge-hub-rpc.polkadot.io --asset-hub-api wss://polkadot-asset-hub-rpc.polkadot.io halt-bridge
```

Or specify individual parts to halt:
```
cargo run --bin snowbridge-preimage -- --bridge-hub-api wss://polkadot-bridge-hub-rpc.polkadot.io --asset-hub-api wss://polkadot-asset-hub-rpc.polkadot.io halt-bridge --inbound-queue --ethereum-client
```

Options:
- `--all`
- `--inbound-queue`
- `--outbound-queue`
- `--gateway`
- `--ethereum-client`
- `--assethub-max-fee`

Resolves: [SNO-1054](https://linear.app/snowfork/issue/SNO-1054)