### PR TITLE
Update gsrpc

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0
+	github.com/snowfork/go-substrate-rpc-client/v4 v4.1.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/snowfork/go-substrate-rpc-client/v4 v4.0.1-0.20240523155545-4272098ec025
+	github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -273,6 +273,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/snowfork/go-substrate-rpc-client/v4 v4.0.1-0.20240523155545-4272098ec025 h1:67zKmOHCBWg+u1uDpkVHcfTngmRIRi45gUOOZVM/pGA=
 github.com/snowfork/go-substrate-rpc-client/v4 v4.0.1-0.20240523155545-4272098ec025/go.mod h1:MVk5+w9icYU7MViYFm7CKYhx1VMj6DpN2tWO6s4OK5g=
+github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0 h1:n7bsglvPt/FjRIcE4840hFiH4yHI78uIZIYLCwagvRs=
+github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0/go.mod h1:g0ocyVfq0Auj9uXVrBcDHsKudQw6LbEtACpPCHmJXQg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -271,10 +271,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/snowfork/go-substrate-rpc-client/v4 v4.0.1-0.20240523155545-4272098ec025 h1:67zKmOHCBWg+u1uDpkVHcfTngmRIRi45gUOOZVM/pGA=
-github.com/snowfork/go-substrate-rpc-client/v4 v4.0.1-0.20240523155545-4272098ec025/go.mod h1:MVk5+w9icYU7MViYFm7CKYhx1VMj6DpN2tWO6s4OK5g=
-github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0 h1:n7bsglvPt/FjRIcE4840hFiH4yHI78uIZIYLCwagvRs=
-github.com/snowfork/go-substrate-rpc-client/v4 v4.1.0/go.mod h1:g0ocyVfq0Auj9uXVrBcDHsKudQw6LbEtACpPCHmJXQg=
+github.com/snowfork/go-substrate-rpc-client/v4 v4.1.1 h1:FpmT19KcJtfRSd5D0+Kul+1oGZ5VnX7AxA2mY+qQOl4=
+github.com/snowfork/go-substrate-rpc-client/v4 v4.1.1/go.mod h1:Olz9N3te1X6+LKSlrpYEgpvTmZIJ7f4Xhj0W8pApIwE=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=


### PR DESCRIPTION
Updates our gsrpc fork with CheckMetadataHash support. Copied from https://github.com/centrifuge/go-substrate-rpc-client/pull/387.