### PR TITLE
Add heartbeat for gsrpc connection

### DIFF
--- a/relayer/chain/parachain/connection.go
+++ b/relayer/chain/parachain/connection.go
@@ -5,6 +5,7 @@ package parachain
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -64,10 +65,38 @@ func (co *Connection) Connect(_ context.Context) error {
 	}
 	co.genesisHash = genesisHash
 
+
 	log.WithFields(logrus.Fields{
 		"endpoint":    co.endpoint,
 		"metaVersion": meta.Version,
 	}).Info("Connected to chain")
+
+	return nil
+}
+
+func (co *Connection) ConnectWithHeartBeat(ctx context.Context, heartBeat time.Duration) error {
+	err := co.Connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(heartBeat)
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, err := co.API().RPC.System.Version()
+				if err != nil {
+					log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
+					return
+				}
+			}
+		}
+	}()
 
 	return nil
 }

--- a/relayer/chain/parachain/connection.go
+++ b/relayer/chain/parachain/connection.go
@@ -65,7 +65,6 @@ func (co *Connection) Connect(_ context.Context) error {
 	}
 	co.genesisHash = genesisHash
 
-
 	log.WithFields(logrus.Fields{
 		"endpoint":    co.endpoint,
 		"metaVersion": meta.Version,

--- a/relayer/relays/beacon/main.go
+++ b/relayer/relays/beacon/main.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"time"
 
 	"github.com/snowfork/snowbridge/relayer/chain/parachain"
 	"github.com/snowfork/snowbridge/relayer/crypto/sr25519"
@@ -36,7 +37,7 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	paraconn := parachain.NewConnection(r.config.Sink.Parachain.Endpoint, r.keypair.AsKeyringPair())
 
-	err := paraconn.Connect(ctx)
+	err := paraconn.ConnectWithHeartBeat(ctx, 60 * time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The heartbeat simply calls the `system_version` RPC method every 60s.


Fixes: SNO-1082