### PR TITLE
Fix to Ethereum stale alarm

### DIFF
--- a/web/packages/operations/src/alarm.ts
+++ b/web/packages/operations/src/alarm.ts
@@ -112,9 +112,8 @@ export const sendMetrics = async (metrics: status.AllMetrics) => {
         metricData.push({
             MetricName: AlarmReason.ToEthereumChannelStale.toString(),
             Value: Number(
-                channel.toEthereum.outbound < channel.toEthereum.inbound ||
-                    (channel.toEthereum.outbound > channel.toEthereum.inbound &&
-                        channel.toEthereum.inbound <= channel.toEthereum.previousInbound)
+                channel.toEthereum.outbound < channel.toEthereum.inbound &&
+                    channel.toEthereum.inbound <= channel.toEthereum.previousInbound
             ),
         })
         metricData.push({


### PR DESCRIPTION
There has been a few cases where the ToEthereumChannelStale alarm raises false positives.

Resolves: [SNO-1151)](https://linear.app/snowfork/issue/SNO-1151)