### PR TITLE
Fix mmr generation

### DIFF
--- a/relayer/cmd/parachain_head_proof.go
+++ b/relayer/cmd/parachain_head_proof.go
@@ -123,9 +123,7 @@ func ParachainHeadProofFn(cmd *cobra.Command, _ []string) error {
 			"mmr":         mmrProof.Leaf.ParachainHeads.Hex(),
 		}).Warn("MMR parachain merkle root does not match calculated merkle root. Filtering out parachain heads.")
 
-		log.WithField("heads", len(paraHeadsAsSlice)).Info("here")
 		paraHeadsAsSlice, err = conn.FilterParachainHeads(paraHeadsAsSlice, relayChainBlockHash)
-		log.WithField("heads", len(paraHeadsAsSlice)).Info("here")
 		if err != nil {
 			log.WithError(err).Fatal("Filtering out parachain heads failed.")
 		}

--- a/relayer/relays/parachain/beefy-listener.go
+++ b/relayer/relays/parachain/beefy-listener.go
@@ -297,8 +297,8 @@ func (li *BeefyListener) generateAndValidateParasHeadsMerkleProof(input *ProofIn
 
 	// Try a filtering out parathreads
 	log.WithFields(log.Fields{
-		"beefyBlock": merkleProofData.Root.Hex(),
-		"leafIndex":  mmrProof.Leaf.ParachainHeads.Hex(),
+		"computedMmr": merkleProofData.Root.Hex(),
+		"mmr":         mmrProof.Leaf.ParachainHeads.Hex(),
 	}).Warn("MMR parachain merkle root does not match calculated merkle root. Trying to filtering out parathreads.")
 
 	paraHeads, err = li.relaychainConn.FilterParachainHeads(paraHeads, input.RelayBlockHash)
@@ -306,6 +306,7 @@ func (li *BeefyListener) generateAndValidateParasHeadsMerkleProof(input *ProofIn
 		return nil, paraHeads, fmt.Errorf("could not filter out parathreads: %w", err)
 	}
 
+	numParas = min(MaxParaHeads, len(paraHeads))
 	merkleProofData, err = CreateParachainMerkleProof(paraHeads[:numParas], input.ParaID)
 	if err != nil {
 		return nil, paraHeads, fmt.Errorf("create parachain header proof: %w", err)


### PR DESCRIPTION
The slice length changes after filtering parathreads.

Test old mmr format without parathreads included:
```console
./build/snowbridge-relay parachain-head-proof \
  --url wss://api-polkadot.dwellir.com/$DWELLIR_API_KEY \
  --beefy-block-hash 495ed6c915cb88a975a577005bb3e5cf7a415797de2088316f5e1cd3d795fe91 \
  --relaychain-block 22890956 \
  --parachain-id 1000
```

Test new mmr format with parathreads included:
```console
./build/snowbridge-relay parachain-head-proof \
  --url wss://api-westend.dwellir.com/$DWELLIR_API_KEY \
  --beefy-block-hash 6f117b7950151ea125ed32833efefb14a29eb931664ac57a2dbb6f3ecf6dbffe \
  --relaychain-block 22910330 \
  --parachain-id 1000
```

Commands will exit with 0 exit code if successful.