### PR TITLE
Audit 10: Remove Duplicate Fee Function

### DIFF
--- a/contracts/src/Assets.sol
+++ b/contracts/src/Assets.sol
@@ -194,36 +194,6 @@ library Assets {
         emit IGateway.TokenSent(token, sender, destinationChain, destinationAddress, amount);
     }
 
-    function _sendForeignTokenCosts(
-        ParaID destinationChain,
-        uint128 destinationChainFee,
-        uint128 maxDestinationChainFee
-    ) internal view returns (Costs memory costs) {
-        AssetsStorage.Layout storage $ = AssetsStorage.layout();
-        if ($.assetHubParaID == destinationChain) {
-            costs.foreign = $.assetHubReserveTransferFee;
-        } else {
-            // Reduce the ability for users to perform arbitrage by exploiting a
-            // favourable exchange rate. For example supplying Ether
-            // and gaining a more valuable amount of DOT on the destination chain.
-            //
-            // Also prevents users from mistakenly sending more fees than would be required
-            // which has negative effects like draining AssetHub's sovereign account.
-            //
-            // For safety, `maxDestinationChainFee` should be less valuable
-            // than the gas cost to send tokens.
-            if (destinationChainFee > maxDestinationChainFee) {
-                revert InvalidDestinationFee();
-            }
-
-            // If the final destination chain is not AssetHub, then the fee needs to additionally
-            // include the cost of executing an XCM on the final destination parachain.
-            costs.foreign = $.assetHubReserveTransferFee + destinationChainFee;
-        }
-        // We don't charge any extra fees beyond delivery costs
-        costs.native = 0;
-    }
-
     // @dev Transfer Polkadot-native tokens back to Polkadot
     function _sendForeignToken(
         bytes32 foreignID,
@@ -240,7 +210,7 @@ library Assets {
         Token(token).burn(sender, amount);
 
         ticket.dest = $.assetHubParaID;
-        ticket.costs = _sendForeignTokenCosts(destinationChain, destinationChainFee, maxDestinationChainFee);
+        ticket.costs = _sendTokenCosts(destinationChain, destinationChainFee, maxDestinationChainFee);
 
         // Construct a message payload
         if (destinationChain == $.assetHubParaID && destinationAddress.isAddress32()) {


### PR DESCRIPTION
`_sendTokenCosts` and `_sendForeignTokenCosts` do the exact same thing. We can just re-use `_sendTokenCosts`.

Resolves: SNO-1202