### PR TITLE
Fix closed connection

### DIFF
--- a/relayer/relays/parachain/main.go
+++ b/relayer/relays/parachain/main.go
@@ -86,7 +86,7 @@ func (relay *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 		return fmt.Errorf("unable to connect to ethereum: beefy: %w", err)
 	}
 
-	err = relay.relaychainConn.Connect(ctx)
+	err = relay.relaychainConn.ConnectWithHeartBeat(ctx, 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/relayer/relays/parachain/scanner.go
+++ b/relayer/relays/parachain/scanner.go
@@ -125,7 +125,7 @@ func (s *Scanner) findTasks(
 
 	err = s.gatherProofInputs(tasks)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gather proof input: %w", err)
 	}
 
 	return tasks, nil

--- a/relayer/relays/parachain/scanner.go
+++ b/relayer/relays/parachain/scanner.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"reflect"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 
 	"github.com/snowfork/go-substrate-rpc-client/v4/scale"
 
@@ -122,7 +123,10 @@ func (s *Scanner) findTasks(
 		return nil, err
 	}
 
-	s.gatherProofInputs(tasks)
+	err = s.gatherProofInputs(tasks)
+	if err != nil {
+		return nil, err
+	}
 
 	return tasks, nil
 }


### PR DESCRIPTION
Resolve [failure](https://snowfork.slack.com/archives/C07BG558XE1/p1729756869201009) in westend-sepolica testnet with relaychain connection closed after a long scan.

```
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: {"@timestamp":"2024-10-24T06:59:18.410647515Z","level":"info","message":"waiting for nonce 38 to be picked up by another relayer"}
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: {"@timestamp":"2024-10-24T06:59:18.590903044Z","level":"info","message":"nonce 38 is not picked up by any one, submit anyway"}
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe7b1d0]
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: goroutine 79 [running]:
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: github.com/snowfork/snowbridge/relayer/relays/parachain.(*BeefyListener).generateProof(0xc0003b82d0, {0x1491900?, 0xc0003b8370?}, 0x0, 0xc000b61280)
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/projects/snowbridge-westend/relayer/relays/parachain/beefy-listener.go:239 +0x1b0
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: github.com/snowfork/snowbridge/relayer/relays/parachain.(*BeefyListener).waitAndSend(0xc0003b82d0, {0x1491900, 0xc0003b8370}, 0xc000721960, 0x0)
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/projects/snowbridge-westend/relayer/relays/parachain/beefy-listener.go:349 +0x22b
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: github.com/snowfork/snowbridge/relayer/relays/parachain.(*BeefyListener).doScan(0xc0003b82d0, {0x1491900, 0xc0003b8370}, 0x8c9f9797f5076c39?)
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/projects/snowbridge-westend/relayer/relays/parachain/beefy-listener.go:169 +0xfe
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: github.com/snowfork/snowbridge/relayer/relays/parachain.(*BeefyListener).Start.func1()
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/projects/snowbridge-westend/relayer/relays/parachain/beefy-listener.go:101 +0x119
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: golang.org/x/sync/errgroup.(*Group).Go.func1()
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]: created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
Oct 24 06:59:18 ip-172-31-41-212 start-asset-hub-parachain-relay.sh[2528854]:         /home/ubuntu/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
Oct 24 06:59:18 ip-172-31-41-212 systemd[1]: snowbridge-asset-hub-parachain-relay.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Oct 24 06:59:18 ip-172-31-41-212 systemd[1]: snowbridge-asset-hub-parachain-relay.service: Failed with result 'exit-code'.

```

Tested that after the fix the parachain relayer worked as expected.