### PR TITLE
Typo Update components.md

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -8,7 +8,7 @@ The system BridgeHub parachain hosts various bridges to other chains, including 
 
 This [pallet](https://github.com/Snowfork/snowbridge/tree/main/parachain/pallets/inbound-queue) is responsible for accepting inbound messages from Ethereum. This involves the following:
 
-1. Verifying that message[^1] that was included in the finalized Ethereum execution chain as tracked by our ethereum light client.
+1. Verifying that message[^1] was included in the finalized Ethereum execution chain as tracked by our ethereum light client.
 2. Converting the message to an [XCM](https://wiki.polkadot.network/docs/learn-xcm) script.
 3. Sending the XCM script to the destination parachain.
 


### PR DESCRIPTION

<img width="855" alt="Снимок экрана 2024-11-10 в 15 38 45" src="https://github.com/user-attachments/assets/ea3fd43a-a610-41ac-8a7d-9a7b93e44887">

The word "**that**" is unnecessary. Corrected version:

"Verifying the message[^1] was included in the finalized Ethereum execution chain as tracked by our Ethereum light client."

Fixed.