### PR TITLE
Fix rate limit check

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/subscan.ts
+++ b/web/packages/api/src/subscan.ts
@@ -51,11 +51,11 @@ export const createApi = (baseUrl: string, apiKey: string, options = { limit: 1 
         }
 
         if (rateLimit.remaining === 0 && rateLimit.retryAfter !== null && rateLimit.retryAfter > 0) {
-            console.log("Being rate limited", rateLimit)
+            console.log("Being rate limited: retryAfter", rateLimit)
             await sleepMs(rateLimit.retryAfter * 1000)
         }
         if (rateLimit.remaining === 0 && rateLimit.reset !== null && rateLimit.reset > 0) {
-            console.log("Being rate limited", rateLimit)
+            console.log("Being rate limited: reset", rateLimit)
             await sleepMs(rateLimit.reset * 1000)
         }
 

--- a/web/packages/api/src/subscan.ts
+++ b/web/packages/api/src/subscan.ts
@@ -50,7 +50,7 @@ export const createApi = (baseUrl: string, apiKey: string, options = { limit: 1 
             redirect: "follow",
         }
 
-        if (rateLimit.retryAfter !== null && rateLimit.retryAfter > 0) {
+        if (rateLimit.remaining === 0 && rateLimit.retryAfter !== null && rateLimit.retryAfter > 0) {
             console.log("Being rate limited", rateLimit)
             await sleepMs(rateLimit.retryAfter * 1000)
         }

--- a/web/packages/api/src/toEthereum.ts
+++ b/web/packages/api/src/toEthereum.ts
@@ -111,10 +111,6 @@ export const validateSend = async (
 ): Promise<SendValidationResult> => {
     const options = { ...ValidateOptionDefaults, ...validateOptions }
     const {
-        ethereum,
-        ethereum: {
-            contracts: { gateway },
-        },
         polkadot: {
             api: { assetHub, bridgeHub, relaychain, parachains },
         },
@@ -218,11 +214,8 @@ export const validateSend = async (
             message: "Asset balance insufficient for transfer.",
         })
 
-    const [bridgeStatus] = await Promise.all([
-        bridgeStatusInfo(context),
-        ethereum.api.getNetwork(),
-        gateway.isTokenRegistered(tokenAddress),
-    ])
+    const bridgeStatus = await bridgeStatusInfo(context);
+    
     const bridgeOperational = bridgeStatus.toEthereum.operatingMode.outbound === "Normal"
     const lightClientLatencyIsAcceptable =
         bridgeStatus.toEthereum.latencySeconds < options.acceptableLatencyInSeconds

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fix rate limit checks. Only sleep if the `remaining` requests are 0.

Subscan has changed their behavior, previously `retryAfter` was set only after the rate limit being reached. Now it is set after the first request so this change waits `remaining` requests is 0 before honouring `retryAfter`.
