### PR TITLE
Fix relayer build GA task

### DIFF
--- a/.github/workflows/release-relayer.yml
+++ b/.github/workflows/release-relayer.yml
@@ -2,9 +2,10 @@ name: release-relayer
 
 on:
   push:
+    paths:
+      - "relayer/**"
     branches:
       - main
-      - fix-relayer-build
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release-relayer.yml
+++ b/.github/workflows/release-relayer.yml
@@ -2,8 +2,6 @@ name: release-relayer
 
 on:
   push:
-    paths:
-      - "relayer/**"
     branches:
       - main
       - fix-relayer-build

--- a/.github/workflows/release-relayer.yml
+++ b/.github/workflows/release-relayer.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Setup go
         uses: actions/checkout@v4
         with:
-          go-version: "~1.22.0" # 1.23.0 has a known abigen build issue: https://github.com/sei-protocol/sei-chain/issues/1902
+          go-version: "^1.21.0"
 
       - name: Install Go tools
         run: >
           go install github.com/magefile/mage@v1.15.0 && 
           go install github.com/ferranbt/fastssz/sszgen@v0.1.3 &&
-          go install github.com/ethereum/go-ethereum/cmd/abigen@v1.13.15
+          go install github.com/ethereum/go-ethereum/cmd/abigen@v1.14.8
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/release-relayer.yml
+++ b/.github/workflows/release-relayer.yml
@@ -6,6 +6,7 @@ on:
       - "relayer/**"
     branches:
       - main
+      - fix-relayer-build
   workflow_dispatch:
 
 env:
@@ -29,7 +30,7 @@ jobs:
       - name: Setup go
         uses: actions/checkout@v4
         with:
-          go-version: "^1.21.0"
+          go-version: "~1.22.0" # 1.23.0 has a known abigen build issue: https://github.com/sei-protocol/sei-chain/issues/1902
 
       - name: Install Go tools
         run: >


### PR DESCRIPTION
There is a known issue when building abigen tools with Go 1.23.x. Upgrading to abigen 1.14.8 with includes a fix: https://gitlab.alpinelinux.org/alpine/aports/-/issues/16401

https://github.com/ethereum/go-ethereum/issues/30100