### PR TITLE
Fix typos and improve clarity in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Integration tests for our local testnet. See [smoketest/README.md](https://githu
 
 We use the Nix package manager to provide a reproducible and maintainable developer environment.
 
-After [installing nix](https://nixos.org/download.html) Nix, enable [flakes](https://wiki.nixos.org/wiki/Flakes):
+After [installing Nix](https://nixos.org/download.html), enable [flakes](https://wiki.nixos.org/wiki/Flakes):
 
 ```sh
 mkdir -p ~/.config/nix

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -16,8 +16,8 @@ The gateway is defined by the following contracts
 
 The gateway is modular in design, being composed of libraries implementing specific functionality:
 
-* [Verification.sol](src/Verification.sol): Verification of inbound messages from Polakdot
-* [Assets.sol](src/Assets.sol): ERC20 token transfers to Polkadot
+* [Verification.sol](src/Verification.sol): Verification of inbound messages from Polkadot
+* [Assets.sol](src/Assets.sol): ERC-20 token transfers to Polkadot
 
 #### Governance
 
@@ -25,14 +25,14 @@ Using cross-chain messaging, the gateway is governed remotely by the governance 
 
 #### Upgrades
 
-The gateway consists of an upgradable proxy, and an implementation contract, loosely following the [ERC1967](https://eips.ethereum.org/EIPS/eip-1967) standard.
+The gateway consists of an upgradable proxy, and an implementation contract, loosely following the [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) standard.
 
 ### Agents
 
 Agents are proxy contracts for arbitrary consensus systems on Polkadot. Logically, one can think of them as the sovereign accounts of remote consensus systems.
 
 They have a number of uses:
-* When an Ethereum user sends ERC20 tokens to Polkadot (Specifically the AssetHub parachain), these tokens are actually locked into the agent contract corresponding to the AssetHub parachain. Then finally, on the AssetHub parachain, wrapped tokens are minted into an account controlled by the sender.
+* When an Ethereum user sends ERC-20 tokens to Polkadot (Specifically the AssetHub parachain), these tokens are actually locked into the agent contract corresponding to the AssetHub parachain. Then finally, on the AssetHub parachain, wrapped tokens are minted into an account controlled by the sender.
 * When a Polkadot parachain wishes to call a function on an Ethereum contract, it will appear to the destination contract that the message sender is the agent contract for the origin parachain.
 * Agents control the funds for receiving fees from users and disbursing rewards to message relayers
 


### PR DESCRIPTION
Changes include:

Fixed the typo "Polakdot" to "Polkadot."
Updated "ERC1967" to "ERC-1967" and "ERC20" to "ERC-20" to align with correct standard naming conventions.
Removed redundancy in the phrase "After installing nix Nix," changing it to "After installing Nix" for better clarity."



![image](https://github.com/user-attachments/assets/0ca86be6-8943-45f2-9b99-006c1013354f)

![image](https://github.com/user-attachments/assets/0b7937cc-63fc-4eda-a099-b9e105bf9360)

![image](https://github.com/user-attachments/assets/d73a5ed3-25dc-4021-9f7e-e9b4aeee80e4)

![image](https://github.com/user-attachments/assets/62837200-d637-479a-ac2e-2e3349b1a827)


