### PR TITLE
Ignore AgentTransferFromNative bridge command

### DIFF
--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -32,9 +32,6 @@ interface IGateway {
     // Emitted when pricing params updated
     event PricingParametersChanged();
 
-    // Emitted when funds are withdrawn from an agent
-    event AgentFundsWithdrawn(bytes32 indexed agentID, address indexed recipient, uint256 amount);
-
     // Emitted when foreign token from polkadot registed
     event ForeignTokenRegistered(bytes32 indexed tokenID, address token);
 

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -181,7 +181,7 @@ contract GatewayTest is Test {
         return (Command.TransferNativeToken, abi.encode(params));
     }
 
-    function makeTransferNativeFromCommand(bytes32 agentID, address recipient, uint128 amount)
+    function makeTransferNativeFromAgentCommand(bytes32 agentID, address recipient, uint128 amount)
         public
         pure
         returns (Command, bytes memory)
@@ -766,7 +766,7 @@ contract GatewayTest is Test {
 
         deal(assetHubAgent, amount);
 
-        (Command command, bytes memory params) = makeTransferNativeFromCommand(assetHubAgentID, recipient, amount);
+        (Command command, bytes memory params) = makeTransferNativeFromAgentCommand(assetHubAgentID, recipient, amount);
 
         assertEq(address(assetHubAgent).balance, amount);
         assertEq(recipient.balance, 0);

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -766,8 +766,7 @@ contract GatewayTest is Test {
 
         deal(assetHubAgent, amount);
 
-        (Command command, bytes memory params) =
-            makeTransferNativeFromCommand(assetHubAgentID, recipient, amount);
+        (Command command, bytes memory params) = makeTransferNativeFromCommand(assetHubAgentID, recipient, amount);
 
         assertEq(address(assetHubAgent).balance, amount);
         assertEq(recipient.balance, 0);

--- a/contracts/test/mocks/MockGateway.sol
+++ b/contracts/test/mocks/MockGateway.sol
@@ -47,10 +47,6 @@ contract MockGateway is Gateway {
         this.setOperatingMode(params);
     }
 
-    function transferNativeFromAgentPublic(bytes calldata params) external {
-        this.transferNativeFromAgent(params);
-    }
-
     function setCommitmentsAreVerified(bool value) external {
         commitmentsAreVerified = value;
     }


### PR DESCRIPTION
Because we now lock Ether in the agent, we should never allow transferring native Ether unless it is part of an unlock bridge command.

Resolves: https://linear.app/snowfork/issue/SNO-1222