### PR TITLE
Update default fee

### DIFF
--- a/web/packages/api/src/toEthereum.ts
+++ b/web/packages/api/src/toEthereum.ts
@@ -80,14 +80,14 @@ export interface IValidateOptions {
 }
 
 const ValidateOptionDefaults: IValidateOptions = {
-    defaultFee: 2_750_872_500_000n,
+    defaultFee: 3_833_568_200_000n,
     acceptableLatencyInSeconds: 28800 /* 8 Hours */,
 }
 
 export const getSendFee = async (
     context: Context,
     options = {
-        defaultFee: 2_750_872_500_000n,
+        defaultFee: 3_833_568_200_000n,
     }
 ) => {
     const assetHub = await context.assetHub()

--- a/web/packages/api/src/toEthereum_v2.ts
+++ b/web/packages/api/src/toEthereum_v2.ts
@@ -382,7 +382,7 @@ export async function getDeliveryFee(
     let snowbridgeDeliveryFeeDOT = 0n
     if (leFee.eqn(0)) {
         console.warn("Asset Hub onchain BridgeHubEthereumBaseFee not set. Using default fee.")
-        snowbridgeDeliveryFeeDOT = defaultFee ?? 2_750_872_500_000n
+        snowbridgeDeliveryFeeDOT = defaultFee ?? 3_833_568_200_000n
     } else {
         snowbridgeDeliveryFeeDOT = BigInt(leFee.toString())
     }


### PR DESCRIPTION
For testnets where we do not explicitly set the default fee on the chain, we use the value embedded in the API.

Partially resolves: SNO-1416,

Do NOT merge until polkadot-sdk release and fellows runtime upgrade is scheduled.
https://github.com/paritytech/polkadot-sdk/pull/7947