### PR TITLE
Increase finalization timeout

### DIFF
--- a/relayer/relays/parachain/scanner.go
+++ b/relayer/relays/parachain/scanner.go
@@ -289,7 +289,7 @@ func (s *Scanner) gatherProofInputs(
 }
 
 // The process for finalizing a backed parachain header times out after these many blocks:
-const FinalizationTimeout = 4
+const FinalizationTimeout = 8
 
 // Find the relaychain block in which a parachain header was included (finalized). This usually happens
 // 2-3 blocks after the relaychain block in which the parachain header was backed.


### PR DESCRIPTION
Alarm at https://snowfork.eu.pagerduty.com/incidents/Q2G9GMSCO7ZOGS?utm_campaign=channel&utm_source=slack

The error log from parachain relayer on Westend

```
Mar 27 06:07:18 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:18.676729164Z","blockNumber":7551289,"level":"debug","message":"Checking header"}
Mar 27 06:07:18 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:18.744898047Z","command":0,"level":"debug","message":"Checking message for OFAC","params":"000000000000000000000000>
Mar 27 06:07:18 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:18.744978875Z","level":"debug","message":"Found AgentExecute message"}
Mar 27 06:07:18 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:18.745070782Z","destination":"0x302f0b71b8ad3cf6dd90adb668e49b2168d652fd","level":"debug","message":"extracted dest>
Mar 27 06:07:18 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:18.770253348Z","ParaBlockNumber":7551289,"level":"debug","message":"Gathering proof inputs for parachain header"}
Mar 27 06:07:19 ip-172-31-3-187 start-parachain-relay.sh[115519]: {"@timestamp":"2025-03-27T06:07:19.048473975Z","error":"scan for sync tasks bounded by BEEFY block 25336687: gather proof input: find inclusion blo>
Mar 27 06:07:19 ip-172-31-3-187 systemd[1]: snowbridge-parachain-relay-westend.service: Main process exited, code=exited, status=1/FAILURE
Mar 27 06:07:19 ip-172-31-3-187 systemd[1]: snowbridge-parachain-relay-westend.service: Failed with result 'exit-code'.
```