### PR TITLE
Audit Issue 3: Keep storage agentAddresses for backward compatibility

### DIFF
--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -13,6 +13,8 @@ library CoreStorage {
         mapping(ChannelID channelID => Channel) channels;
         // Agents
         mapping(bytes32 agentID => address) agents;
+        // Agent addresses - DEPRECATED in V2 but kept for storage layout compatibility
+        mapping(address agent => bytes32 agentID) agentAddresses;
         // V2
         SparseBitmap inboundNonce;
         uint64 outboundNonce;

--- a/contracts/src/storage/CoreStorage.sol
+++ b/contracts/src/storage/CoreStorage.sol
@@ -13,8 +13,8 @@ library CoreStorage {
         mapping(ChannelID channelID => Channel) channels;
         // Agents
         mapping(bytes32 agentID => address) agents;
-        // Agent addresses - DEPRECATED in V2 but kept for storage layout compatibility
-        mapping(address agent => bytes32 agentID) agentAddresses;
+        // Reserve slot to prevent state collision
+        uint256 private __gap;
         // V2
         SparseBitmap inboundNonce;
         uint64 outboundNonce;


### PR DESCRIPTION
Resolves: [SNO-1456](https://linear.app/snowfork/issue/SNO-1456)

The recommendation options are:
- Allocating new, uncontested storage slots for the inboundNonce and outboundNonce mappings.
- Keeping the older field agentAddresses but ensuring that it is not used in the V2 interface. _(I opted for this option because it allows using the CoreStorage Layout, which I believe it simpler than added a new storage layout)._