### PR TITLE
Hot fix event index

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.52-alpha.1",
+  "version": "0.1.52",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.51",
+  "version": "0.1.52-alpha.1",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/utils.ts
+++ b/web/packages/api/src/utils.ts
@@ -121,6 +121,12 @@ export const fetchFinalityUpdate = async (
 export const getEventIndex = (id: string) => {
     let parts = id.split("-")
     let blockNumber = parseInt(parts[0])
-    let eventIndex = parseInt(parts[2])
+    // Extract eventIndex for compatibility
+    let eventIndex
+    if (parts.length == 2) {
+        eventIndex = parseInt(parts[1])
+    } else {
+        eventIndex = parseInt(parts[2])
+    }
     return `${blockNumber}-${eventIndex}`
 }

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.52-alpha.1",
+  "version": "0.1.52",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.51",
+  "version": "0.1.52-alpha.1",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.52-alpha.1",
+  "version": "0.1.52",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.51",
+  "version": "0.1.52-alpha.1",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
It seems that the event format from Subsquid indexer has recently changed, which breaks the links on the history page of our UI. Applying a hot fix here for compatibility.