### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/relayer/chain/ethereum/receipt.go
+++ b/relayer/chain/ethereum/receipt.go
@@ -21,10 +21,7 @@ func GetAllReceipts(ctx context.Context, conn *Connection, block *etypes.Block) 
 
 	for i := 0; i < numTransactions; i += receiptFetchBatchSize {
 		eg, ctx := errgroup.WithContext(ctx)
-		upper := i + receiptFetchBatchSize
-		if upper >= numTransactions {
-			upper = numTransactions
-		}
+		upper := min(i+receiptFetchBatchSize, numTransactions)
 		for j, tx := range transactions[i:upper] {
 			index := i + j
 			txHash := tx.Hash()

--- a/relayer/chain/parachain/mortal_era.go
+++ b/relayer/chain/parachain/mortal_era.go
@@ -16,10 +16,7 @@ func NewMortalEra(currentBlockNumber uint64) types.ExtrinsicEra {
 	// Adapted from https://substrate.dev/rustdocs/v2.0.1/src/sp_runtime/generic/era.rs.html#66
 	phase := currentBlockNumber % MortalEraPeriod
 
-	quantizeFactor := MortalEraPeriod >> 12
-	if quantizeFactor < 1 {
-		quantizeFactor = 1
-	}
+	quantizeFactor := max(MortalEraPeriod>>12, 1)
 	quantizedPhase := phase / quantizeFactor * quantizeFactor
 
 	encoded := uint16(math.Log2(float64(MortalEraPeriod))-1) | uint16((quantizedPhase/quantizeFactor)<<4)

--- a/relayer/relays/beefy/token-bucket.go
+++ b/relayer/relays/beefy/token-bucket.go
@@ -40,10 +40,7 @@ func (tb *TokenBucket) refiller(ctx context.Context) {
 			return
 		case <-ticker.C:
 			currentTokens := tb.tokens.Load()
-			newTokens := currentTokens + tb.refillAmount
-			if newTokens > tb.maxTokens {
-				newTokens = tb.maxTokens
-			}
+			newTokens := min(currentTokens+tb.refillAmount, tb.maxTokens)
 			tb.tokens.Store(newTokens)
 		}
 	}


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.