### PR TITLE
Adds min balance to Kusama fee

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/forKusama.ts
+++ b/web/packages/api/src/forKusama.ts
@@ -15,6 +15,7 @@ import {
     dotLocationOnKusamaAssetHub,
     ksmLocationOnPolkadotAssetHub,
     DOT_LOCATION,
+    matchesConsensusSystem,
 } from "./xcmBuilder"
 import {
     buildKusamaToPolkadotDestAssetHubXCM,
@@ -22,7 +23,7 @@ import {
     buildTransferKusamaToPolkadotExportXCM,
     buildTransferPolkadotToKusamaExportXCM,
 } from "./xcmBuilderKusama"
-import { Asset, AssetRegistry, Parachain, getAssetHubConversationPalletSwap } from "./assets_v2"
+import {Asset, AssetRegistry, Parachain, getAssetHubConversationPalletSwap, AssetMap} from "./assets_v2"
 import {
     CallDryRunEffects,
     EventRecord,
@@ -213,10 +214,13 @@ export async function getDeliveryFee(
     )
 
     let feeAssetOnDest
+    let minBalanceFeeDest: bigint;
     if (direction == Direction.ToPolkadot) {
         feeAssetOnDest = ksmLocationOnPolkadotAssetHub
+        minBalanceFeeDest = getDestFeeAssetMinimumBalance(registry.parachains[registry.assetHubParaId].assets, "kusama")
     } else {
         feeAssetOnDest = dotLocationOnKusamaAssetHub
+        minBalanceFeeDest = getDestFeeAssetMinimumBalance(registry.kusama.parachains[registry.kusama.assetHubParaId].assets, "polkadot")
     }
     let destinationFee = await getAssetHubConversationPalletSwap(
         destAssetHub,
@@ -226,6 +230,11 @@ export async function getDeliveryFee(
     )
     // pad destination XCM fee
     destinationFee = destinationFee + (destinationFee * 33n) / 100n
+
+    // add minimum balance to the dest fee, to avoid not being able to deposit leftover fees
+    console.log("adding min balance", minBalanceFeeDest)
+    destinationFee = destinationFee + BigInt(minBalanceFeeDest)
+
     // pad destination XCM fee
     totalXcmBridgeFee = totalXcmBridgeFee + (totalXcmBridgeFee * 33n) / 100n
 
@@ -885,4 +894,18 @@ async function getStorageItem(sourceAssetHub: ApiPromise, key: string) {
     const feeStorageKey = xxhashAsHex(key, 128, true)
     const feeStorageItem = await sourceAssetHub.rpc.state.getStorage(feeStorageKey)
     return new BN((feeStorageItem as Codec).toHex().replace("0x", ""), "hex", "le")
+}
+
+function getDestFeeAssetMinimumBalance(assetMap: AssetMap, network: string): bigint {
+    const assets = Object.values(assetMap)
+    for (const asset of assets) {
+        if (asset.location === undefined) {
+            continue;
+        }
+        if (matchesConsensusSystem(asset.location, network)) {
+           return asset.minimumBalance;
+        }
+    }
+
+    return 0n;
 }

--- a/web/packages/api/src/forKusama.ts
+++ b/web/packages/api/src/forKusama.ts
@@ -232,7 +232,6 @@ export async function getDeliveryFee(
     destinationFee = destinationFee + (destinationFee * 33n) / 100n
 
     // add minimum balance to the dest fee, to avoid not being able to deposit leftover fees
-    console.log("adding min balance", minBalanceFeeDest)
     destinationFee = destinationFee + BigInt(minBalanceFeeDest)
 
     // pad destination XCM fee

--- a/web/packages/api/src/xcmBuilder.ts
+++ b/web/packages/api/src/xcmBuilder.ts
@@ -1301,7 +1301,7 @@ export function isDOTOnOtherConsensusSystem(location: any): boolean {
     return matchesConsensusSystem(location, "Polkadot")
 }
 
-function matchesConsensusSystem(location: any, expectedSystem: string): boolean {
+export function matchesConsensusSystem(location: any, expectedSystem: string): boolean {
     if (location.parents !== 2 || !location.interior) return false
 
     const kind = Object.keys(location.interior).find((k) => k.toLowerCase() === "x1")

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
When a user transfers from Polkadot AH to Kusama AH (and in the other direction), they might not have the source native token (DOT for P->K and KSM for K->P) on the destination chain. Any leftover fees deposited on the destination might be less than the minimum token balance, which then causes DepositAsset to fail.

This PR adds the min balance to the fee, so that there will at least min balance on the dest.

Issue: https://github.com/Snowfork/snowbridge-app/issues/116