### PR TITLE
Beefy-On-Demand-Relay: Sync beefy head newer than parachain head

### DIFF
--- a/relayer/relays/beefy/on-demand-sync.go
+++ b/relayer/relays/beefy/on-demand-sync.go
@@ -116,6 +116,8 @@ func (relay *OnDemandRelay) Start(ctx context.Context) error {
 			}
 
 			log.Info("Performing sync")
+			// sleep to ensure that beefy head newer than relay chain block in which the parachain block was accepted.
+			sleep(ctx, time.Minute*1)
 
 			beefyBlockHash, err := relay.relaychainConn.API().RPC.Beefy.GetFinalizedHead()
 			if err != nil {


### PR DESCRIPTION
Fixes an edge case that causes the on-demand-relay and parachain relay to not work with each other correctly, leading to increased messaging latency for users.