### PR TITLE
Update GQL with a limit & Some cleanup

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/api/src/subsquid.ts
+++ b/web/packages/api/src/subsquid.ts
@@ -170,62 +170,6 @@ export const fetchToEthereumTransfers = async () => {
     return result?.transferStatusToEthereums
 }
 
-const fetchBridgeHubOutboundMessageAccepted = async (messageID: string) => {
-    let query = `query { outboundMessageAcceptedOnBridgeHubs(where: {messageId_eq:"${messageID}"}) {
-            id
-            nonce
-            blockNumber
-            timestamp
-        }
-    }`
-    let result = await queryByGraphQL(query)
-    return result?.outboundMessageAcceptedOnBridgeHubs[0]
-}
-
-const fetchEthereumInboundMessageDispatched = async (messageID: string) => {
-    let query = `query {inboundMessageDispatchedOnEthereums(where: {messageId_eq: "${messageID}"}) {
-            id
-            channelId
-            blockNumber
-            messageId
-            nonce
-            success
-            timestamp
-            txHash
-        }
-    }`
-    let result = await queryByGraphQL(query)
-    return result?.inboundMessageDispatchedOnEthereums[0]
-}
-
-const fetchBridgeHubInboundMessageReceived = async (messageID: string) => {
-    let query = `query { inboundMessageReceivedOnBridgeHubs(where: {messageId_eq:"${messageID}"}) {
-            id
-            channelId
-            blockNumber
-            messageId
-            nonce
-            timestamp
-        }
-    }`
-    let result = await queryByGraphQL(query)
-    return result?.inboundMessageReceivedOnBridgeHubs[0]
-}
-
-const fetchMessageProcessedOnPolkadot = async (messageID: string) => {
-    let query = `query { messageProcessedOnPolkadots(where: {messageId_eq:"${messageID}"}) {
-            id
-            blockNumber
-            messageId
-            paraId
-            timestamp
-            success
-        }
-    }`
-    let result = await queryByGraphQL(query)
-    return result?.messageProcessedOnPolkadots[0]
-}
-
 /**
  * Query the estimated delivery time for transfers to both directions
 
@@ -307,7 +251,7 @@ $graphqlApiUrl --no-progress-meter | jq "."
 ]
  **/
 export const fetchToPolkadotTransferById = async (id: string) => {
-    let query = `query { transferStatusToPolkadots(where: {messageId_eq: "${id}", OR: {txHash_eq: "${id}"}}) {
+    let query = `query { transferStatusToPolkadots(limit: 1, where: {messageId_eq: "${id}", OR: {txHash_eq: "${id}"}}) {
             id
             status
             blockNumber
@@ -387,7 +331,7 @@ $graphqlApiUrl --no-progress-meter | jq "."
 ]
  **/
 export const fetchToEthereumTransferById = async (id: string) => {
-    let query = `query { transferStatusToEthereums(where: {messageId_eq: "${id}", OR: {txHash_eq: "${id}"}}) {
+    let query = `query { transferStatusToEthereums(limit: 1, where: {messageId_eq: "${id}", OR: {txHash_eq: "${id}"}}) {
             id
             status
             blockNumber

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/operations/src/global_transfer_history_v2.ts
+++ b/web/packages/operations/src/global_transfer_history_v2.ts
@@ -1,5 +1,5 @@
 import "dotenv/config"
-import { historyV2 } from "@snowbridge/api"
+import { historyV2, subsquid } from "@snowbridge/api"
 
 const monitor = async () => {
     console.log("To Ethereum transfers:")
@@ -26,6 +26,13 @@ const monitor = async () => {
         "0x04b7a6c7552d2890094dfe43e037cb5f5495fec2419f33b0072439a9ee7629a0"
     )
     console.log(JSON.stringify(toEthereum, null, 2))
+
+    const estimatedDeliveryTime = await subsquid.fetchEstimatedDeliveryTime(
+        "0xc173fac324158e77fb5840738a1a541f633cbec8884c6a601c567d2b376a0539"
+    )
+    console.log(estimatedDeliveryTime)
+    const latestBlock = await subsquid.fetchLatestBlocksSynced()
+    console.log(latestBlock)
 }
 
 monitor()


### PR DESCRIPTION
Related: https://github.com/Snowfork/snowbridge-subsquid/pull/23

Since we gonna to harden the index using `--max-response-size`, all queries must either use a limit or specify list/entity cardinalities, otherwise they will return an error `exceed the size limit`.