### PR TITLE
chore: fix function name in comment

### DIFF
--- a/relayer/crypto/merkle/simplified_mmr_proof.go
+++ b/relayer/crypto/merkle/simplified_mmr_proof.go
@@ -170,7 +170,7 @@ func calculateMerkleProofOrder(leavePos uint64, proofItems []types.H256) (error,
 	return fmt.Errorf("corrupted proof"), proofOrder
 }
 
-// SimplifiedMMRProof is pre-processed MMR proof format which makes it easy to verify in Solidity
+// ConvertToSimplifiedMMRProof is pre-processed MMR proof format which makes it easy to verify in Solidity
 // Original MMRProof is generated in substrate with https://github.com/nervosnetwork/merkle-mountain-range
 // The optimization works by pre-calculating order of the merkle tree proof so that we don't have to use mathematic operation to determine the same on solidity side
 // More details in https://github.com/Snowfork/snowbridge/pull/495


### PR DESCRIPTION
 fix function name in comment