### PR TITLE
Fix the sync status query from Subsquid on Westend

### DIFF
--- a/web/packages/api/src/subsquid.ts
+++ b/web/packages/api/src/subsquid.ts
@@ -402,8 +402,8 @@ $graphqlApiUrl --no-progress-meter | jq "."
   }
 }
 **/
-export const fetchLatestBlocksSynced = async () => {
-    let query = `query { latestBlocks {
+export const fetchLatestBlocksSynced = async (includePKBridge: boolean) => {
+    let query = `query { latestBlocks(withPKBridge: ${includePKBridge}) {
                     height
                     name
                 }}`

--- a/web/packages/operations/src/global_transfer_history_v2.ts
+++ b/web/packages/operations/src/global_transfer_history_v2.ts
@@ -31,7 +31,7 @@ const monitor = async () => {
         "0xc173fac324158e77fb5840738a1a541f633cbec8884c6a601c567d2b376a0539"
     )
     console.log(estimatedDeliveryTime)
-    const latestBlock = await subsquid.fetchLatestBlocksSynced()
+    const latestBlock = await subsquid.fetchLatestBlocksSynced(true)
     console.log(latestBlock)
 }
 

--- a/web/packages/operations/src/monitor.ts
+++ b/web/packages/operations/src/monitor.ts
@@ -175,7 +175,7 @@ export const monitor = async (): Promise<status.AllMetrics> => {
     const latestBlockOfBH = (await bridgeHub.query.system.number()).toPrimitive() as number
     const latestBlockOfEth = await ethereum.getBlockNumber()
 
-    const chains = await subsquid.fetchLatestBlocksSynced()
+    const chains = await subsquid.fetchLatestBlocksSynced(env == "polkadot_mainnet")
     for (let chain of chains?.latestBlocks) {
         let info: status.IndexerServiceStatusInfo = {
             chain: chain.name,


### PR DESCRIPTION
There is no P-K bridge status to query on Westend. Add a query flag to exclude it in the custom resolver. 

Requires: https://github.com/Snowfork/snowbridge-subsquid/pull/27