### PR TITLE
Adjusted the scheduler of on-demand BEEFY relay

### DIFF
--- a/relayer/cmd/run/beefy/command.go
+++ b/relayer/cmd/run/beefy/command.go
@@ -106,7 +106,7 @@ func run(_ *cobra.Command, _ []string) error {
 			return err
 		}
 
-		err = relay.Start(ctx,eg)
+		err = relay.Start(ctx, eg)
 		if err != nil {
 			logrus.WithError(err).Fatal("Unhandled error")
 			cancel()

--- a/relayer/cmd/run/beefy/command.go
+++ b/relayer/cmd/run/beefy/command.go
@@ -106,7 +106,7 @@ func run(_ *cobra.Command, _ []string) error {
 			return err
 		}
 
-		err = relay.Start(ctx)
+		err = relay.Start(ctx,eg)
 		if err != nil {
 			logrus.WithError(err).Fatal("Unhandled error")
 			cancel()

--- a/relayer/relays/beefy/on-demand-sync.go
+++ b/relayer/relays/beefy/on-demand-sync.go
@@ -86,10 +86,11 @@ func (relay *OnDemandRelay) Start(ctx context.Context, eg *errgroup.Group) error
 		return fmt.Errorf("create gateway client: %w", err)
 	}
 	relay.gatewayContract = gatewayContract
-	// Check the on-demand sync every 30 minutes
-	ticker := time.NewTicker(time.Minute * 30)
+
+	ticker := time.NewTicker(time.Second * 60)
 
 	eg.Go(func() error {
+		defer ticker.Stop()
 		for {
 			log.Info("Starting check")
 

--- a/relayer/relays/beefy/on-demand-sync.go
+++ b/relayer/relays/beefy/on-demand-sync.go
@@ -108,6 +108,9 @@ func (relay *OnDemandRelay) Start(ctx context.Context, eg *errgroup.Group) error
 
 				log.Info("Performing sync")
 
+				// sleep to ensure that beefy head newer than relay chain block in which the parachain block was accepted.
+				time.Sleep(time.Minute * 1)
+
 				beefyBlockHash, err := relay.relaychainConn.API().RPC.Beefy.GetFinalizedHead()
 
 				if err != nil {

--- a/relayer/relays/beefy/on-demand-sync.go
+++ b/relayer/relays/beefy/on-demand-sync.go
@@ -2,7 +2,6 @@ package beefy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/snowfork/snowbridge/relayer/chain/relaychain"
 	"github.com/snowfork/snowbridge/relayer/contracts"
 	"github.com/snowfork/snowbridge/relayer/crypto/secp256k1"
+	"golang.org/x/sync/errgroup"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -62,7 +62,7 @@ func NewOnDemandRelay(config *Config, ethereumKeypair *secp256k1.Keypair) (*OnDe
 	return &relay, nil
 }
 
-func (relay *OnDemandRelay) Start(ctx context.Context) error {
+func (relay *OnDemandRelay) Start(ctx context.Context, eg *errgroup.Group) error {
 	err := relay.ethereumConn.Connect(ctx)
 	if err != nil {
 		return fmt.Errorf("connect to ethereum: %w", err)
@@ -86,98 +86,72 @@ func (relay *OnDemandRelay) Start(ctx context.Context) error {
 		return fmt.Errorf("create gateway client: %w", err)
 	}
 	relay.gatewayContract = gatewayContract
+	// Check the on-demand sync every 30 minutes
+	ticker := time.NewTicker(time.Minute * 30)
 
-	relay.tokenBucket.Start(ctx)
+	eg.Go(func() error {
+		for {
+			log.Info("Starting check")
 
-	for {
-		sleep(ctx, time.Minute*1)
-		log.Info("Starting check")
+			paraNonce, ethNonce, err := relay.queryNonces(ctx)
+			if err != nil {
+				return fmt.Errorf("Query nonces: %w", err)
+			}
 
-		paraNonce, ethNonce, err := relay.queryNonces(ctx)
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
+			log.WithFields(log.Fields{
+				"paraNonce": paraNonce,
+				"ethNonce":  ethNonce,
+			}).Info("Nonces checked")
+
+			if paraNonce > ethNonce {
+
+				log.Info("Performing sync")
+
+				beefyBlockHash, err := relay.relaychainConn.API().RPC.Beefy.GetFinalizedHead()
+
+				if err != nil {
+					return fmt.Errorf("Fetch latest beefy block hash: %w", err)
+				}
+
+				header, err := relay.relaychainConn.API().RPC.Chain.GetHeader(beefyBlockHash)
+				if err != nil {
+					return fmt.Errorf("Fetch latest beefy block header: %w", err)
+				}
+
+				err = relay.sync(ctx, uint64(header.Number))
+				if err != nil {
+					return fmt.Errorf("Sync failed: %w", err)
+				}
+
+				log.Info("Sync completed")
+
+				err = relay.waitUntilMessagesSynced(ctx, paraNonce)
+				if err != nil {
+					return fmt.Errorf("wait until messages synced: %w", err)
+				}
+			}
+			select {
+			case <-ctx.Done():
 				return nil
+			case <-ticker.C:
+				continue
 			}
-			log.WithError(err).Error("Query nonces")
-			continue
 		}
-
-		log.WithFields(log.Fields{
-			"paraNonce": paraNonce,
-			"ethNonce":  ethNonce,
-		}).Info("Nonces checked")
-
-		if paraNonce > ethNonce {
-
-			// Check if we are rate-limited
-			if !relay.tokenBucket.TryConsume(1) {
-				log.Info("Rate-limit exceeded")
-				continue
-			}
-
-			log.Info("Performing sync")
-			// sleep to ensure that beefy head newer than relay chain block in which the parachain block was accepted.
-			sleep(ctx, time.Minute*1)
-
-			beefyBlockHash, err := relay.relaychainConn.API().RPC.Beefy.GetFinalizedHead()
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return nil
-				}
-				log.WithError(err).Error("Fetch latest beefy block hash")
-				continue
-			}
-
-			header, err := relay.relaychainConn.API().RPC.Chain.GetHeader(beefyBlockHash)
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return nil
-				}
-				log.WithError(err).Error("Fetch latest beefy block header")
-				continue
-			}
-
-			err = relay.sync(ctx, uint64(header.Number))
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return nil
-				}
-				log.WithError(err).Error("Sync failed")
-				continue
-			}
-
-			log.Info("Sync completed")
-
-			relay.waitUntilMessagesSynced(ctx, paraNonce)
-		}
-	}
+	})
+	return nil
 }
 
-func (relay *OnDemandRelay) waitUntilMessagesSynced(ctx context.Context, paraNonce uint64) {
-	sleep(ctx, time.Minute*10)
+func (relay *OnDemandRelay) waitUntilMessagesSynced(ctx context.Context, paraNonce uint64) error {
 	for {
 		ethNonce, err := relay.fetchEthereumNonce(ctx)
 		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return
-			}
-			log.WithError(err).Error("fetch latest ethereum nonce")
-			sleep(ctx, time.Minute*1)
-			continue
+			return fmt.Errorf("fetch latest ethereum nonce: %w", err)
 		}
 
 		if ethNonce >= paraNonce {
-			return
+			return nil
 		}
-	}
-
-}
-
-func sleep(ctx context.Context, d time.Duration) {
-	select {
-	case <-ctx.Done():
-		return
-	case <-time.After(d):
+		time.Sleep(time.Second * 30)
 	}
 }
 


### PR DESCRIPTION
Replace the bucket scheduler with a fixed periodic scheduler.

Meawhile, fixed a bug to properly capture the error and exit. Tested on Westend with an outbound message to Ethereum. The on-demand log below demonstrates that the flow worked as expected.

```
{"@timestamp":"2025-07-21T03:12:44.059632304Z","level":"info","message":"Starting check"}
{"@timestamp":"2025-07-21T03:12:44.113019496Z","ethNonce":291,"level":"info","message":"Nonces checked","paraNonce":292}
{"@timestamp":"2025-07-21T03:12:44.113046606Z","level":"info","message":"Performing sync"}
...
{"@timestamp":"2025-07-21T03:14:27.418995023Z","currentValidatorSetID":14733,"latestBeefyBlock":26980305,"level":"info","message":"Sync beefy update success","nextValidatorSetID":14734}
{"@timestamp":"2025-07-21T03:14:27.41903592Z","level":"info","message":"Sync completed"}
...
{"@timestamp":"2025-07-21T03:43:44.059632304Z","level":"info","message":"Starting check"}
{"@timestamp":"2025-07-21T03:43:58.28301848Z","ethNonce":292,"level":"info","message":"Nonces checked","paraNonce":292}
```
