### PR TITLE
Publish web packages from CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,19 @@ name: npm-publish
 on:
   release:
     types: [published]
+  push:
+    paths:
+      - "web/packages/api/**"
+      - "web/packages/base-types/**"
+      - "web/packages/registry/**"
+    branches:
+      - main
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: false
+        type: "string"
 
 env:
   NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -42,7 +54,82 @@ jobs:
         run: |
           pnpm install
           pnpm build
-      
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git fetch --tags
+
+      - name: Determine new version
+        id: new_version
+        run: |
+          # Get the most recent tag in the format web-api-v<version>
+          current_tag=$(git tag --list "web-api-v*" --sort=-v:refname | head -n 1)
+          echo "Current tag: $current_tag"
+          current_version=$(echo $current_tag | sed -E 's/web-api-v//')
+          echo "Current version: $current_version"
+
+          # If there is no current version, set it to 1.0.0
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            new_version="${{ github.event.inputs.version }}"
+          elif [ -z "$current_version" ]; then
+            new_version="1.0.0"
+          else
+            new_version=$(npx semver $current_version -i patch)
+          fi
+            
+          echo "New version: $new_version"
+          echo "version=$new_version" >> $GITHUB_OUTPUT
+          echo "from_tag=$current_tag" >> $GITHUB_OUTPUT
+
+      - name: Set version in package.json
+        working-directory: web
+        run: |
+          /bin/bash set-version.sh ${{ steps.new_version.outputs.version }}
+
+      - name: Create new tag
+        id: create_tag
+        run: |
+          tag_name="web-api-v${{ steps.new_version.outputs.version }}"
+          echo "Tag name: $tag_name"
+          echo "tag=$tag_name" >> $GITHUB_OUTPUT
+          git tag $tag_name
+
+      - name: Push new tag
+        run: |
+          git push origin --tags
+
+      - name: "Build Changelog"
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}\n\n<details>\n</details>",
+              "categories": [
+                {
+                    "title": "## Web API Changes",
+                    "labels": ["Component: Web API"]
+                }
+              ]
+            }
+          fromTag: ${{ steps.new_version.outputs.from_tag }}
+          toTag: ${{ steps.create_tag.outputs.tag }}
+
+      - name: Create a GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.create_tag.outputs.tag }}
+          release_name: ${{ steps.create_tag.outputs.tag }}
+          body: |
+            ${{steps.build_changelog.outputs.changelog}}
+          draft: false
+          prerelease: false
+
       - name: Publish Base Types
         working-directory: web/packages/base-types
         run: |
@@ -62,7 +149,7 @@ jobs:
         working-directory: web/packages/api
         run: |
           pnpm publish --no-git-checks --access public
-      
+
       - name: Publish Registry
         working-directory: web/packages/registry
         run: |

--- a/web/set-version.sh
+++ b/web/set-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+new_version=$1
+echo "Set API versions to $new_version:"
+declare -a files=("packages/api/package.json" "packages/base-types/package.json" "packages/contract-types/package.json" "packages/contracts/package.json" "packages/registry/package.json")
+for file in "${files[@]}"; do
+    echo "Updating $file"
+    sed -i "s/\"version\": .*/\"version\": \"$new_version\",/g" $file
+done
+echo "Set API versions done."


### PR DESCRIPTION
### Context 

Currently, publishing new Web SDK packages is a bit tedious, as it requires manually editing the version number in multiple `package.json` files before releasing.

In this PR, we add a CI flow to automate the publishing process. An optional version number can be provided to specify the release version. If not provided, the version will be automatically incremented as a patch-level change using SemVer.