### PR TITLE
Fix setup scripts

### DIFF
--- a/web/packages/test/scripts/configure-others.sh
+++ b/web/packages/test/scripts/configure-others.sh
@@ -133,12 +133,6 @@ function transfer_local_balance() {
 
 
 configure_on_ah() {
-    # Mint Ether to Alice
-    local call="0x3506020109079edaa80200d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d1300002cf61a24a229"
-    send_transact_through_bridge_from_relaychain $ASSET_HUB_PARAID "$call"
-    # Mint Ether to Ferdie
-    local call="0x3506020109079edaa802001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c1300002cf61a24a229"
-    send_transact_through_bridge_from_relaychain $ASSET_HUB_PARAID "$call"
     # Create Pool for Ether<->Wnd and add liquidity
     local call="0x38000100020109079edaa802"
     send_transact_through_user_origin_from_relaychain $ASSET_HUB_PARAID "$sudo_pubkey" "$call"

--- a/web/packages/test/scripts/configure-substrate.sh
+++ b/web/packages/test/scripts/configure-substrate.sh
@@ -56,6 +56,12 @@ configure_ah() {
     # Create Ether
     local call="0x28020c1f04020109079edaa802040000003501020109079edaa80200ce796ae65569a670d0c1cc1ac12515a3ce21b5fbf729d63d7b289baad070139d01043513020109079edaa8021445746865721445746865721200"
     send_governance_transact_from_relaychain $ASSET_HUB_PARAID "$call"
+    # Mint Ether to Alice
+    local call="0x3506020109079edaa80200d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d1300002cf61a24a229"
+    send_transact_through_bridge_from_relaychain $ASSET_HUB_PARAID "$call"
+    # Mint Ether to Ferdie
+    local call="0x3506020109079edaa802001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c1300002cf61a24a229"
+    send_transact_through_bridge_from_relaychain $ASSET_HUB_PARAID "$call"
 }
 
 


### PR DESCRIPTION
### Context 

In the previous PR, to speed up the E2E setup, I moved some scripts into an additional script called `configure-others.sh`. This script is mainly used for preparing Penpal for the smoke tests, which I consider optional—meaning the setup could be run separately if needed.

However, prefunding some Ether to the Substrate test accounts is required for the basic setup, specifically for running `register_ena`, `send_ena_to_ah` which failed as Robert pointed out [here](https://github.com/Snowfork/snowbridge/pull/1532#issuecomment-3120024121). So in this PR, I’m moving that part back.


