### PR TITLE
Fatal error on config error

### DIFF
--- a/relayer/cmd/run/beefy/command.go
+++ b/relayer/cmd/run/beefy/command.go
@@ -2,7 +2,6 @@ package beefy
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -61,7 +60,8 @@ func run(_ *cobra.Command, _ []string) error {
 
 	err = config.Validate()
 	if err != nil {
-		return fmt.Errorf("config file validation failed: %w", err)
+		logrus.WithError(err).Fatal("Configuration file validation failed")
+		return err
 	}
 
 	keypair, err := ethereum.ResolvePrivateKey(privateKey, privateKeyFile, privateKeyID)

--- a/relayer/cmd/run/execution/command.go
+++ b/relayer/cmd/run/execution/command.go
@@ -64,6 +64,7 @@ func run(_ *cobra.Command, _ []string) error {
 
 	err = config.Validate()
 	if err != nil {
+		logrus.WithError(err).Fatal("config file validation failed")
 		return fmt.Errorf("config file validation failed: %w", err)
 	}
 

--- a/relayer/cmd/run/parachain/command.go
+++ b/relayer/cmd/run/parachain/command.go
@@ -3,7 +3,6 @@ package parachain
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -62,7 +61,8 @@ func run(_ *cobra.Command, _ []string) error {
 
 	err = config.Validate()
 	if err != nil {
-		return fmt.Errorf("config file validation failed: %w", err)
+		logrus.WithError(err).Fatal("Configuration file validation failed")
+		return err
 	}
 
 	keypair, err := ethereum.ResolvePrivateKey(privateKey, privateKeyFile, privateKeyID)


### PR DESCRIPTION
The alarms currently do not pick up some relayer failures because the "fatal" keyword is missing from the logs.