### PR TITLE
Allow disabling heartbeat

### DIFF
--- a/relayer/chain/ethereum/connection.go
+++ b/relayer/chain/ethereum/connection.go
@@ -67,24 +67,26 @@ func (co *Connection) ConnectWithHeartBeat(ctx context.Context, eg *errgroup.Gro
 	co.client = client
 	co.chainID = chainID
 
-	ticker := time.NewTicker(heartBeat)
+	if heartBeat.Abs() > 0 {
+		ticker := time.NewTicker(heartBeat)
 
-	eg.Go(func() error {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-ticker.C:
-				_, err := client.NetworkID(ctx)
-				if err != nil {
-					log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
-					return err
+		eg.Go(func() error {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-ticker.C:
+					_, err := client.NetworkID(ctx)
+					if err != nil {
+						log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
+						return err
+					}
+					log.WithField("endpoint", co.endpoint).Info("Connection heartbeat received")
 				}
-				log.WithField("endpoint", co.endpoint).Info("Connection heartbeat received")
 			}
-		}
-	})
+		})
+	}
 
 	return nil
 }

--- a/relayer/chain/parachain/connection.go
+++ b/relayer/chain/parachain/connection.go
@@ -80,23 +80,25 @@ func (co *Connection) ConnectWithHeartBeat(ctx context.Context, eg *errgroup.Gro
 		return err
 	}
 
-	ticker := time.NewTicker(heartBeat)
+	if heartBeat.Abs() > 0 {
+		ticker := time.NewTicker(heartBeat)
 
-	eg.Go(func() error {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-ticker.C:
-				_, err := co.API().RPC.System.Version()
-				if err != nil {
-					log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
-					return err
+		eg.Go(func() error {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-ticker.C:
+					_, err := co.API().RPC.System.Version()
+					if err != nil {
+						log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
+						return err
+					}
 				}
 			}
-		}
-	})
+		})
+	}
 
 	return nil
 }

--- a/relayer/chain/relaychain/connection.go
+++ b/relayer/chain/relaychain/connection.go
@@ -73,23 +73,25 @@ func (co *Connection) ConnectWithHeartBeat(ctx context.Context, eg *errgroup.Gro
 		return err
 	}
 
-	ticker := time.NewTicker(heartBeat)
+	if heartBeat.Abs() > 0 {
+		ticker := time.NewTicker(heartBeat)
 
-	eg.Go(func() error {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-ticker.C:
-				_, err := co.API().RPC.System.Version()
-				if err != nil {
-					log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
-					return err
+		eg.Go(func() error {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-ticker.C:
+					_, err := co.API().RPC.System.Version()
+					if err != nil {
+						log.WithField("endpoint", co.endpoint).Error("Connection heartbeat failed")
+						return err
+					}
 				}
 			}
-		}
-	})
+		})
+	}
 
 	return nil
 }

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -30,9 +30,6 @@ func (p ParachainConfig) Validate() error {
 	if p.Endpoint == "" {
 		return errors.New("[endpoint] is not set")
 	}
-	if p.HeartbeatSecs == 0 {
-		return errors.New("[heartbeatSecs] config is not set")
-	}
 	return nil
 }
 
@@ -40,18 +37,12 @@ func (e EthereumConfig) Validate() error {
 	if e.Endpoint == "" {
 		return errors.New("[endpoint] config is not set")
 	}
-	if e.HeartbeatSecs == 0 {
-		return errors.New("[heartbeatSecs] config is not set")
-	}
 	return nil
 }
 
 func (p PolkadotConfig) Validate() error {
 	if p.Endpoint == "" {
 		return errors.New("[endpoint] config is not set")
-	}
-	if p.HeartbeatSecs == 0 {
-		return errors.New("[heartbeatSecs] config is not set")
 	}
 	return nil
 }

--- a/relayer/relays/beacon/config/config.go
+++ b/relayer/relays/beacon/config/config.go
@@ -105,8 +105,5 @@ func (p ParachainConfig) Validate() error {
 	if p.HeaderRedundancy == 0 {
 		return errors.New("[headerRedundancy] is not set")
 	}
-	if p.HeartbeatSecs == 0 {
-		return errors.New("[heartBeatSecs] is not set")
-	}
 	return nil
 }


### PR DESCRIPTION
### Context

We added an ethereum connection heartbeat in https://github.com/Snowfork/snowbridge/pull/1539, but it doesn't seems nessessary based on Alchemy’s guidelines: https://www.alchemy.com/support/what-s-the-right-way-for-the-client-to-send-a-ping-to-alchemy 

Additionally, the ping loop is already included in the go-ethereum client (see https://github.com/ethereum/go-ethereum/blob/5b2fc67eeef09b76a93dab3d93b15b725aaf1259/rpc/websocket.go#L348).

In this PR, we’ve made the heartbeat optional—disabled by default and only enabled when explicitly configured. I also deployed a parachain relayer without the heartbeat, and the relay appears to work fine.


@vgeddes - was this the reason you initially didn’t add a heartbeat for Ethereum connections?