### PR TITLE
Fix Ethereum relay to wait until the next block

### DIFF
--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -516,13 +516,13 @@ func (r *Relay) isInFinalizedBlock(ctx context.Context, event *contracts.Gateway
 	blockHeader, err := r.ethconn.Client().HeaderByNumber(ctx, nextBlockNumber)
 	if err != nil {
 		// If not found, retry fetching the block header after a delay
-		if err != ErrNotFound {
-			return fmt.Errorf("get block header: %w", err)
+		if !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("get block header before retry: %w", err)
 		}
 		time.Sleep(30 * time.Second)
 		blockHeader, err = r.ethconn.Client().HeaderByNumber(ctx, nextBlockNumber)
 		if err != nil {
-			return fmt.Errorf("get block header: %w", err)
+			return fmt.Errorf("get block header after retry: %w", err)
 		}
 	}
 

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -515,10 +515,7 @@ func (r *Relay) isInFinalizedBlock(ctx context.Context, event *contracts.Gateway
 
 	blockHeader, err := r.ethconn.Client().HeaderByNumber(ctx, nextBlockNumber)
 	if err != nil {
-		// If not found, retry fetching the block header after a delay
-		if !errors.Is(err, ErrNotFound) {
-			return fmt.Errorf("get block header before retry: %w", err)
-		}
+		log.WithField("blockNumber", nextBlockNumber.Uint64()).Info("block not found, retrying after 30 seconds")
 		time.Sleep(30 * time.Second)
 		blockHeader, err = r.ethconn.Client().HeaderByNumber(ctx, nextBlockNumber)
 		if err != nil {

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -505,10 +505,6 @@ func (r *Relay) isMessageProcessed(eventNonce uint64) (bool, error) {
 	return false, nil
 }
 
-var (
-	ErrNotFound = errors.New("not found")
-)
-
 // isInFinalizedBlock checks if the block containing the event is a finalized block.
 func (r *Relay) isInFinalizedBlock(ctx context.Context, event *contracts.GatewayOutboundMessageAccepted) error {
 	nextBlockNumber := new(big.Int).SetUint64(event.Raw.BlockNumber + 1)


### PR DESCRIPTION
### Context 

Search log from ethereum-relay in [cloudwatch](https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-43200~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'filter*20*40logStream*20*3d*20*27snowbridge-asset-hub-ethereum-relay.service*27*0a*20*7c*20filter*20level*20*3d*20*22fatal*22~queryId~'be5e1433-bed1-4bab-a092-7ccb96c5af5b~source~(~'prod*2fvector*2fjournald)~lang~'CWLI))

we will see error logs as follows:

```
{"@timestamp":"2025-08-29T11:43:24.320591228Z","error":"submit event: check beacon header finalized: get block header: not found","host":"relays","level":"fatal","message":"Unhandled error","unit":"snowbridge-asset-hub-ethereum-relay.service"}
```