### PR TITLE
Revert "Use nix geth (#1563)"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1753250450,
-        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,8 @@
                     tree
                     # ps for zombienet, required in pure shells on Linux
                     ps
-                    # convenience for developing relayer
-                    killall
 
-                    typescript
+                    # typescript
                     python311
                     nodePackages.pnpm
                     nodejs_22
@@ -55,7 +53,6 @@
                     go
                     gotools
                     gopls
-                    go-ethereum
                     go-outline
                     gopkgs
                     godef
@@ -72,14 +69,8 @@
                     # NOTE: when upgrading rustup, check for a command to install the version in the toolchain file:
                     # https://github.com/rust-lang/rustup/issues/2686
                     rustup
-                    # convenience for clearing unused build outputs
-                    cargo-sweep
 
                     cowsay
-
-                    # smoketest
-                    openssl.dev
-                    pkg-config
                 ];
 
                 shellHook = ''

--- a/web/packages/test/scripts/deploy-ethereum.sh
+++ b/web/packages/test/scripts/deploy-ethereum.sh
@@ -6,13 +6,31 @@ source scripts/set-env.sh
 start_geth() {
     pushd "$root_dir/.."
 
+    GETH_PATH="go-ethereum/build/bin/geth"
+
+    # Install Electra geth binary
+    if [ ! -f "$GETH_PATH" ]; then
+      echo "Local geth binary not found at $GETH_PATH."
+      echo "Cloning and building go-ethereum..."
+
+      git clone https://github.com/ethereum/go-ethereum/ go-ethereum
+      pushd go-ethereum
+      git checkout $GETH_VERSION
+      make geth
+      popd
+    else
+      echo "Local geth binary already exists at $GETH_PATH. Skipping clone and build."
+    fi
+
+    pushd go-ethereum
+
     echo "Starting geth local node"
-    geth version
-    geth \
+    ./build/bin/geth version
+    ./build/bin/geth \
       --datadir "$output_dir/ethereum" \
       --state.scheme=hash \
       init "$config_dir/genesis.json"
-    geth \
+    ./build/bin/geth \
       --networkid 11155111 \
       --vmdebug \
       --datadir "$output_dir/ethereum" \
@@ -38,6 +56,8 @@ start_geth() {
       --syncmode=full \
       --state.scheme=hash \
       > "$output_dir/geth.log" 2>&1 &
+
+      popd
 
     popd
 }

--- a/web/packages/test/scripts/set-env.sh
+++ b/web/packages/test/scripts/set-env.sh
@@ -14,6 +14,7 @@ zombienet_data_dir="$output_dir/zombienet"
 export PATH="$output_bin_dir:$PATH"
 polkadot_sdk_dir="${POLKADOT_SDK_DIR:-../polkadot-sdk}"
 
+export GETH_VERSION=v1.15.11
 export LODESTAR_VERSION=v1.31.0
 export snowbridge_v1="${BUILD_V1:-false}"
 v1_root_dir="$root_dir/../snowbridge-v1"


### PR DESCRIPTION
This reverts commit e5229c137af008df152c4bfee7d223f8a77ef5d3 as building Polkadot-SDK fail with errors

```
error: failed to run custom build command for `wasm-opt-sys v0.116.0`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/Users/yangrong/Projects/polkadot-sdk/target/release/build/wasm-opt-sys-5137c7b427b5a623/build-script-build` (exit status: 1)
  --- stdout
  OUT_DIR = Some(/Users/yangrong/Projects/polkadot-sdk/target/release/build/wasm-opt-sys-50648f3b5571defd/out)
  TARGET = Some(aarch64-apple-darwin)
  HOST = Some(aarch64-apple-darwin)
  cargo:rerun-if-env-changed=CXX_aarch64-apple-darwin
  CXX_aarch64-apple-darwin = None
  cargo:rerun-if-env-changed=CXX_aarch64_apple_darwin
  CXX_aarch64_apple_darwin = None
  cargo:rerun-if-env-changed=HOST_CXX
  HOST_CXX = None
  cargo:rerun-if-env-changed=CXX
  CXX = Some(clang++)
  cargo:rerun-if-env-changed=CC_KNOWN_WRAPPER_CUSTOM
  CC_KNOWN_WRAPPER_CUSTOM = None
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  OUT_DIR = Some(/Users/yangrong/Projects/polkadot-sdk/target/release/build/wasm-opt-sys-50648f3b5571defd/out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  TARGET = Some(aarch64-apple-darwin)
  cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET
  MACOSX_DEPLOYMENT_TARGET = Some(11.3)
  HOST = Some(aarch64-apple-darwin)
  cargo:rerun-if-env-changed=CXXFLAGS
  CXXFLAGS = None
  cargo:rerun-if-env-changed=HOST_CXXFLAGS
  HOST_CXXFLAGS = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64_apple_darwin
  CXXFLAGS_aarch64_apple_darwin = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64-apple-darwin
  CXXFLAGS_aarch64-apple-darwin = None

  --- stderr
  Error: C++ compiler does not support `-std=c++17` flag

  Stack backtrace:
     0: std::backtrace::Backtrace::create
     1: anyhow::error::<impl anyhow::Error>::msg
     2: build_script_build::check_cxx17_support
     3: build_script_build::main
     4: core::ops::function::FnOnce::call_once
     5: std::sys::backtrace::__rust_begin_short_backtrace
     6: std::rt::lang_start::{{closure}}
     7: std::rt::lang_start_internal
     8: std::rt::lang_start
     9: _main
```
