### PR TITLE
chore: fix wrong struct field name in comment

### DIFF
--- a/relayer/relays/parachain/merkle-proof.go
+++ b/relayer/relays/parachain/merkle-proof.go
@@ -11,7 +11,7 @@ import (
 	"github.com/snowfork/snowbridge/relayer/crypto/merkle"
 )
 
-// ByLeafIndex implements sort.Interface based on the LeafIndex field.
+// ByParaID implements sort.Interface based on the LeafIndex field.
 type ByParaID []relaychain.ParaHead
 
 func (b ByParaID) Len() int           { return len(b) }


### PR DESCRIPTION
 fix wrong struct field name in comment