### PR TITLE
add vTAO to AssetHub

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snowbridge API client",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/base-types/package.json
+++ b/web/packages/base-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/base-types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snowbridge Base Types",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contract-types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snowbridge contract type bindings",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/contracts/package.json
+++ b/web/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/contracts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snowbridge contract source and abi.",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/registry/package.json
+++ b/web/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowbridge/registry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snowbridge Asset Registry",
   "license": "Apache-2.0",
   "repository": {

--- a/web/packages/registry/src/polkadot_mainnet.registry.json
+++ b/web/packages/registry/src/polkadot_mainnet.registry.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-10-07T21:35:27.436Z",
+  "timestamp": "2025-10-19T20:14:50.232Z",
   "environment": "polkadot_mainnet",
   "ethChainId": 1,
   "gatewayAddress": "0x27ca963c279c93801941e1eb8799c23f407d68e7",
@@ -578,6 +578,14 @@
           "name": "Aave Token",
           "minimumBalance": "bigint:1",
           "symbol": "AAVE",
+          "decimals": 18,
+          "isSufficient": false
+        },
+        "0xe9f6d9898f9269b519e1435e6ebaff766c7f46bf": {
+          "token": "0xe9f6d9898f9269b519e1435e6ebaff766c7f46bf",
+          "name": "vTAO",
+          "minimumBalance": "bigint:1",
+          "symbol": "vTAO",
           "decimals": 18,
           "isSufficient": false
         },

--- a/web/packages/registry/src/polkadot_mainnet.registry.json
+++ b/web/packages/registry/src/polkadot_mainnet.registry.json
@@ -217,6 +217,13 @@
           "decimals": 18,
           "deliveryGas": "bigint:80000"
         },
+        "0xe9f6d9898f9269b519e1435e6ebaff766c7f46bf": {
+          "token": "0xe9f6d9898f9269b519e1435e6ebaff766c7f46bf",
+          "name": "vTAO",
+          "symbol": "vTAO",
+          "decimals": 18,
+          "deliveryGas": "bigint:80000"
+        },
         "0x196c20da81fbc324ecdf55501e95ce9f0bd84d14": {
           "token": "0x196c20da81fbc324ecdf55501e95ce9f0bd84d14",
           "name": "Polkadot",


### PR DESCRIPTION
Adds vTAO from Ethereum to AssetHub.

vTAO is a TAO LST bridged to Eth via LayerZero on Bittensor's frontier EVM

Etherscan: https://etherscan.io/token/0xe9f6d9898f9269b519e1435e6ebaff766c7f46bf
Project Website: https://www.tao.app/bridge