### PR TITLE
Update Moonbeam url

### DIFF
--- a/web/packages/api/src/environment.ts
+++ b/web/packages/api/src/environment.ts
@@ -511,7 +511,7 @@ export const SNOWBRIDGE_ENV: { [id: string]: SnowbridgeEnvironment } = {
                 "3369": "wss://polkadot-mythos-rpc.polkadot.io",
                 "2034": "wss://hydration-rpc.n.dwellir.com",
                 "2030": "wss://bifrost-polkadot.ibp.network",
-                "2004": "wss://moonbeam-rpc.n.dwellir.com",
+                "2004": "wss://moonbeam.ibp.network",
                 "2000": "wss://acala-rpc-0.aca-api.network",
                 "2043": "wss://parachain-rpc.origin-trail.network",
                 // TODO: Add back in jampton once we have an indexer in place.


### PR DESCRIPTION
Dwellir is no longer hosting Moonbeam nodes, so we need to switch this out.