### PR TITLE
Remove KSM order hack

### DIFF
--- a/web/packages/api/src/forKusama.ts
+++ b/web/packages/api/src/forKusama.ts
@@ -617,30 +617,16 @@ export function createERC20ToKusamaTx(
                 },
             ],
         }
-        // Hack for https://github.com/polkadot-js/api/issues/6214.
-    } else if (isKSM(Direction.ToKusama, tokenLocation)) {
-        assets = {
-            v4: [
-                {
-                    id: NATIVE_TOKEN_LOCATION,
-                    fun: { Fungible: destFeeInSourceNative },
-                },
-                {
-                    id: tokenLocation,
-                    fun: { Fungible: amount },
-                },
-            ],
-        }
     } else {
         assets = {
             v4: [
                 {
-                    id: tokenLocation,
-                    fun: { Fungible: amount },
-                },
-                {
                     id: NATIVE_TOKEN_LOCATION,
                     fun: { Fungible: destFeeInSourceNative },
+                },
+                {
+                    id: tokenLocation,
+                    fun: { Fungible: amount },
                 },
             ],
         }


### PR DESCRIPTION
It looks like the ordering code has changed and the hack is no longer necessary.

Related to https://github.com/Snowfork/snowbridge-app/issues/180