### PR TITLE
Inject the RPC endpoint via an environment variable

### DIFF
--- a/web/packages/api/src/index.ts
+++ b/web/packages/api/src/index.ts
@@ -334,52 +334,18 @@ export function contextConfigFor(
         }
     }
 
-    let injectedEthChains: { [ethChainId: string]: string | AbstractProvider } = {}
-    for (const ethChainIdKey of Object.keys(ETHEREUM_CHAINS)) {
-        if (
-            process.env[`ETHEREUM_RPC_URL_${ethChainIdKey}`] ||
-            process.env[`NEXT_PUBLIC_ETHEREUM_RPC_URL_${ethChainIdKey}`]
-        ) {
-            injectedEthChains[ethChainIdKey] =
-                process.env[`ETHEREUM_RPC_URL_${ethChainIdKey}`] ||
-                (process.env[`NEXT_PUBLIC_ETHEREUM_RPC_URL_${ethChainIdKey}`] as string)
-            continue
-        }
-        injectedEthChains[ethChainIdKey] = ETHEREUM_CHAINS[ethChainIdKey]
-    }
-
-    let injectedParachains: { [paraId: string]: string } = {}
-    for (const paraIdKey of Object.keys(PARACHAINS)) {
-        if (
-            process.env[`PARACHAIN_RPC_URL_${paraIdKey}`] ||
-            process.env[`NEXT_PUBLIC_PARACHAIN_RPC_URL_${paraIdKey}`]
-        ) {
-            injectedParachains[paraIdKey] =
-                process.env[`PARACHAIN_RPC_URL_${paraIdKey}`] ||
-                (process.env[`NEXT_PUBLIC_PARACHAIN_RPC_URL_${paraIdKey}`] as string)
-            continue
-        }
-        injectedParachains[paraIdKey] = PARACHAINS[paraIdKey]
-    }
-
     return {
         environment: env,
         ethereum: {
             ethChainId,
-            ethChains: injectedEthChains,
-            beacon_url:
-                process.env["BEACON_RPC_URL"] ||
-                process.env["NEXT_PUBLIC_BEACON_RPC_URL"] ||
-                BEACON_HTTP_API,
+            ethChains: ETHEREUM_CHAINS,
+            beacon_url: BEACON_HTTP_API,
         },
         polkadot: {
             assetHubParaId: ASSET_HUB_PARAID,
             bridgeHubParaId: BRIDGE_HUB_PARAID,
-            parachains: injectedParachains,
-            relaychain:
-                process.env["RELAY_CHAIN_RPC_URL"] ||
-                process.env["NEXT_PUBLIC_RELAY_CHAIN_RPC_URL"] ||
-                RELAY_CHAIN_URL,
+            parachains: PARACHAINS,
+            relaychain: RELAY_CHAIN_URL,
         },
         kusama,
         appContracts: {
@@ -389,4 +355,46 @@ export function contextConfigFor(
         graphqlApiUrl: GRAPHQL_API_URL,
         monitorChains: TO_MONITOR_PARACHAINS,
     }
+}
+
+export function contextConfigOverrides(input: Config): Config {
+    let config = { ...input }
+    let injectedEthChains: { [ethChainId: string]: string | AbstractProvider } = {}
+    for (const ethChainIdKey of Object.keys(input.ethereum.ethChains)) {
+        if (
+            process.env[`ETHEREUM_RPC_URL_${ethChainIdKey}`] ||
+            process.env[`NEXT_PUBLIC_ETHEREUM_RPC_URL_${ethChainIdKey}`]
+        ) {
+            injectedEthChains[ethChainIdKey] =
+                process.env[`ETHEREUM_RPC_URL_${ethChainIdKey}`] ||
+                (process.env[`NEXT_PUBLIC_ETHEREUM_RPC_URL_${ethChainIdKey}`] as string)
+            continue
+        }
+        injectedEthChains[ethChainIdKey] = input.ethereum.ethChains[ethChainIdKey]
+    }
+    config.ethereum.ethChains = injectedEthChains
+    config.ethereum.beacon_url =
+        process.env["BEACON_RPC_URL"] ||
+        process.env["NEXT_PUBLIC_BEACON_RPC_URL"] ||
+        input.ethereum.beacon_url
+
+    let injectedParachains: { [paraId: string]: string } = {}
+    for (const paraIdKey of Object.keys(input.polkadot.parachains)) {
+        if (
+            process.env[`PARACHAIN_RPC_URL_${paraIdKey}`] ||
+            process.env[`NEXT_PUBLIC_PARACHAIN_RPC_URL_${paraIdKey}`]
+        ) {
+            injectedParachains[paraIdKey] = (process.env[`PARACHAIN_RPC_URL_${paraIdKey}`] ||
+                process.env[`NEXT_PUBLIC_PARACHAIN_RPC_URL_${paraIdKey}`]) as string
+            continue
+        }
+        injectedParachains[paraIdKey] = input.polkadot.parachains[paraIdKey]
+    }
+    config.polkadot.parachains = injectedParachains
+    config.polkadot.relaychain =
+        process.env["RELAY_CHAIN_RPC_URL"] ||
+        process.env["NEXT_PUBLIC_RELAY_CHAIN_RPC_URL"] ||
+        input.polkadot.relaychain
+
+    return config
 }

--- a/web/packages/operations/src/monitor.ts
+++ b/web/packages/operations/src/monitor.ts
@@ -1,6 +1,14 @@
 import { u8aToHex } from "@polkadot/util"
 import { blake2AsU8a } from "@polkadot/util-crypto"
-import { Context, environment, status, utils, subsquid, contextConfigFor } from "@snowbridge/api"
+import {
+    Context,
+    environment,
+    status,
+    utils,
+    subsquid,
+    contextConfigFor,
+    contextConfigOverrides,
+} from "@snowbridge/api"
 import { sendMetrics } from "./alarm"
 import { Config } from "@snowbridge/api/dist/environment"
 
@@ -16,7 +24,7 @@ export const monitor = async (): Promise<status.AllMetrics> => {
 
     const { config, name } = snowbridgeEnv
 
-    const context = new Context(contextConfigFor(env))
+    const context = new Context(contextConfigOverrides(contextConfigFor(env)))
 
     const bridgeStatus = await status.bridgeStatusInfo(context, {
         polkadotBlockTimeInSeconds: 6,


### PR DESCRIPTION
Context

I encountered a ‘Too Many Requests’ error when periodically running the monitor process in production, likely due to rate limits on the public endpoint. In this PR, we add support for injecting the RPC endpoint via an environment variable.