### PR TITLE
History fix

### DIFF
--- a/web/packages/api/src/subsquid_v2.ts
+++ b/web/packages/api/src/subsquid_v2.ts
@@ -205,7 +205,7 @@ $graphqlApiUrl --no-progress-meter | jq "."
 ]
  **/
 export const fetchToPolkadotTransferById = async (graphqlApiUrl: string, id: string) => {
-    let nonceFilter = !isNaN(Number(id)) ? `{nonce_eq: ${id}}` : ""
+    let nonceFilter = id.length > 0 && !id.startsWith("0x") && !isNaN(Number(id)) ? `{nonce_eq: ${id}}` : ""
     let query = `query { transferStatusToPolkadotV2s(limit: 1, where: { OR: [ {messageId_eq: "${id}"} {txHash_eq: "${id}"} ${nonceFilter} ] }) {
             id
             status
@@ -287,7 +287,7 @@ $graphqlApiUrl --no-progress-meter | jq "."
 ]
  **/
 export const fetchToEthereumTransferById = async (graphqlApiUrl: string, id: string) => {
-    let nonceFilter = !isNaN(Number(id)) ? `{nonce_eq: ${id}}` : ""
+    let nonceFilter = id.length > 0 && !id.startsWith("0x") && !isNaN(Number(id)) ? `{nonce_eq: ${id}}` : ""
     let query = `query { transferStatusToEthereumV2s(limit: 1, where: { OR: [ {messageId_eq: "${id}"} {txHash_eq: "${id}"} ${nonceFilter} ] }) {
             id
             status


### PR DESCRIPTION
The GraphQL query builder is incorrectly treating empty strings and hex strings (like "0x123...") as valid numeric nonce values because JavaScript's Number() function converts empty strings to 0 and parses hex notation, causing isNaN() checks to pass and generating invalid GraphQL syntax like {nonce_eq: } or {nonce_eq: 0x123}. 

The fix adds checks to ensure the id is not empty and doesn't start with "0x" before including it as a numeric nonce filter in the query.