### PR TITLE
Audit Issue 9: Enforce single payload

### DIFF
--- a/contracts/src/BeefyClient.sol
+++ b/contracts/src/BeefyClient.sol
@@ -693,16 +693,11 @@ contract BeefyClient {
         if (commitment.payload.length != 1) {
             revert CommitmentNotRelevant();
         }
-        for (uint256 i = 0; i < commitment.payload.length; i++) {
-            if (commitment.payload[i].payloadID == MMR_ROOT_ID) {
-                if (commitment.payload[i].data.length != 32) {
-                    revert InvalidMMRRootLength();
-                } else {
-                    return bytes32(commitment.payload[i].data);
-                }
-            }
+        PayloadItem memory payload = commitment.payload[0];
+        if (payload.payloadID != MMR_ROOT_ID || payload.data.length != 32) {
+            revert CommitmentNotRelevant();
         }
-        revert CommitmentNotRelevant();
+        return bytes32(payload.data);
     }
 
     function encodeCommitment(Commitment calldata commitment)


### PR DESCRIPTION
This addresses Issue 9 of the Oak Audit Report.

After checking the upstream code [here](https://github.com/paritytech/polkadot-sdk/blob/18cb5ee6196e884c74bce3b79981604a352b3829/substrate/primitives/consensus/beefy/src/mmr.rs#L201), it appears that only a single payload is currently supported. Therefore, enforcing this constraint should be safe.