### PR TITLE
Disable smoke tests in CI

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   smoketests:
+    if: false # temporarily disable smoke tests
     runs-on: snowbridge-runner
     env:
       CARGO_INCREMENTAL: 0


### PR DESCRIPTION
### Context

It seems the smoke tests have been consistently failing recently. In my view, it’s difficult to reliably maintain a dedicated running test environment for these tests within CI, so I’d prefer to remove them from the CI pipeline. 

Since we already have a testnet environment (Westend/Paseo), we could consider adding CI tasks in a future PR that execute transfer flows against the testnet, if necessary.