### PR TITLE
Fix: update solc version

### DIFF
--- a/contracts/scripts/l2-integration/across/constants/Mainnet.sol
+++ b/contracts/scripts/l2-integration/across/constants/Mainnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 // Mainnet addressess
 address constant SPOKE_POOL = 0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5;

--- a/contracts/scripts/l2-integration/across/constants/Sepolia.sol
+++ b/contracts/scripts/l2-integration/across/constants/Sepolia.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 // Sepolia addressess
 address constant SPOKE_POOL = 0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662;

--- a/contracts/scripts/l2-integration/across/deploy/DeploySnowbridgeL1Adaptor.s.sol
+++ b/contracts/scripts/l2-integration/across/deploy/DeploySnowbridgeL1Adaptor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {

--- a/contracts/scripts/l2-integration/across/deploy/DeploySnowbridgeL2Adaptor.s.sol
+++ b/contracts/scripts/l2-integration/across/deploy/DeploySnowbridgeL2Adaptor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 

--- a/contracts/scripts/l2-integration/across/interfaces/ISwapLegacyRouter.sol
+++ b/contracts/scripts/l2-integration/across/interfaces/ISwapLegacyRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 interface ISwapLegacyRouter {
     struct ExactOutputSingleParams {

--- a/contracts/scripts/l2-integration/across/interfaces/ISwapQuoter.sol
+++ b/contracts/scripts/l2-integration/across/interfaces/ISwapQuoter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 interface ISwapQuoter {
     struct QuoteExactOutputSingleParams {

--- a/contracts/scripts/l2-integration/across/interfaces/ISwapRouter.sol
+++ b/contracts/scripts/l2-integration/across/interfaces/ISwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 interface ISwapRouter {
     struct ExactOutputSingleParams {

--- a/contracts/scripts/l2-integration/across/interfaces/IXcm.sol
+++ b/contracts/scripts/l2-integration/across/interfaces/IXcm.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 interface IXcm {
     /// @notice Weight v2 used for measurement for an XCM execution

--- a/contracts/scripts/l2-integration/across/test/TestSnowbridgeL1Adaptor.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestSnowbridgeL1Adaptor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";

--- a/contracts/scripts/l2-integration/across/test/TestSnowbridgeL1AdaptorNativeEther.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestSnowbridgeL1AdaptorNativeEther.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";

--- a/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2Adaptor.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2Adaptor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";

--- a/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2AdaptorNativeEther.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2AdaptorNativeEther.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";

--- a/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2AdaptorWeth.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestSnowbridgeL2AdaptorWeth.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";

--- a/contracts/scripts/l2-integration/across/test/TestXcm.s.sol
+++ b/contracts/scripts/l2-integration/across/test/TestXcm.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {Script} from "forge-std/Script.sol";
 import {XCM_PRECOMPILE} from "../constants/Sepolia.sol";

--- a/contracts/src/l2-integration/SnowbridgeL1Adaptor.sol
+++ b/contracts/src/l2-integration/SnowbridgeL1Adaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/src/l2-integration/SnowbridgeL2Adaptor.sol
+++ b/contracts/src/l2-integration/SnowbridgeL2Adaptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/src/l2-integration/Types.sol
+++ b/contracts/src/l2-integration/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 struct Call {
     address target;

--- a/contracts/src/l2-integration/interfaces/ISpokePool.sol
+++ b/contracts/src/l2-integration/interfaces/ISpokePool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.28;
+pragma solidity 0.8.33;
 
 interface ISpokePool {
     function deposit(


### PR DESCRIPTION
This is a patch for https://github.com/Snowfork/snowbridge/pull/1672, which missed the recently merged L2 contracts.