### PR TITLE
Exit on non-retryable error

### DIFF
--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -178,8 +178,7 @@ func (r *Relay) Start(ctx context.Context, eg *errgroup.Group) error {
 						log.WithField("nonce", ev.Nonce).Info("beacon header not finalized yet")
 						continue
 					} else if err != nil {
-						log.WithFields(log.Fields{"nonce": ev.Nonce, "error": err}).Warn("submit event: message was not processed")
-						continue
+						return fmt.Errorf("The submit call failed and is not retryable: %w", err)
 					}
 				}
 			}


### PR DESCRIPTION
### Context

Logs from the production Ethereum relay service. The error below appears to occur during gas estimation, causing the bridge to become stuck with undelivered messages.

```
Jan 29 02:44:32 relays start-asset-hub-ethereum-relay-v2.sh[3283494]: {"@timestamp":"2026-01-29T02:44:32.887760863Z","level":"debug","message":"Estimating gas"}
...
Jan 29 02:44:33 relays start-asset-hub-ethereum-relay-v2.sh[3283494]: {"@timestamp":"2026-01-29T02:44:33.940373246Z","error":"exit status 1","level":"error","message":"gas estimator execution failed","stderr":"Error: Invalid command: Failed to dry run call: Metadata(IncompatibleCodegen)\n","stdout":""}
Jan 29 02:44:33 relays start-asset-hub-ethereum-relay-v2.sh[3283494]: {"@timestamp":"2026-01-29T02:44:33.94042641Z","error":"submit inbound message: gas estimation failed: gas estimator execution failed: exit status 1","level":"error","message":"permanent error encountered"}
Jan 29 02:44:33 relays start-asset-hub-ethereum-relay-v2.sh[3283494]: {"@timestamp":"2026-01-29T02:44:33.94044098Z","error":"submit inbound message: gas estimation failed: gas estimator execution failed: exit status 1","level":"warning","message":"submit event: message was not processed","nonce":88}
```
