### PR TITLE
Alchemy fix urls by updating package.

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -35,6 +35,6 @@
     "@polkadot/util-crypto": "13.5.6",
     "@snowbridge/base-types": "workspace:*",
     "@snowbridge/contract-types": "workspace:*",
-    "ethers": "6.15.0"
+    "ethers": "6.16.0"
   }
 }

--- a/web/packages/contract-types/package.json
+++ b/web/packages/contract-types/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "@snowbridge/contracts": "workspace:*",
-    "ethers": "6.15.0"
+    "ethers": "6.16.0"
   }
 }

--- a/web/packages/operations/package.json
+++ b/web/packages/operations/package.json
@@ -84,10 +84,10 @@
     "@typescript-eslint/parser": "^8.45.0",
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
+    "prettier": "3.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.9.3",
-    "prettier": "3.6.2"
+    "typescript": "5.9.3"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.901.0",
@@ -102,7 +102,7 @@
     "@snowbridge/registry": "workspace:*",
     "@types/pino": "^7.0.5",
     "dotenv": "^17.2.3",
-    "ethers": "^6.15.0",
+    "ethers": "^6.16.0",
     "lodash": "^4.17.21",
     "pino": "^10.0.0",
     "pino-pretty": "^13.1.1"

--- a/web/packages/registry/package.json
+++ b/web/packages/registry/package.json
@@ -17,21 +17,21 @@
     "format": "prettier src --write && prettier scripts --write"
   },
   "devDependencies": {
-    "@snowbridge/api": "workspace:*",
-    "@snowbridge/contract-types": "workspace:*",
     "@polkadot/api": "16.4.8",
     "@polkadot/util": "13.5.6",
-    "ethers": "6.15.0",
+    "@snowbridge/api": "workspace:*",
+    "@snowbridge/contract-types": "workspace:*",
     "@types/node": "24.6.2",
     "@typescript-eslint/eslint-plugin": "8.45.0",
     "@typescript-eslint/parser": "8.45.0",
+    "dotenv": "^17.2.3",
     "eslint": "9.37.0",
     "eslint-config-prettier": "10.1.8",
+    "ethers": "6.16.0",
     "prettier": "3.6.2",
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
-    "typescript": "5.9.3",
-    "dotenv": "^17.2.3"
+    "typescript": "5.9.3"
   },
   "dependencies": {
     "@snowbridge/base-types": "workspace:*"

--- a/web/packages/test-helpers/package.json
+++ b/web/packages/test-helpers/package.json
@@ -24,10 +24,10 @@
     "@typescript-eslint/parser": "^8.45.0",
     "eslint": "9.37.0",
     "eslint-config-prettier": "^10.1.8",
+    "prettier": "3.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.9.3",
-    "prettier": "3.6.2"
+    "typescript": "5.9.3"
   },
   "dependencies": {
     "@polkadot/api": "16.4.8",
@@ -43,7 +43,7 @@
     "@types/secp256k1": "^4.0.7",
     "@types/seedrandom": "^3.0.8",
     "bitfield": "^4.2.0",
-    "ethers": "^6.15.0",
+    "ethers": "^6.16.0",
     "keccak": "^3.0.4",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.6.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.2.0)(typescript@5.9.3)
       tsconfig-paths:
         specifier: 4.2.0
         version: 4.2.0
@@ -45,12 +45,12 @@ importers:
         specifier: workspace:*
         version: link:../contract-types
       ethers:
-        specifier: 6.15.0
-        version: 6.15.0
+        specifier: 6.16.0
+        version: 6.16.0
     devDependencies:
       '@typechain/ethers-v6':
         specifier: 0.5.1
-        version: 0.5.1(ethers@6.15.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       '@types/node':
         specifier: 24.6.2
         version: 24.6.2
@@ -115,12 +115,12 @@ importers:
         specifier: workspace:*
         version: link:../contracts
       ethers:
-        specifier: 6.15.0
-        version: 6.15.0
+        specifier: 6.16.0
+        version: 6.16.0
     devDependencies:
       '@typechain/ethers-v6':
         specifier: 0.5.1
-        version: 0.5.1(ethers@6.15.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       '@types/node':
         specifier: 24.6.2
         version: 24.6.2
@@ -175,8 +175,8 @@ importers:
         specifier: ^17.2.3
         version: 17.2.3
       ethers:
-        specifier: ^6.15.0
-        version: 6.15.0
+        specifier: ^6.16.0
+        version: 6.16.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -204,7 +204,7 @@ importers:
         version: 3.6.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.2.0)(typescript@5.9.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -249,8 +249,8 @@ importers:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.37.0)
       ethers:
-        specifier: 6.15.0
-        version: 6.15.0
+        specifier: 6.16.0
+        version: 6.16.0
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -271,7 +271,7 @@ importers:
         version: 0.63.16
       '@zombienet/cli':
         specifier: 1.3.133
-        version: 1.3.133(@polkadot/util@13.5.6)(@types/node@24.6.2)(chokidar@3.6.0)
+        version: 1.3.133(@polkadot/util@13.5.6)(@types/node@25.2.0)(chokidar@3.6.0)
 
   packages/test-helpers:
     dependencies:
@@ -298,7 +298,7 @@ importers:
         version: link:../contract-types
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.15.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       '@types/keccak':
         specifier: ^3.0.5
         version: 3.0.5
@@ -315,8 +315,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       ethers:
-        specifier: ^6.15.0
-        version: 6.15.0
+        specifier: ^6.16.0
+        version: 6.16.0
       keccak:
         specifier: ^3.0.4
         version: 3.0.4
@@ -1116,6 +1116,9 @@ packages:
   '@types/node@24.6.2':
     resolution: {integrity: sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==}
 
+  '@types/node@25.2.0':
+    resolution: {integrity: sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==}
+
   '@types/pino@7.0.5':
     resolution: {integrity: sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==}
     deprecated: This is a stub types definition. pino provides its own type definitions, so you do not need this installed.
@@ -1587,8 +1590,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  ethers@6.15.0:
-    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
   eventemitter3@5.0.1:
@@ -2519,6 +2522,9 @@ packages:
   undici-types@7.13.0:
     resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -2602,8 +2608,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3635,7 +3641,7 @@ snapshots:
     dependencies:
       '@polkadot/x-global': 13.5.6
       tslib: 2.8.1
-      ws: 8.18.3
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3997,9 +4003,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@typechain/ethers-v6@0.5.1(ethers@6.15.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      ethers: 6.15.0
+      ethers: 6.16.0
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.9.3)
       typechain: 8.3.2(typescript@5.9.3)
@@ -4028,6 +4034,10 @@ snapshots:
   '@types/node@24.6.2':
     dependencies:
       undici-types: 7.13.0
+
+  '@types/node@25.2.0':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/pino@7.0.5':
     dependencies:
@@ -4134,11 +4144,11 @@ snapshots:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
-  '@zombienet/cli@1.3.133(@polkadot/util@13.5.6)(@types/node@24.6.2)(chokidar@3.6.0)':
+  '@zombienet/cli@1.3.133(@polkadot/util@13.5.6)(@types/node@25.2.0)(chokidar@3.6.0)':
     dependencies:
       '@zombienet/dsl-parser-wrapper': 0.1.11
-      '@zombienet/orchestrator': 0.0.110(@polkadot/util@13.5.6)(@types/node@24.6.2)(chokidar@3.6.0)
-      '@zombienet/utils': 0.0.29(@types/node@24.6.2)(chokidar@3.6.0)(typescript@5.9.3)
+      '@zombienet/orchestrator': 0.0.110(@polkadot/util@13.5.6)(@types/node@25.2.0)(chokidar@3.6.0)
+      '@zombienet/utils': 0.0.29(@types/node@25.2.0)(chokidar@3.6.0)(typescript@5.9.3)
       cli-progress: 3.12.0
       commander: 11.1.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -4157,12 +4167,12 @@ snapshots:
 
   '@zombienet/dsl-parser-wrapper@0.1.11': {}
 
-  '@zombienet/orchestrator@0.0.110(@polkadot/util@13.5.6)(@types/node@24.6.2)(chokidar@3.6.0)':
+  '@zombienet/orchestrator@0.0.110(@polkadot/util@13.5.6)(@types/node@25.2.0)(chokidar@3.6.0)':
     dependencies:
       '@polkadot/api': 14.3.1
       '@polkadot/keyring': 13.5.6(@polkadot/util-crypto@13.5.6(@polkadot/util@13.5.6))(@polkadot/util@13.5.6)
       '@polkadot/util-crypto': 13.5.6(@polkadot/util@13.5.6)
-      '@zombienet/utils': 0.0.28(@types/node@24.6.2)(chokidar@3.6.0)(typescript@5.9.3)
+      '@zombienet/utils': 0.0.28(@types/node@25.2.0)(chokidar@3.6.0)(typescript@5.9.3)
       JSONStream: 1.3.5
       chai: 4.5.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -4189,14 +4199,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@zombienet/utils@0.0.28(@types/node@24.6.2)(chokidar@3.6.0)(typescript@5.9.3)':
+  '@zombienet/utils@0.0.28(@types/node@25.2.0)(chokidar@3.6.0)(typescript@5.9.3)':
     dependencies:
       cli-table3: 0.6.5
       debug: 4.4.3(supports-color@8.1.1)
       mocha: 10.8.2
       nunjucks: 3.2.4(chokidar@3.6.0)
       toml: https://codeload.github.com/pepoviola/toml-node/tar.gz/5e17114f1af5b5b70e4f2ec10cd007623c928988
-      ts-node: 10.9.2(@types/node@24.6.2)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4205,14 +4215,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@zombienet/utils@0.0.29(@types/node@24.6.2)(chokidar@3.6.0)(typescript@5.9.3)':
+  '@zombienet/utils@0.0.29(@types/node@25.2.0)(chokidar@3.6.0)(typescript@5.9.3)':
     dependencies:
       cli-table3: 0.6.5
       debug: 4.4.3(supports-color@8.1.1)
       mocha: 10.8.2
       nunjucks: 3.2.4(chokidar@3.6.0)
       toml: https://codeload.github.com/pepoviola/toml-node/tar.gz/5e17114f1af5b5b70e4f2ec10cd007623c928988
-      ts-node: 10.9.2(@types/node@24.6.2)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4600,7 +4610,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  ethers@6.15.0:
+  ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -4905,7 +4915,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -5236,7 +5246,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 24.6.2
+      '@types/node': 25.2.0
       long: 4.0.0
 
   psl@1.15.0:
@@ -5337,7 +5347,7 @@ snapshots:
 
   smoldot@2.0.26:
     dependencies:
-      ws: 8.18.3
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5462,6 +5472,24 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@25.2.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -5535,6 +5563,8 @@ snapshots:
 
   undici-types@7.13.0: {}
 
+  undici-types@7.16.0: {}
+
   universalify@0.1.2: {}
 
   universalify@0.2.0: {}
@@ -5596,7 +5626,7 @@ snapshots:
 
   ws@8.17.1: {}
 
-  ws@8.18.3: {}
+  ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
UI shows this error:

```
Transfer blocked
server response 410 (request={ }, response={ }, error=null, info={ "requestUrl": "https://eth-mainnet.alchemyapi.io/v2/idB-OO4vx88RFYNadhd65Z4-mWyDp3dF", "responseBody": "{\"jsonrpc\":\"2.0\",\"id\":76,\"error\":{\"code\":-32000,\"message\":\"Requests to alchemyapi.io are no longer allowed. Please use g.alchemy.com going forwards.\"}}", "responseStatus": "410 " }, code=SERVER_ERROR, version=6.15.0)
```