### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/relayer/relays/beacon/cache/cache.go
+++ b/relayer/relays/beacon/cache/cache.go
@@ -129,14 +129,7 @@ func (b *BeaconCache) pruneOldCheckpoints() {
 }
 
 func (b *BeaconCache) addSlot(slot uint64) {
-	addedAlready := false
-	for _, i := range b.Finalized.Checkpoints.Slots {
-		if i == slot {
-			addedAlready = true
-			break
-		}
-	}
-	if !addedAlready {
+	if !slices.Contains(b.Finalized.Checkpoints.Slots, slot) {
 		b.Finalized.Checkpoints.Slots = append(b.Finalized.Checkpoints.Slots, slot)
 	}
 	slices.Sort(b.Finalized.Checkpoints.Slots)

--- a/relayer/relays/execution/main.go
+++ b/relayer/relays/execution/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"time"
 
@@ -613,10 +614,8 @@ func (r *Relay) isMessageProcessed(eventNonce uint64) (bool, error) {
 	}
 	// Check the nonce again in case another relayer processed the message while this relayer downloading beacon state
 
-	for _, paraNonce := range paraNonces {
-		if eventNonce == paraNonce {
-			return false, nil
-		}
+	if slices.Contains(paraNonces, eventNonce) {
+		return false, nil
 	}
 
 	return true, nil

--- a/relayer/relays/execution/main_test.go
+++ b/relayer/relays/execution/main_test.go
@@ -1,0 +1,133 @@
+package execution
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRelay wraps Relay and allows mocking fetchUnprocessedParachainNonces
+type mockRelay struct {
+	*Relay
+	mockFetchUnprocessedParachainNonces func(latest uint64) ([]uint64, error)
+}
+
+// Override fetchUnprocessedParachainNonces to use the mock
+func (m *mockRelay) fetchUnprocessedParachainNonces(latest uint64) ([]uint64, error) {
+	if m.mockFetchUnprocessedParachainNonces != nil {
+		return m.mockFetchUnprocessedParachainNonces(latest)
+	}
+	return m.Relay.fetchUnprocessedParachainNonces(latest)
+}
+
+// isMessageProcessed is a copy of the method for testing with mockRelay
+func (m *mockRelay) isMessageProcessed(eventNonce uint64) (bool, error) {
+	paraNonces, err := m.fetchUnprocessedParachainNonces(eventNonce)
+	if err != nil {
+		return false, fmt.Errorf("fetch latest parachain nonce: %w", err)
+	}
+
+	if slices.Contains(paraNonces, eventNonce) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func TestIsMessageProcessed(t *testing.T) {
+	tests := []struct {
+		name                  string
+		eventNonce            uint64
+		unprocessedNonces     []uint64
+		fetchError            error
+		expectedProcessed     bool
+		expectedError         bool
+		expectedErrorContains string
+	}{
+		{
+			name:              "message not processed - nonce in unprocessed list",
+			eventNonce:        5,
+			unprocessedNonces: []uint64{3, 5, 7},
+			fetchError:        nil,
+			expectedProcessed: false,
+			expectedError:     false,
+		},
+		{
+			name:              "message processed - nonce not in unprocessed list",
+			eventNonce:        10,
+			unprocessedNonces: []uint64{3, 5, 7},
+			fetchError:        nil,
+			expectedProcessed: true,
+			expectedError:     false,
+		},
+		{
+			name:              "message processed - empty unprocessed list",
+			eventNonce:        1,
+			unprocessedNonces: []uint64{},
+			fetchError:        nil,
+			expectedProcessed: true,
+			expectedError:     false,
+		},
+		{
+			name:                  "error fetching nonces",
+			eventNonce:            5,
+			unprocessedNonces:     nil,
+			fetchError:            errors.New("connection error"),
+			expectedProcessed:     false,
+			expectedError:         true,
+			expectedErrorContains: "fetch latest parachain nonce",
+		},
+		{
+			name:              "message not processed - nonce at beginning of list",
+			eventNonce:        1,
+			unprocessedNonces: []uint64{1, 2, 3},
+			fetchError:        nil,
+			expectedProcessed: false,
+			expectedError:     false,
+		},
+		{
+			name:              "message not processed - nonce at end of list",
+			eventNonce:        100,
+			unprocessedNonces: []uint64{50, 75, 100},
+			fetchError:        nil,
+			expectedProcessed: false,
+			expectedError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock relay
+			relay := &mockRelay{
+				Relay: &Relay{},
+			}
+
+			// Mock the fetchUnprocessedParachainNonces method
+			relay.mockFetchUnprocessedParachainNonces = func(latest uint64) ([]uint64, error) {
+				assert.Equal(t, tt.eventNonce, latest, "fetchUnprocessedParachainNonces should be called with eventNonce")
+				if tt.fetchError != nil {
+					return nil, tt.fetchError
+				}
+				return tt.unprocessedNonces, nil
+			}
+
+			// Call the method under test
+			processed, err := relay.isMessageProcessed(tt.eventNonce)
+
+			// Verify results
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.expectedErrorContains != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedProcessed, processed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.