### PR TITLE
Dry run on Ethereum

### DIFF
--- a/web/packages/api/src/dryRunEthereum.ts
+++ b/web/packages/api/src/dryRunEthereum.ts
@@ -1,0 +1,440 @@
+import { Context } from "./index"
+import {
+    Transfer,
+    ValidationLog,
+    ValidationKind,
+    ValidationReason,
+} from "./types/toEthereum"
+import { EthereumProviderTypes, V2CommandStruct } from "@snowbridge/base-types"
+import { sourceAgentId } from "./toEthereumSnowbridgeV2"
+
+const V2_DISPATCH_OVERHEAD_GAS = 24_000n
+const DRY_RUN_GAS_BUFFER = 100_000_000n
+const DEFAULT_FORK_RPC_CONNECT_TIMEOUT_MS = 15_000
+const DEFAULT_FORK_RPC_SEND_TIMEOUT_MS = 30_000
+
+export function dryRunCommandGasBudgets(transfer: Transfer): bigint[] {
+    if (transfer.input.contractCall) {
+        return [10_000_000n, 10_000_000n]
+    }
+    return [10_000_000n]
+}
+
+const L1_ADAPTOR_DEPOSIT_CALL_INVOKED_TOPIC0 =
+    "0x14bfd4fd7e654256d3222db5d1ec5e59cd23dd5df10bd8faccc1cabe984b3508"
+const L1_ADAPTOR_DEPOSIT_CALL_FAILED_TOPIC0 =
+    "0x759aee2ba41080c1e3a57140ba7b446c1347cff289214a2fd1c81554ddc17380"
+
+type EthereumDryRunTx = {
+    from?: string
+    to?: string
+    data?: string
+    value?: bigint | string | number
+}
+
+type ForkedRpcProvider = {
+    send(method: string, params: unknown[]): Promise<unknown>
+    waitForTransaction(txHash: string): Promise<{
+        status?: number | bigint | string | null
+        logs: unknown[]
+    } | null>
+}
+
+function forkRpcTimeoutMs(envKey: string, defaultMs: number): number {
+    const raw = process.env[envKey]
+    if (!raw) {
+        return defaultMs
+    }
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return defaultMs
+    }
+    return Math.floor(parsed)
+}
+
+async function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    operationName: string,
+): Promise<T> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+            reject(new Error(`${operationName} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+    })
+
+    try {
+        return await Promise.race([promise, timeoutPromise])
+    } finally {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle)
+        }
+    }
+}
+
+async function tryImpersonateForkedSigner(
+    forkedProvider: ForkedRpcProvider,
+    from?: string,
+): Promise<boolean> {
+    if (!from) {
+        return false
+    }
+
+    // Ensure the impersonated account has balance to pass intrinsic checks.
+    try {
+        await forkedProvider.send("anvil_setBalance", [from, "0x56BC75E2D63100000"])
+    } catch (e) {
+        console.warn("Failed to set balance for impersonated account:", e)
+    }
+
+    // Sync the forked node's time with the real clock + 1 hour to pass deadline checks in bridge calls.
+    try {
+        const nowPlusHour = Math.floor(Date.now() / 1000) + 3600
+        await forkedProvider.send("evm_setNextBlockTimestamp", [nowPlusHour])
+        await forkedProvider.send("evm_mine", [])
+    } catch (e) {
+        console.warn("Failed to set forked chain timestamp:", e)
+    }
+
+    // Raise block gas limit on the fork: the dry-run dispatch tx asks for ~120M
+    // gas to cover both commands plus a generous safety buffer, which exceeds the
+    // ~30-60M cap inherited from mainnet. Hex-encoded uint256, value = 480M.
+    try {
+        await forkedProvider.send("anvil_setBlockGasLimit", ["0x1c9c3800"])
+    } catch (e) {
+        console.warn("Failed to raise forked chain block gas limit:", e)
+    }
+
+    try {
+        await forkedProvider.send("anvil_impersonateAccount", [from])
+    } catch (e) {
+        console.warn("Failed to impersonate account on Anvil:", e)
+        return false
+    }
+
+    return true
+}
+
+export async function buildEthereumDryRunCall<T extends EthereumProviderTypes>(
+    context: Context<T>,
+    parachainId: number,
+    sourceAccountHex: string,
+    transfer: Transfer,
+): Promise<T["ContractTransaction"]> {
+    let commands: V2CommandStruct[] = []
+    const agentID = await sourceAgentId(context, parachainId, sourceAccountHex)
+    if (transfer.computed.sourceAssetMetadata.foreignId) {
+        // PNA
+        const mintForeignParams = context.ethereumProvider.encodeAbiParameters(
+            ["bytes32", "address", "uint128"],
+            [
+                transfer.computed.sourceAssetMetadata.foreignId,
+                transfer.input.beneficiaryAccount,
+                transfer.input.amount,
+            ],
+        )
+        const mintCommand: V2CommandStruct = {
+            kind: 4,
+            gas: 10_000_000n,
+            payload: mintForeignParams,
+        }
+        commands.push(mintCommand)
+    } else {
+        // ENA
+        const unlockNativeParams = context.ethereumProvider.encodeAbiParameters(
+            ["address", "address", "uint128"],
+            [transfer.input.tokenAddress, transfer.input.beneficiaryAccount, transfer.input.amount],
+        )
+        const unlockCommand: V2CommandStruct = {
+            kind: 2,
+            gas: 10_000_000n,
+            payload: unlockNativeParams,
+        }
+        commands.push(unlockCommand)
+    }
+
+    if (transfer.input.contractCall) {
+        // Match `abi.encode(CallContractParams)` from Solidity: because
+        // CallContractParams contains a dynamic field (`bytes data`), the
+        // struct itself is a dynamic tuple, so its ABI encoding is prefixed
+        // with a 32-byte offset (= 0x20). Encoding the three fields as a
+        // flat tuple omits that leading word and the deployed handler then
+        // reads `target` as the bytes offset, fails the uint64 bound check,
+        // and reverts.
+        const contractCallParams = context.ethereumProvider.encodeAbiParameters(
+            ["(address,bytes,uint256)"],
+            [
+                [
+                    transfer.input.contractCall.target,
+                    transfer.input.contractCall.calldata,
+                    transfer.input.contractCall.value,
+                ],
+            ],
+        )
+        const contractCallCommand: V2CommandStruct = {
+            kind: 5,
+            gas: 10_000_000n,
+            payload: contractCallParams,
+        }
+        commands.push(contractCallCommand)
+    }
+
+    const nonce = BigInt(Math.floor(Math.random() * 1000000) + 1000000)
+    console.log(`Dry-run: Using nonce ${nonce} and agentID ${agentID}`)
+    const ethereumTx = (await context
+        .gatewayV2()
+        .getFunction("v2_dispatch")
+        .populateTransaction(commands, agentID, nonce, {
+            from: context.environment.gatewayContract,
+        })) as T["ContractTransaction"]
+
+    return ethereumTx
+}
+
+function computeDryRunDispatchGasLimit(commandGasBudgets: bigint[]): bigint {
+    const requiredGas = commandGasBudgets.reduce((acc, commandGas) => {
+        return acc + commandGas + V2_DISPATCH_OVERHEAD_GAS
+    }, 0n)
+    // Account for the 63/64 forwarding rule used in Gateway.v2_dispatch gas checks.
+    const minGas = (requiredGas * 64n + 62n) / 63n
+    return minGas + DRY_RUN_GAS_BUFFER
+}
+
+function parseL1AdaptorDryRunEvent(
+    log: any,
+    l1AdapterAddress?: string,
+): {
+    name: "DepositCallInvoked" | "DepositCallFailed"
+    topic?: string
+    depositId?: bigint
+} | null {
+    if (!l1AdapterAddress) {
+        return null
+    }
+    const address = String(log?.address || "").toLowerCase()
+    if (!address || address !== l1AdapterAddress.toLowerCase()) {
+        return null
+    }
+
+    const topics = Array.isArray(log?.topics) ? log.topics.map((t: any) => String(t)) : []
+    const topic0 = (topics[0] || "").toLowerCase()
+    const data = String(log?.data || "0x")
+
+    if (topic0 === L1_ADAPTOR_DEPOSIT_CALL_INVOKED_TOPIC0 && data.length >= 130) {
+        const topic = "0x" + data.slice(2, 66)
+        const depositIdHex = data.slice(66, 130)
+        return {
+            name: "DepositCallInvoked",
+            topic,
+            depositId: BigInt("0x" + depositIdHex),
+        }
+    }
+
+    if (topic0 === L1_ADAPTOR_DEPOSIT_CALL_FAILED_TOPIC0 && data.length >= 66) {
+        const topic = "0x" + data.slice(2, 66)
+        return {
+            name: "DepositCallFailed",
+            topic,
+        }
+    }
+
+    return null
+}
+
+export async function runEthereumDryRun<T extends EthereumProviderTypes>(
+    context: Context<T>,
+    sourceParaId: number,
+    sourceAccountHex: string,
+    transfer: Transfer,
+    logs: ValidationLog[],
+): Promise<{ ethereumDryRunError?: string }> {
+    let ethereumDryRunError: string | undefined
+
+    try {
+        const ethereumTx = await buildEthereumDryRunCall(
+            context,
+            sourceParaId,
+            sourceAccountHex,
+            transfer,
+        )
+        const txGasLimit = computeDryRunDispatchGasLimit(dryRunCommandGasBudgets(transfer))
+        try {
+            const forkedProvider = context.forkedProvider() as unknown as ForkedRpcProvider
+            const connectTimeoutMs = forkRpcTimeoutMs(
+                "FORKED_PROVIDER_CONNECT_TIMEOUT_MS",
+                DEFAULT_FORK_RPC_CONNECT_TIMEOUT_MS,
+            )
+            const sendTimeoutMs = forkRpcTimeoutMs(
+                "FORKED_PROVIDER_SEND_TIMEOUT_MS",
+                DEFAULT_FORK_RPC_SEND_TIMEOUT_MS,
+            )
+
+            await withTimeout(
+                forkedProvider.send("eth_blockNumber", []),
+                connectTimeoutMs,
+                "Forked RPC eth_blockNumber",
+            )
+            const txRequest = {
+                from: (ethereumTx as EthereumDryRunTx).from,
+                to: (ethereumTx as EthereumDryRunTx).to,
+                data: (ethereumTx as EthereumDryRunTx).data,
+                value: (ethereumTx as EthereumDryRunTx).value ?? "0x0",
+                gas: "0x" + txGasLimit.toString(16),
+            }
+
+            let txHash: string
+            try {
+                await tryImpersonateForkedSigner(forkedProvider, txRequest.from)
+                await context.ethereumProvider.estimateGas(forkedProvider, ethereumTx)
+                txHash = String(
+                    await withTimeout(
+                        forkedProvider.send("eth_sendTransaction", [txRequest]),
+                        sendTimeoutMs,
+                        "Forked RPC eth_sendTransaction",
+                    ),
+                )
+            } catch (sendError) {
+                const sendErrorMessage = String((sendError as Error).message || sendError)
+                const shouldImpersonate =
+                    sendErrorMessage.includes("No Signer available") ||
+                    sendErrorMessage.includes("unknown account")
+                const impersonated = shouldImpersonate
+                    ? await tryImpersonateForkedSigner(forkedProvider, txRequest.from)
+                    : false
+                if (!impersonated) {
+                    throw sendError
+                }
+                await context.ethereumProvider.estimateGas(forkedProvider, ethereumTx)
+                txHash = String(
+                    await withTimeout(
+                        forkedProvider.send("eth_sendTransaction", [txRequest]),
+                        sendTimeoutMs,
+                        "Forked RPC eth_sendTransaction",
+                    ),
+                )
+            }
+
+            console.log("Tx hash:", txHash)
+
+            const receipt = await withTimeout(
+                forkedProvider.waitForTransaction(txHash),
+                sendTimeoutMs,
+                `Forked RPC waitForTransaction(${txHash})`,
+            )
+            if (!receipt) {
+                ethereumDryRunError =
+                    "Dry run transaction simulation on forked Ethereum did not return a receipt (node may be unavailable/out of sync)."
+                logs.push({
+                    kind: ValidationKind.Warning,
+                    reason: ValidationReason.DryRunFailed,
+                    message: ethereumDryRunError,
+                })
+            } else {
+                const receiptStatus = receipt.status
+                const isRevertedReceipt =
+                    receiptStatus === 0 ||
+                    receiptStatus === 0n ||
+                    receiptStatus === "0x0" ||
+                    receiptStatus === "0"
+                if (isRevertedReceipt) {
+                    ethereumDryRunError =
+                        "Dry run transaction simulation reverted on Ethereum (receipt status 0)."
+                    logs.push({
+                        kind: ValidationKind.Error,
+                        reason: ValidationReason.DryRunFailed,
+                        message: ethereumDryRunError,
+                    })
+                }
+
+                console.log("Logs:", receipt.logs)
+                const parsedLogs = receipt.logs
+                    .map((log: any) => {
+                        try {
+                            return context.gatewayV2().interface.parseLog(log)
+                        } catch (e) {
+                            return null
+                        }
+                    })
+                    .filter((log: any) => log !== null)
+                const errorLogs = parsedLogs.filter((log: any) => log.name === "CommandFailed")
+                console.log("CommandFailed logs:", errorLogs)
+                if (errorLogs.length > 0) {
+                    const failedIndex = errorLogs[0]?.args?.index
+                    ethereumDryRunError =
+                        "Dry run v2_dispatch simulation reported CommandFailed at index: " +
+                        String(failedIndex)
+                    logs.push({
+                        kind: ValidationKind.Error,
+                        reason: ValidationReason.DryRunFailed,
+                        message: ethereumDryRunError,
+                    })
+                }
+
+                const l1AdapterAddress = context.environment.l2Bridge?.l1AdapterAddress
+                const adaptorEvents = receipt.logs
+                    .map((log: any) => parseL1AdaptorDryRunEvent(log, l1AdapterAddress))
+                    .filter(
+                        (
+                            event,
+                        ): event is {
+                            name: "DepositCallInvoked" | "DepositCallFailed"
+                            topic?: string
+                            depositId?: bigint
+                        } => event !== null,
+                    )
+                const depositCallFailed = adaptorEvents.filter(
+                    (event) => event.name === "DepositCallFailed",
+                )
+                if (depositCallFailed.length > 0) {
+                    const topic = depositCallFailed[0]?.topic
+                    ethereumDryRunError =
+                        "Dry run failed on Ethereum: L1 adaptor emitted DepositCallFailed" +
+                        (topic ? ` (topic: ${topic})` : "")
+                    logs.push({
+                        kind: ValidationKind.Error,
+                        reason: ValidationReason.DryRunFailed,
+                        message: ethereumDryRunError,
+                    })
+                }
+
+                const depositCallInvoked = adaptorEvents.find(
+                    (event) => event.name === "DepositCallInvoked",
+                )
+                if (depositCallInvoked) {
+                    console.log("L1 adaptor event:", {
+                        name: depositCallInvoked.name,
+                        topic: depositCallInvoked.topic,
+                        depositId: depositCallInvoked.depositId?.toString(),
+                    })
+                } else if (errorLogs.length > 0 && adaptorEvents.length === 0) {
+                    logs.push({
+                        kind: ValidationKind.Warning,
+                        reason: ValidationReason.DryRunFailed,
+                        message:
+                            "Synthetic v2_dispatch dry run reported upstream failure before adaptor events; this may diverge from proof-based production execution.",
+                    })
+                }
+            }
+        } catch (forkUnavailableError) {
+            console.error("Ethereum forked RPC dry-run failed:", forkUnavailableError)
+            ethereumDryRunError =
+                "Skipping Ethereum dry-run transaction simulation because the forked RPC node is unavailable."
+            logs.push({
+                kind: ValidationKind.Warning,
+                reason: ValidationReason.DryRunFailed,
+                message: ethereumDryRunError,
+            })
+        }
+    } catch (e) {
+        console.error("Ethereum gas estimation failed:", e)
+        ethereumDryRunError = "Could not estimate gas on Ethereum."
+        logs.push({
+            kind: ValidationKind.Error,
+            reason: ValidationReason.FeeEstimationError,
+            message: ethereumDryRunError,
+        })
+    }
+
+    return { ethereumDryRunError }
+}

--- a/web/packages/api/src/index.ts
+++ b/web/packages/api/src/index.ts
@@ -91,6 +91,7 @@ export class Context<T extends EthereumProviderTypes> {
     #gatewayV2?: T["Contract"] & IGatewayV2
     #beefyClient?: T["Contract"] & BeefyClient
     #l1SwapQuoter?: T["Contract"] & ISwapQuoter
+    #forkedProvider?: T["Connection"]
 
     // Substrate
     #polkadotParachains: Record<string, Promise<ApiPromise>>
@@ -335,6 +336,20 @@ export class Context<T extends EthereumProviderTypes> {
         return this.environment.indexerGraphQlUrl
     }
 
+    forkedProvider(): T["Connection"] {
+        if (this.#forkedProvider) {
+            return this.#forkedProvider
+        }
+        const apiKey =
+            process.env.FORKED_PROVIDER_API_KEY ||
+            process.env.NEXT_PUBLIC_FORKED_PROVIDER_API_KEY
+        this.#forkedProvider = this.ethereumProvider.createProvider(
+            this.environment.forkedProviderUrl || "https://fork-mainnet.snowbridge.network",
+            apiKey ? { headers: { "X-API-Key": apiKey } } : undefined,
+        )
+        return this.#forkedProvider
+    }
+
     async destroyContext(): Promise<void> {
         // clean up contract listeners
         if (this.#beefyClient) {
@@ -345,6 +360,9 @@ export class Context<T extends EthereumProviderTypes> {
         }
         if (this.#gatewayV2) {
             await this.ethereumProvider.destroyContract(this.gatewayV2())
+        }
+        if (this.#forkedProvider) {
+            this.ethereumProvider.destroyProvider(this.#forkedProvider)
         }
 
         // clean up ethereum

--- a/web/packages/api/src/index.ts
+++ b/web/packages/api/src/index.ts
@@ -84,6 +84,7 @@ export * as governance from "./governance"
 export class Context<T extends EthereumProviderTypes> {
     readonly environment: Environment
     readonly ethereumProvider: EthereumProvider<T>
+    readonly forkedProviderApiKey?: string
 
     // Ethereum
     #ethChains: Record<string, T["Connection"]>
@@ -101,9 +102,14 @@ export class Context<T extends EthereumProviderTypes> {
     static #rpcInitTimeoutMs = 40_000
     static #wsRequestTimeoutMs = 30_000
 
-    constructor(environment: Environment, ethereumProvider: EthereumProvider<T>) {
+    constructor(
+        environment: Environment,
+        ethereumProvider: EthereumProvider<T>,
+        forkedProviderApiKey?: string,
+    ) {
         this.environment = environment
         this.ethereumProvider = ethereumProvider
+        this.forkedProviderApiKey = forkedProviderApiKey
         this.#polkadotParachains = {}
         this.#kusamaParachains = {}
         this.#ethChains = {}
@@ -341,6 +347,8 @@ export class Context<T extends EthereumProviderTypes> {
             return this.#forkedProvider
         }
         const apiKey =
+            this.forkedProviderApiKey ||
+            this.environment.forkedProviderApiKey ||
             process.env.FORKED_PROVIDER_API_KEY ||
             process.env.NEXT_PUBLIC_FORKED_PROVIDER_API_KEY
         this.#forkedProvider = this.ethereumProvider.createProvider(
@@ -406,6 +414,7 @@ export class Context<T extends EthereumProviderTypes> {
 export type ApiOptions<P extends EthereumProvider<any>> = {
     info: BridgeInfo
     ethereumProvider: P
+    forkedProviderApiKey?: string
 }
 
 export type TransferImplementation<T extends EthereumProviderTypes = EthereumProviderTypes> =
@@ -477,6 +486,7 @@ export class SnowbridgeApi<P extends EthereumProvider<any>> {
         this.context = new Context<ProviderTypesFor<P>>(
             options.info.environment,
             options.ethereumProvider as unknown as EthereumProvider<ProviderTypesFor<P>>,
+            options.forkedProviderApiKey,
         )
     }
     createAgent(): AgentCreationInterface<ProviderTypesFor<P>["ContractTransaction"]> {

--- a/web/packages/api/src/toEthereumSnowbridgeV2.ts
+++ b/web/packages/api/src/toEthereumSnowbridgeV2.ts
@@ -9,6 +9,7 @@ import {
     EthereumProviderTypes,
     Parachain,
     TransferRoute,
+    V2CommandStruct,
 } from "@snowbridge/base-types"
 import { CallDryRunEffects, XcmDryRunApiError, XcmDryRunEffects } from "@polkadot/types/interfaces"
 import { Result } from "@polkadot/types"
@@ -46,7 +47,7 @@ import {
     checkNativeDotPoolLiquidityForParachainToEthereum,
 } from "./poolReserves"
 import { ParachainBase } from "./parachains/parachainBase"
-
+import { runEthereumDryRun, dryRunCommandGasBudgets } from "./dryRunEthereum"
 
 export { signAndSendTransfer } from "./toEthereum_v2"
 export { ValidationKind } from "./types/toEthereum"
@@ -1256,6 +1257,7 @@ export const validateTransferFromAssetHub = async <T extends EthereumProviderTyp
     let sourceDryRunError
     let assetHubDryRunError
     let bridgeHubDryRunError
+    let ethereumDryRunError: string | undefined
     // do the dry run, get the forwarded xcm and dry run that
     const dryRunResultAssetHub = await dryRunOnSourceParachain(
         sourceParachain,
@@ -1270,7 +1272,16 @@ export const validateTransferFromAssetHub = async <T extends EthereumProviderTyp
             registry.assetHubParaId,
             dryRunResultAssetHub.bridgeHubForwarded[1][0],
         )
-        if (!dryRunResultBridgeHub.success) {
+        if (dryRunResultBridgeHub.success) {
+            const ethResult = await runEthereumDryRun(
+                context,
+                registry.assetHubParaId,
+                sourceAccountHex,
+                transfer,
+                logs,
+            )
+            ethereumDryRunError = ethResult.ethereumDryRunError
+        } else {
             logs.push({
                 kind: ValidationKind.Error,
                 reason: ValidationReason.DryRunFailed,
@@ -1355,6 +1366,7 @@ export const validateTransferFromAssetHub = async <T extends EthereumProviderTyp
             sourceDryRunError,
             assetHubDryRunError,
             bridgeHubDryRunError,
+            ethereumDryRunError,
         },
         ...transfer,
     }
@@ -1539,6 +1551,7 @@ export const validateTransferFromParachain = async <T extends EthereumProviderTy
     let sourceDryRunError
     let assetHubDryRunError
     let bridgeHubDryRunError
+    let ethereumDryRunError: string | undefined
     if (source.features.hasDryRunApi) {
         // do the dry run, get the forwarded xcm and dry run that
         const dryRunSource = await dryRunOnSourceParachain(
@@ -1584,6 +1597,15 @@ export const validateTransferFromParachain = async <T extends EthereumProviderTy
                             message: "Dry run failed on Bridge Hub.",
                         })
                         bridgeHubDryRunError = dryRunResultBridgeHub.errorMessage
+                    } else {
+                        const ethResult = await runEthereumDryRun(
+                            context,
+                            sourceParaId,
+                            sourceAccountHex,
+                            transfer,
+                            logs,
+                        )
+                        ethereumDryRunError = ethResult.ethereumDryRunError
                     }
                 } else {
                     logs.push({
@@ -1677,6 +1699,7 @@ export const validateTransferFromParachain = async <T extends EthereumProviderTy
             sourceDryRunError,
             assetHubDryRunError,
             bridgeHubDryRunError,
+            ethereumDryRunError,
         },
         ...transfer,
     }

--- a/web/packages/api/src/types/toEthereum.ts
+++ b/web/packages/api/src/types/toEthereum.ts
@@ -89,6 +89,7 @@ export type ValidatedTransfer = Transfer & {
         sourceDryRunError: any
         assetHubDryRunError: any
         bridgeHubDryRunError?: any
+        ethereumDryRunError?: any
     }
 }
 

--- a/web/packages/base-types/src/contracts.ts
+++ b/web/packages/base-types/src/contracts.ts
@@ -29,6 +29,12 @@ export type SwapParamsStruct = {
   callData: string;
 };
 
+export type V2CommandStruct = {
+  kind: number;
+  gas: bigint;
+  payload: string;
+};
+
 export type IGatewayV1 = {
   quoteSendTokenFee(
     token: string,
@@ -46,6 +52,17 @@ export type IGatewayV2 = {
   v2_outboundNonce(): Promise<bigint>;
   isTokenRegistered(token: string): Promise<boolean>;
   agentOf(agentID: string): Promise<string>;
+  getFunction(name: "v2_dispatch"): {
+    populateTransaction(
+      commands: V2CommandStruct[],
+      origin: string,
+      nonce: bigint,
+      overrides?: { from?: string },
+    ): Promise<any>;
+  };
+  interface: {
+    parseLog(log: any): { name: string; args: any };
+  };
 };
 
 export type BeefyClient = {
@@ -201,6 +218,29 @@ export const IGATEWAY_V2_ABI = [
   },
   {
     type: "function",
+    name: "v2_dispatch",
+    inputs: [
+      {
+        name: "commands",
+        type: "tuple[]",
+        internalType: "struct CommandV2[]",
+        components: [
+          { name: "kind", type: "uint8", internalType: "enum CommandKind" },
+          { name: "gas", type: "uint64", internalType: "uint64" },
+          { name: "payload", type: "bytes", internalType: "bytes" },
+        ],
+      },
+      { name: "origin", type: "bytes32", internalType: "bytes32" },
+      { name: "nonce", type: "uint64", internalType: "uint64" },
+    ],
+    outputs: [
+      { name: "insufficientGasLimit", type: "bool", internalType: "bool" },
+      { name: "success", type: "bool", internalType: "bool" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "v2_outboundNonce",
     inputs: [],
     outputs: [{ name: "", type: "uint64", internalType: "uint64" }],
@@ -230,6 +270,25 @@ export const IGATEWAY_V2_ABI = [
     ],
     outputs: [],
     stateMutability: "payable",
+  },
+  {
+    type: "event",
+    name: "CommandFailed",
+    inputs: [
+      {
+        name: "nonce",
+        type: "uint64",
+        indexed: true,
+        internalType: "uint64",
+      },
+      {
+        name: "index",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
   },
   {
     type: "event",

--- a/web/packages/base-types/src/index.ts
+++ b/web/packages/base-types/src/index.ts
@@ -141,6 +141,8 @@ export type Environment = {
   };
   // Indexer
   indexerGraphQlUrl: string;
+  // Dry-run forked Ethereum node
+  forkedProviderUrl?: string;
   kusama?: {
     assetHubParaId: number;
     bridgeHubParaId: number;
@@ -241,6 +243,7 @@ export type AssetRegistry = {
 };
 
 export type {
+  EthereumProviderConnectionOptions,
   EthereumProvider,
   EthereumProviderTypes,
   FeeData,

--- a/web/packages/base-types/src/index.ts
+++ b/web/packages/base-types/src/index.ts
@@ -143,6 +143,7 @@ export type Environment = {
   indexerGraphQlUrl: string;
   // Dry-run forked Ethereum node
   forkedProviderUrl?: string;
+  forkedProviderApiKey?: string;
   kusama?: {
     assetHubParaId: number;
     bridgeHubParaId: number;

--- a/web/packages/base-types/src/provider.ts
+++ b/web/packages/base-types/src/provider.ts
@@ -93,9 +93,13 @@ export interface EthereumProviderTypes {
   ContractTransaction: unknown;
 }
 
+export type EthereumProviderConnectionOptions = {
+  headers?: Record<string, string>;
+};
+
 export interface EthereumProvider<T extends EthereumProviderTypes> {
   readonly providerTypes: T;
-  createProvider(url: string): T["Connection"];
+  createProvider(url: string, options?: EthereumProviderConnectionOptions): T["Connection"];
   destroyProvider(provider: T["Connection"]): void;
   destroyContract(contract: T["Contract"]): Promise<void>;
   connectContract(
@@ -114,6 +118,7 @@ export interface EthereumProvider<T extends EthereumProviderTypes> {
     method: string,
     args: readonly unknown[],
   ): string;
+  encodeAbiParameters(types: string[], values: readonly unknown[]): string;
   decodeFunctionResult<U = unknown>(
     abi: T["Abi"],
     method: string,

--- a/web/packages/provider-ethers/src/index.ts
+++ b/web/packages/provider-ethers/src/index.ts
@@ -4,6 +4,7 @@ import {
   Contract,
   ContractTransaction,
   FeeData as EthersFeeData,
+  FetchRequest,
   Interface,
   InterfaceAbi,
   JsonRpcProvider,
@@ -15,6 +16,7 @@ import type {
   BeefyClient,
   DepositParamsStruct,
   EthereumProvider,
+  EthereumProviderConnectionOptions,
   EthereumProviderTypes,
   FeeData,
   GatewayV1OutboundMessageAccepted,
@@ -58,8 +60,15 @@ export class EthersEthereumProvider
   static gatewayV2Interface = new Interface(IGATEWAY_V2_ABI);
   static l2AdaptorInterface = new Interface(SNOWBRIDGE_L2_ADAPTOR_ABI);
 
-  createProvider(url: string): AbstractProvider {
+  createProvider(url: string, options?: EthereumProviderConnectionOptions): AbstractProvider {
     if (url.startsWith("http")) {
+      if (options?.headers && Object.keys(options.headers).length > 0) {
+        const request = new FetchRequest(url);
+        for (const [key, value] of Object.entries(options.headers) as [string, string][]) {
+          request.setHeader(key, value);
+        }
+        return new JsonRpcProvider(request);
+      }
       return new JsonRpcProvider(url);
     }
     return new WebSocketProvider(url);
@@ -269,6 +278,10 @@ export class EthersEthereumProvider
     args: readonly unknown[],
   ): string {
     return new Interface(abi).encodeFunctionData(method, args);
+  }
+
+  encodeAbiParameters(types: string[], values: readonly unknown[]): string {
+    return AbiCoder.defaultAbiCoder().encode(types, values);
   }
 
   decodeFunctionResult<T = unknown>(

--- a/web/packages/provider-viem/src/index.ts
+++ b/web/packages/provider-viem/src/index.ts
@@ -25,6 +25,7 @@ import type {
   BeefyClient,
   DepositParamsStruct,
   EthereumProvider,
+  EthereumProviderConnectionOptions,
   EthereumProviderTypes,
   FeeData,
   GatewayV1OutboundMessageAccepted,
@@ -195,9 +196,13 @@ export class ViemEthereumProvider
 {
   declare readonly providerTypes: ViemProviderTypes;
 
-  createProvider(url: string): PublicClient {
+  createProvider(url: string, options?: EthereumProviderConnectionOptions): PublicClient {
     return createPublicClient({
-      transport: url.startsWith("http") ? http(url) : webSocket(url),
+      transport: url.startsWith("http")
+        ? http(url, {
+            fetchOptions: options?.headers ? { headers: options.headers } : undefined,
+          })
+        : webSocket(url),
     });
   }
 
@@ -420,6 +425,10 @@ export class ViemEthereumProvider
       functionName: method,
       args: [...args],
     } as never);
+  }
+
+  encodeAbiParameters(types: string[], values: readonly unknown[]): Hex {
+    return encodeAbiParameters(parseAbiParameters(types.join(",")), [...values]);
   }
 
   decodeFunctionResult<T = unknown>(

--- a/web/packages/registry/scripts/buildRegistry.ts
+++ b/web/packages/registry/scripts/buildRegistry.ts
@@ -120,6 +120,7 @@ const SNOWBRIDGE_ENV: { [env: string]: Environment } = {
         bridgeHubParaId: 1002,
         v2_parachains: [1000, 2034],
         indexerGraphQlUrl: "https://subsquid.snowbridge.network/graphql",
+        forkedProviderUrl: "https://fork-mainnet.snowbridge.network",
         kusama: {
             assetHubParaId: 1000,
             bridgeHubParaId: 1002,

--- a/web/packages/registry/src/polkadot_mainnet_bridge_info.g.ts
+++ b/web/packages/registry/src/polkadot_mainnet_bridge_info.g.ts
@@ -27,6 +27,7 @@ const registry = {
         bridgeHubParaId: 1002,
         v2_parachains: [1000, 2034],
         indexerGraphQlUrl: "https://subsquid.snowbridge.network/graphql",
+        forkedProviderUrl: "https://fork-mainnet.snowbridge.network",
         kusama: {
             assetHubParaId: 1000,
             bridgeHubParaId: 1002,
@@ -573,7 +574,7 @@ const registry = {
         },
     ],
     registry: {
-        timestamp: "2026-06-11T08:10:26.142Z",
+        timestamp: "2026-06-11T08:55:00.280Z",
         environment: "polkadot_mainnet",
         ethChainId: 1,
         gatewayAddress: "0x27ca963c279c93801941e1eb8799c23f407d68e7",
@@ -1959,7 +1960,7 @@ const registry = {
                         isSufficient: false,
                     },
                 },
-                estimatedExecutionFeeDOT: 55438383n,
+                estimatedExecutionFeeDOT: 54967893n,
                 estimatedDeliveryFeeDOT: 307100000n,
             },
             polkadot_2034: {
@@ -2159,7 +2160,7 @@ const registry = {
                         isSufficient: true,
                     },
                 },
-                estimatedExecutionFeeDOT: 3125982n,
+                estimatedExecutionFeeDOT: 3119486n,
                 estimatedDeliveryFeeDOT: 307100000n,
             },
             polkadot_2043: {

--- a/web/packages/test/scripts/start-forked-mainnet.sh
+++ b/web/packages/test/scripts/start-forked-mainnet.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Wrapper for running Anvil as a local mainnet fork.
+#
+# Usage:
+#   MAINNET_RPC_URL=https://... ./start-anvil-mainnet-fork.sh
+#   ./start-anvil-mainnet-fork.sh --rpc-url https://... --block-number 22000000
+#
+# Optional env vars:
+#   MAINNET_RPC_URL (default: https://ethereum.publicnode.com)
+#   ANVIL_HOST (default: 0.0.0.0)
+#   ANVIL_PORT (default: 8545)
+#   ANVIL_CHAIN_ID (default: 1)
+#   ANVIL_ACCOUNTS (default: 20)
+#   ANVIL_BALANCE_ETHER (default: 10000)
+#   REFRESH_INTERVAL (default: 600 seconds; set to 0 to disable)
+
+DEFAULT_MAINNET_RPC_URL="https://ethereum.publicnode.com"
+RPC_URL="${MAINNET_RPC_URL:-${ETH_MAINNET_RPC_URL:-$DEFAULT_MAINNET_RPC_URL}}"
+BLOCK_NUMBER=""
+ANVIL_HOST="${ANVIL_HOST:-0.0.0.0}"
+ANVIL_PORT="${ANVIL_PORT:-8545}"
+ANVIL_CHAIN_ID="${ANVIL_CHAIN_ID:-1}"
+ANVIL_ACCOUNTS="${ANVIL_ACCOUNTS:-20}"
+ANVIL_BALANCE_ETHER="${ANVIL_BALANCE_ETHER:-10000}"
+REFRESH_INTERVAL="${REFRESH_INTERVAL:-600}"
+
+usage() {
+    cat <<'EOF'
+Usage: start-anvil-mainnet-fork.sh [options]
+
+Options:
+    --rpc-url URL                Mainnet RPC endpoint (or use MAINNET_RPC_URL / ETH_MAINNET_RPC_URL)
+  --block-number NUMBER          Pin the fork to an exact block (disables periodic refresh)
+  --refresh-interval SECONDS     Re-fork from upstream every N seconds (default: 600; 0 = disabled)
+  -h, --help                     Show this help
+
+Default RPC URL:
+    https://ethereum.publicnode.com
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --rpc-url)
+            RPC_URL="${2:-}"
+            shift 2
+            ;;
+        --block-number)
+            BLOCK_NUMBER="${2:-}"
+            shift 2
+            ;;
+        --refresh-interval)
+            REFRESH_INTERVAL="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v anvil >/dev/null 2>&1; then
+    echo "Error: anvil not found in PATH. Install Foundry first: https://book.getfoundry.sh/getting-started/installation" >&2
+    exit 1
+fi
+
+# A fixed --block-number means the user wants a frozen state — never refresh.
+if [[ -n "$BLOCK_NUMBER" ]]; then
+    REFRESH_INTERVAL=0
+fi
+
+CMD=(
+    anvil
+    --host "$ANVIL_HOST"
+    --port "$ANVIL_PORT"
+    --chain-id "$ANVIL_CHAIN_ID"
+    --accounts "$ANVIL_ACCOUNTS"
+    --balance "$ANVIL_BALANCE_ETHER"
+    --fork-url "$RPC_URL"
+)
+
+if [[ -n "$BLOCK_NUMBER" ]]; then
+    CMD+=(--fork-block-number "$BLOCK_NUMBER")
+fi
+
+echo "Starting Anvil mainnet fork on ${ANVIL_HOST}:${ANVIL_PORT} (chain id ${ANVIL_CHAIN_ID})"
+if [[ -n "$BLOCK_NUMBER" ]]; then
+    echo "Fork block: ${BLOCK_NUMBER} (frozen — periodic refresh disabled)"
+elif [[ "$REFRESH_INTERVAL" -gt 0 ]]; then
+    echo "Periodic refresh: every ${REFRESH_INTERVAL}s (anvil_reset to upstream HEAD)"
+else
+    echo "Periodic refresh: disabled"
+fi
+
+# Background a refresh loop that re-forks against the latest upstream block.
+# It exits cleanly once Anvil's port stops responding (i.e. Anvil shut down).
+if [[ "$REFRESH_INTERVAL" -gt 0 ]]; then
+    REFRESH_URL="http://127.0.0.1:${ANVIL_PORT}"
+    (
+        # Give Anvil time to bind its port before the first reset.
+        sleep "$REFRESH_INTERVAL"
+        while curl -sf -m 5 -X POST -H "Content-Type: application/json" \
+                --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+                "$REFRESH_URL" >/dev/null 2>&1; do
+            payload=$(printf '{"jsonrpc":"2.0","method":"anvil_reset","params":[{"forking":{"jsonRpcUrl":"%s"}}],"id":1}' "$RPC_URL")
+            if curl -sf -m 30 -X POST -H "Content-Type: application/json" \
+                    --data "$payload" "$REFRESH_URL" >/dev/null 2>&1; then
+                echo "[refresh] anvil_reset to upstream HEAD at $(date '+%H:%M:%S')"
+            else
+                echo "[refresh] anvil_reset failed at $(date '+%H:%M:%S')" >&2
+            fi
+            sleep "$REFRESH_INTERVAL"
+        done
+    ) &
+    REFRESH_PID=$!
+    # Stop the refresher when this script exits (Ctrl-C or Anvil dies).
+    trap 'kill "$REFRESH_PID" 2>/dev/null || true' EXIT
+fi
+
+exec "${CMD[@]}"


### PR DESCRIPTION
### Dry run on Ethereum

Validates Snowbridge V2 transfers end-to-end by simulating the resulting `Gateway.v2_dispatch` against a forked Ethereum node, surfacing reverts, CommandFailed events, and L1Adapter DepositCallInvoked / DepositCallFailed outcomes before the user signs anything.

For Polkadot → Ethereum (L1 and L2) transfers, after the source / AH / BridgeHub Polkadot dry-runs succeed, the SDK now:
1. Builds a synthetic `v2_dispatch(commands, agentID, nonce)` tx whose commands mirror what the relayer would submit to mainnet (UnlockNativeToken + optional CallContract).
2. Sends it to a forked Ethereum node (`FORKED_PROVIDER_URL`) using impersonation of the gateway proxy as `from`.
3. Parses the resulting receipt for the gateway's `CommandFailed` event and the L1 Adapter's `DepositCallInvoked` / `DepositCallFailed` events, surfacing failures via the existing `ValidationLog` mechanism.