### PR TITLE
Update NIX flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1760346693,
-        "narHash": "sha256-ie/IYt22vxzgRPP4BiNWw5Gjg5Bn7mtMussy5KjEKlA=",
+        "lastModified": 1771399323,
+        "narHash": "sha256-n0XT6j6VfctleIK246g1Am1RRpAQxCfz3G2aAGvuvng=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "2edb0b71a90ac505736da3e9776d26e66f011d7b",
+        "rev": "a3f632d174b6bd6c2acd09fe9d32048a3d4a9571",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Go version was 1.22.5 in the flake, behind the required version of 1.23 in go.mod. Had to update nix.