### PR TITLE
Limit scope of monitoring

### DIFF
--- a/web/packages/api/src/status.ts
+++ b/web/packages/api/src/status.ts
@@ -219,21 +219,24 @@ export const channelStatusInfo = async (
         await bridgeHub.query.ethereumOutboundQueue.nonce(channelId)
     ).toPrimitive() as number
 
-    // V2 nonces
-    const v2_outbound_nonce_eth = Number(await gatewayV2.v2_outboundNonce())
-    const v2_outbound_nonce_sub = (
-        await bridgeHub.query.ethereumOutboundQueueV2.nonce()
-    ).toPrimitive() as number
-
     let estimatedDeliveryTime: any,
         toEthereumUndeliveredTimeout: number | undefined,
         toPolkadotUndeliveredTimeout: number | undefined = undefined,
         toEthereumPendings: ToEthereumTransferResult[] = [],
         toPolkadotPendings: ToPolkadotTransferResult[] = [],
         v2_max_delivered_nonce_to_polkadot: number | undefined = undefined,
-        v2_max_delivered_nonce_to_ethereum: number | undefined = undefined
+        v2_max_delivered_nonce_to_ethereum: number | undefined = undefined,
+        v2_outbound_nonce_eth: number | undefined = undefined,
+        v2_outbound_nonce_sub: number | undefined = undefined
 
-    if (context.environment.name == "polkadot_mainnet") {
+    if (
+        context.environment.name == "polkadot_mainnet" &&
+        channelId.toLowerCase() == ASSET_HUB_CHANNEL_ID.toLowerCase()
+    ) {
+        v2_outbound_nonce_eth = Number(await gatewayV2.v2_outboundNonce())
+        v2_outbound_nonce_sub = (
+            await bridgeHub.query.ethereumOutboundQueueV2.nonce()
+        ).toPrimitive() as number
         v2_max_delivered_nonce_to_polkadot = await subsquidV2.fetchMaxDeliveredNonceToPolkadot(
             context.graphqlApiUrl(),
             v2_outbound_nonce_eth,
@@ -242,24 +245,20 @@ export const channelStatusInfo = async (
             context.graphqlApiUrl(),
             v2_outbound_nonce_sub,
         )
+        estimatedDeliveryTime = await subsquidV2.fetchEstimatedDeliveryTime(context.graphqlApiUrl())
 
-        if (channelId.toLowerCase() == ASSET_HUB_CHANNEL_ID.toLowerCase()) {
-            estimatedDeliveryTime = await subsquidV2.fetchEstimatedDeliveryTime(
-                context.graphqlApiUrl(),
-            )
-
-            let latency = await subsquidV2.fetchToEthereumUndeliveredLatency(
-                context.graphqlApiUrl(),
-            )
-            if (latency && latency.elapse) {
-                toEthereumUndeliveredTimeout = latency.elapse
-            }
-            latency = await subsquidV2.fetchToPolkadotUndeliveredLatency(context.graphqlApiUrl())
-            if (latency && latency.elapse) {
-                toPolkadotUndeliveredTimeout = latency.elapse
-            }
-            // Pending transfers
+        let toEthereumUndelivered = await subsquidV2.fetchToEthereumUndeliveredLatency(
+            context.graphqlApiUrl(),
+        )
+        if (toEthereumUndelivered && toEthereumUndelivered.elapse) {
+            toEthereumUndeliveredTimeout = toEthereumUndelivered.elapse
             toEthereumPendings = await toEthereumPendingTransfers(context.graphqlApiUrl(), 10)
+        }
+        let toPolkadotUndelivered = await subsquidV2.fetchToPolkadotUndeliveredLatency(
+            context.graphqlApiUrl(),
+        )
+        if (toPolkadotUndelivered && toPolkadotUndelivered.elapse) {
+            toPolkadotUndeliveredTimeout = toPolkadotUndelivered.elapse
             toPolkadotPendings = await toPolkadotPendingTransfers(context.graphqlApiUrl(), 10)
         }
     }

--- a/web/packages/api/src/status.ts
+++ b/web/packages/api/src/status.ts
@@ -225,39 +225,42 @@ export const channelStatusInfo = async (
         await bridgeHub.query.ethereumOutboundQueueV2.nonce()
     ).toPrimitive() as number
 
-    const v2_max_delivered_nonce_to_polkadot = await subsquidV2.fetchMaxDeliveredNonceToPolkadot(
-        context.graphqlApiUrl(),
-        v2_outbound_nonce_eth,
-    )
-    const v2_max_delivered_nonce_to_ethereum = await subsquidV2.fetchMaxDeliveredNonceToEthereum(
-        context.graphqlApiUrl(),
-        v2_outbound_nonce_sub,
-    )
-
     let estimatedDeliveryTime: any,
         toEthereumUndeliveredTimeout: number | undefined,
         toPolkadotUndeliveredTimeout: number | undefined = undefined,
         toEthereumPendings: ToEthereumTransferResult[] = [],
-        toPolkadotPendings: ToPolkadotTransferResult[] = []
+        toPolkadotPendings: ToPolkadotTransferResult[] = [],
+        v2_max_delivered_nonce_to_polkadot: number | undefined = undefined,
+        v2_max_delivered_nonce_to_ethereum: number | undefined = undefined
 
-    if (channelId.toLowerCase() == ASSET_HUB_CHANNEL_ID.toLowerCase()) {
-        estimatedDeliveryTime = await subsquidV2.fetchEstimatedDeliveryTime(context.graphqlApiUrl())
+    if (context.environment.name == "polkadot_mainnet") {
+        v2_max_delivered_nonce_to_polkadot = await subsquidV2.fetchMaxDeliveredNonceToPolkadot(
+            context.graphqlApiUrl(),
+            v2_outbound_nonce_eth,
+        )
+        v2_max_delivered_nonce_to_ethereum = await subsquidV2.fetchMaxDeliveredNonceToEthereum(
+            context.graphqlApiUrl(),
+            v2_outbound_nonce_sub,
+        )
 
-        let latency = await subsquidV2.fetchToEthereumUndeliveredLatency(context.graphqlApiUrl())
-        if (latency && latency.elapse) {
-            toEthereumUndeliveredTimeout = latency.elapse
-        }
-        latency = await subsquidV2.fetchToPolkadotUndeliveredLatency(context.graphqlApiUrl())
-        if (latency && latency.elapse) {
-            toPolkadotUndeliveredTimeout = latency.elapse
-        }
+        if (channelId.toLowerCase() == ASSET_HUB_CHANNEL_ID.toLowerCase()) {
+            estimatedDeliveryTime = await subsquidV2.fetchEstimatedDeliveryTime(
+                context.graphqlApiUrl(),
+            )
 
-        try {
+            let latency = await subsquidV2.fetchToEthereumUndeliveredLatency(
+                context.graphqlApiUrl(),
+            )
+            if (latency && latency.elapse) {
+                toEthereumUndeliveredTimeout = latency.elapse
+            }
+            latency = await subsquidV2.fetchToPolkadotUndeliveredLatency(context.graphqlApiUrl())
+            if (latency && latency.elapse) {
+                toPolkadotUndeliveredTimeout = latency.elapse
+            }
             // Pending transfers
             toEthereumPendings = await toEthereumPendingTransfers(context.graphqlApiUrl(), 10)
             toPolkadotPendings = await toPolkadotPendingTransfers(context.graphqlApiUrl(), 10)
-        } catch (error) {
-            console.error("Error fetching pending transfers:", error)
         }
     }
 

--- a/web/packages/operations/src/monitor.ts
+++ b/web/packages/operations/src/monitor.ts
@@ -356,37 +356,12 @@ const fetchBalances = async (context: Context, env: Environment) => {
         ).data.free,
     )
 
-    let assetHubAgentBalance = await context
-        .ethereum()
-        .getBalance(
-            await context
-                .gateway()
-                .agentOf(utils.paraIdToAgentId(bridgeHub.registry, env.assetHubParaId)),
-        )
-
-    const bridgeHubAgentId = u8aToHex(blake2AsU8a("0x00", 256))
-    let bridgeHubAgentBalance = await context
-        .ethereum()
-        .getBalance(await context.gateway().agentOf(bridgeHubAgentId))
-
     let sovereigns: status.Sovereign[] = [
         {
             name: "AssetHub",
             account: utils.paraIdToSovereignAccount("sibl", env.assetHubParaId),
             balance: assetHubSovereignBalance,
             type: "substrate",
-        },
-        {
-            name: "AssetHubAgent",
-            account: utils.paraIdToAgentId(bridgeHub.registry, env.assetHubParaId),
-            balance: assetHubAgentBalance,
-            type: "ethereum",
-        },
-        {
-            name: "BridgeHubAgent",
-            account: u8aToHex(blake2AsU8a("0x00", 256)),
-            balance: bridgeHubAgentBalance,
-            type: "ethereum",
         },
     ]
     return { relayers, sovereigns }


### PR DESCRIPTION
### Context

The Westend monitor is currently stuck due to the removal of indexer support. We should limit the monitoring scope to the Polkadot mainnet. For Westend, we can keep a minimal set of metrics (e.g., consensus latency) that do not depend on the indexer.