### PR TITLE
Snowbridge V2 E->P fee padding

### DIFF
--- a/web/packages/api/src/registration/toPolkadot/registerToken.ts
+++ b/web/packages/api/src/registration/toPolkadot/registerToken.ts
@@ -38,7 +38,7 @@ export class RegisterToken<T extends EthereumProviderTypes> implements Registrat
         const assetHub = await context.assetHub()
         const bridgeHub = await context.bridgeHub()
 
-        const feePadPercentage = options?.padFeeByPercentage ?? 33n
+        const feePadPercentage = options?.padFeeByPercentage ?? 50n
         const ether = erc20Location(registry.ethChainId, ETHER_TOKEN_ADDRESS)
 
         const assetDepositDOT = getAssetDeposit(assetHub)
@@ -63,9 +63,12 @@ export class RegisterToken<T extends EthereumProviderTypes> implements Registrat
         // AssetHub Execution fee
         const assetHubImpl = await context.paraImplementation(assetHub)
 
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Quote in the runtime swap direction (ETH->DOT) for all three legs:
+        // delivery, AH execution, and asset deposit are all paid by swapping
+        // user ETH for DOT, so the LP fee must be charged on the ETH input.
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             deliveryFeeInDOT,
         )
 
@@ -75,13 +78,21 @@ export class RegisterToken<T extends EthereumProviderTypes> implements Registrat
         )
 
         const assetHubExecutionFeeEther = padFeeByPercentage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, assetHubExecutionFeeDOT),
+            await assetHubImpl.getAssetHubConversionPalletSwap(
+                ether,
+                DOT_LOCATION,
+                assetHubExecutionFeeDOT,
+            ),
             feePadPercentage,
         )
 
         // Convert asset deposit from DOT to Ether
         const assetDepositEther = padFeeByPercentage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, assetDepositDOT),
+            await assetHubImpl.getAssetHubConversionPalletSwap(
+                ether,
+                DOT_LOCATION,
+                assetDepositDOT,
+            ),
             10n,
         )
 

--- a/web/packages/api/src/toPolkadotSnowbridgeV2.ts
+++ b/web/packages/api/src/toPolkadotSnowbridgeV2.ts
@@ -242,9 +242,12 @@ export async function inboundMessageExtrinsicFee(
     const extrinsicFeeDot = 250_000_000n
 
     const etherLocation = erc20Location(ethChainId, ETHER_TOKEN_ADDRESS)
-    const extrinsicFeeEther = await assetHub.swapAsset1ForAsset2(
-        DOT_LOCATION,
+    // Quote in the runtime swap direction (ETH->DOT): the runtime swaps the
+    // user's ETH for DOT to pay weight, so charge the LP fee on the ETH input
+    // side (`quotePriceTokensForExactTokens`).
+    const extrinsicFeeEther = await assetHub.getAssetHubConversionPalletSwap(
         etherLocation,
+        DOT_LOCATION,
         extrinsicFeeDot,
     )
 

--- a/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
+++ b/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
@@ -133,12 +133,28 @@ export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInter
             ether,
             deliveryFeeInDOT,
         )
-        // AssetHub Execution fee
+        // AssetHub Execution fee. Always compute the DOT figure for the fee
+        // breakdown, then prefer AH's direct weight→ether quote when available,
+        // using the indirect DOT→ETH swap exposes us to AssetConversion pool
+        // movement during the Across+Snowbridge delivery window, which has
+        // produced `TooExpensive` traps on L2 ether transfers.
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
 
+        let assetHubExecutionFeeEtherRaw: bigint
+        try {
+            assetHubExecutionFeeEtherRaw = await assetHubImpl.calculateXcmFee(assetHubXcm, ether)
+        } catch {
+            assetHubExecutionFeeEtherRaw = await assetHubImpl.swapAsset1ForAsset2(
+                DOT_LOCATION,
+                ether,
+                assetHubExecutionFeeDOT,
+            )
+        }
+        // Bumped pad for L2: the L2→L1 (Across) + L1→AH (Snowbridge) latency is
+        // minutes, so pool/rate movement can exceed the L1-path's 33% buffer.
         let assetHubExecutionFeeEther = padFeeByPercentage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, assetHubExecutionFeeDOT),
-            feePadPercentage ?? 33n,
+            assetHubExecutionFeeEtherRaw,
+            feePadPercentage ?? 100n,
         )
         // For non-ether transfers, oversize executionFee by AH bridged-ether
         // min_balance: the post-PayFees surplus then naturally lands at the

--- a/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
+++ b/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
@@ -42,13 +42,6 @@ import { VolumeFeeParams, calculateVolumeTipInWei } from "../../feeSchedule"
 import { addBreakdown, computeTotals, findInBreakdown, findInBreakdownOrZero, findTotal } from "../../fees"
 import { checkDotEthPoolLiquidityForEthereumToPolkadot } from "../../poolReserves"
 
-// 20% slippage on AssetConversion DOT↔ETH quotes. The pool rate drifts over
-// the L2→L1 (Across) + L1→AH (Snowbridge) delivery window, so quotes taken at
-// estimation time under-quote actual execution cost.
-const SWAP_SLIPPAGE_BPS = 2000n // 20% in basis points
-const applySwapSlippage = (amount: bigint): bigint =>
-    (amount * (10_000n + SWAP_SLIPPAGE_BPS)) / 10_000n
-
 export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInterface<T> {
     constructor(
         public readonly context: Context<T>,
@@ -135,33 +128,31 @@ export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInter
         )
 
         const assetHubImpl = await this.context.paraImplementation(assetHub)
-        // 20% slippage buffer on every DOT→ETH swap result: the AssetConversion
-        // pool rate can drift over the Across+Snowbridge delivery window, so
-        // overcompensate at quote time to keep `PayFees` from running short.
-        const deliveryFeeInEther = applySwapSlippage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, deliveryFeeInDOT),
+        // Quote in the runtime swap direction (ETH->DOT) so the LP fee lands
+        // on the ETH input side, matching what AH's SwapFirstAssetTrader does.
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
+            ether,
+            DOT_LOCATION,
+            deliveryFeeInDOT,
         )
         // AssetHub Execution fee. Always compute the DOT figure for the fee
-        // breakdown. The ether figure goes through the AssetConversion pool
-        // either way (AH's `SwapFirstAssetTrader` resolves bridged-ether via
-        // the same pool the SDK queries), so apply the slippage buffer to
-        // both the direct ether quote and the manual DOT→ETH fallback.
+        // breakdown. Prefer AH's direct weight->ether quote when available,
+        // fall back to the manual ETH->DOT swap.
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
 
         let assetHubExecutionFeeEtherRaw: bigint
         try {
             assetHubExecutionFeeEtherRaw = await assetHubImpl.calculateXcmFee(assetHubXcm, ether)
         } catch {
-            assetHubExecutionFeeEtherRaw = await assetHubImpl.swapAsset1ForAsset2(
-                DOT_LOCATION,
+            assetHubExecutionFeeEtherRaw = await assetHubImpl.getAssetHubConversionPalletSwap(
                 ether,
+                DOT_LOCATION,
                 assetHubExecutionFeeDOT,
             )
         }
-        assetHubExecutionFeeEtherRaw = applySwapSlippage(assetHubExecutionFeeEtherRaw)
         let assetHubExecutionFeeEther = padFeeByPercentage(
             assetHubExecutionFeeEtherRaw,
-            feePadPercentage ?? 33n,
+            feePadPercentage ?? 50n,
         )
         // For non-ether transfers, oversize executionFee by AH bridged-ether
         // min_balance: the post-PayFees surplus then naturally lands at the

--- a/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
+++ b/web/packages/api/src/transfers/l2ToPolkadot/erc20ToAH.ts
@@ -42,6 +42,13 @@ import { VolumeFeeParams, calculateVolumeTipInWei } from "../../feeSchedule"
 import { addBreakdown, computeTotals, findInBreakdown, findInBreakdownOrZero, findTotal } from "../../fees"
 import { checkDotEthPoolLiquidityForEthereumToPolkadot } from "../../poolReserves"
 
+// 20% slippage on AssetConversion DOT↔ETH quotes. The pool rate drifts over
+// the L2→L1 (Across) + L1→AH (Snowbridge) delivery window, so quotes taken at
+// estimation time under-quote actual execution cost.
+const SWAP_SLIPPAGE_BPS = 2000n // 20% in basis points
+const applySwapSlippage = (amount: bigint): bigint =>
+    (amount * (10_000n + SWAP_SLIPPAGE_BPS)) / 10_000n
+
 export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInterface<T> {
     constructor(
         public readonly context: Context<T>,
@@ -128,16 +135,17 @@ export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInter
         )
 
         const assetHubImpl = await this.context.paraImplementation(assetHub)
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
-            ether,
-            deliveryFeeInDOT,
+        // 20% slippage buffer on every DOT→ETH swap result: the AssetConversion
+        // pool rate can drift over the Across+Snowbridge delivery window, so
+        // overcompensate at quote time to keep `PayFees` from running short.
+        const deliveryFeeInEther = applySwapSlippage(
+            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, deliveryFeeInDOT),
         )
         // AssetHub Execution fee. Always compute the DOT figure for the fee
-        // breakdown, then prefer AH's direct weight→ether quote when available,
-        // using the indirect DOT→ETH swap exposes us to AssetConversion pool
-        // movement during the Across+Snowbridge delivery window, which has
-        // produced `TooExpensive` traps on L2 ether transfers.
+        // breakdown. The ether figure goes through the AssetConversion pool
+        // either way (AH's `SwapFirstAssetTrader` resolves bridged-ether via
+        // the same pool the SDK queries), so apply the slippage buffer to
+        // both the direct ether quote and the manual DOT→ETH fallback.
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
 
         let assetHubExecutionFeeEtherRaw: bigint
@@ -150,11 +158,10 @@ export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInter
                 assetHubExecutionFeeDOT,
             )
         }
-        // Bumped pad for L2: the L2→L1 (Across) + L1→AH (Snowbridge) latency is
-        // minutes, so pool/rate movement can exceed the L1-path's 33% buffer.
+        assetHubExecutionFeeEtherRaw = applySwapSlippage(assetHubExecutionFeeEtherRaw)
         let assetHubExecutionFeeEther = padFeeByPercentage(
             assetHubExecutionFeeEtherRaw,
-            feePadPercentage ?? 100n,
+            feePadPercentage ?? 33n,
         )
         // For non-ether transfers, oversize executionFee by AH bridged-ether
         // min_balance: the post-PayFees surplus then naturally lands at the

--- a/web/packages/api/src/transfers/toPolkadot/erc20ToAH.ts
+++ b/web/packages/api/src/transfers/toPolkadot/erc20ToAH.ts
@@ -97,17 +97,23 @@ export class ERC20ToAH<T extends EthereumProviderTypes> implements TransferInter
         )
 
         const assetHubImpl = await this.context.paraImplementation(assetHub)
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Quote in the runtime swap direction (ETH->DOT) so the LP fee lands
+        // on the ETH input side, matching what AH's SwapFirstAssetTrader does.
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             deliveryFeeInDOT,
         )
         // AssetHub Execution fee
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
 
         let assetHubExecutionFeeEther = padFeeByPercentage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, assetHubExecutionFeeDOT),
-            feePadPercentage ?? 33n,
+            await assetHubImpl.getAssetHubConversionPalletSwap(
+                ether,
+                DOT_LOCATION,
+                assetHubExecutionFeeDOT,
+            ),
+            feePadPercentage ?? 50n,
         )
         // For non-ether transfers, oversize executionFee by AH bridged-ether
         // min_balance: the post-PayFees surplus then naturally lands at the

--- a/web/packages/api/src/transfers/toPolkadot/erc20ToParachain.ts
+++ b/web/packages/api/src/transfers/toPolkadot/erc20ToParachain.ts
@@ -119,15 +119,19 @@ export class ERC20ToParachain<T extends EthereumProviderTypes> implements Transf
         )
         // AssetHub execution fee
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
-        // Swap to ether
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Swap to ether, runtime direction (ETH->DOT).
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             deliveryFeeInDOT,
         )
         let assetHubExecutionFeeEther = padFeeByPercentage(
-            await assetHubImpl.swapAsset1ForAsset2(DOT_LOCATION, ether, assetHubExecutionFeeDOT),
-            feePadPercentage ?? 33n,
+            await assetHubImpl.getAssetHubConversionPalletSwap(
+                ether,
+                DOT_LOCATION,
+                assetHubExecutionFeeDOT,
+            ),
+            feePadPercentage ?? 50n,
         )
         // For non-ether transfers, oversize executionFee by AH bridged-ether
         // min_balance: the post-PayFees surplus then naturally lands at the
@@ -174,10 +178,10 @@ export class ERC20ToParachain<T extends EthereumProviderTypes> implements Transf
             destinationXcm,
         )
 
-        // Swap to ether
-        const destinationDeliveryFeeEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Swap to ether, runtime direction (ETH->DOT).
+        const destinationDeliveryFeeEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             destinationDeliveryFeeDOT,
         )
 
@@ -191,17 +195,17 @@ export class ERC20ToParachain<T extends EthereumProviderTypes> implements Transf
                 DOT_LOCATION,
             )
             destinationExecutionFeeEther = padFeeByPercentage(
-                await assetHubImpl.swapAsset1ForAsset2(
-                    DOT_LOCATION,
+                await assetHubImpl.getAssetHubConversionPalletSwap(
                     ether,
+                    DOT_LOCATION,
                     destinationExecutionFeeDOT,
                 ),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             )
         } else if (feeAsset == ether) {
             destinationExecutionFeeEther = padFeeByPercentage(
                 await destinationImpl.calculateXcmFee(destinationXcm, ether),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             )
         } else {
             throw Error(`Unsupported fee asset`)

--- a/web/packages/api/src/transfers/toPolkadot/pnaToAH.ts
+++ b/web/packages/api/src/transfers/toPolkadot/pnaToAH.ts
@@ -103,9 +103,10 @@ export class PNAToAH<T extends EthereumProviderTypes> implements TransferInterfa
         )
 
         const assetHubImpl = await this.context.paraImplementation(assetHub)
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Runtime direction (ETH->DOT).
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             deliveryFeeInDOT,
         )
         // AssetHub Execution fee
@@ -113,12 +114,12 @@ export class PNAToAH<T extends EthereumProviderTypes> implements TransferInterfa
 
         let assetHubExecutionFeeEther =
             padFeeByPercentage(
-                await assetHubImpl.swapAsset1ForAsset2(
-                    DOT_LOCATION,
+                await assetHubImpl.getAssetHubConversionPalletSwap(
                     ether,
+                    DOT_LOCATION,
                     assetHubExecutionFeeDOT,
                 ),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             ) +
             // PNAs never carry ether themselves, so the post-PayFees surplus
             // must alone cover the recipient's bridged-ether min_balance —

--- a/web/packages/api/src/transfers/toPolkadot/pnaToParachain.ts
+++ b/web/packages/api/src/transfers/toPolkadot/pnaToParachain.ts
@@ -116,20 +116,20 @@ export class PNAToParachain<T extends EthereumProviderTypes> implements Transfer
         )
         // AssetHub execution fee
         let assetHubExecutionFeeDOT = await assetHubImpl.calculateXcmFee(assetHubXcm, DOT_LOCATION)
-        // Swap to ether
-        const deliveryFeeInEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Swap to ether, runtime direction (ETH->DOT).
+        const deliveryFeeInEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             deliveryFeeInDOT,
         )
         let assetHubExecutionFeeEther =
             padFeeByPercentage(
-                await assetHubImpl.swapAsset1ForAsset2(
-                    DOT_LOCATION,
+                await assetHubImpl.getAssetHubConversionPalletSwap(
                     ether,
+                    DOT_LOCATION,
                     assetHubExecutionFeeDOT,
                 ),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             ) +
             // PNAs never carry ether themselves, so the post-PayFees surplus
             // must alone cover the recipient's bridged-ether min_balance —
@@ -171,10 +171,10 @@ export class PNAToParachain<T extends EthereumProviderTypes> implements Transfer
             this.to.id,
             destinationXcm,
         )
-        // Swap to ether
-        const destinationDeliveryFeeEther = await assetHubImpl.swapAsset1ForAsset2(
-            DOT_LOCATION,
+        // Swap to ether, runtime direction (ETH->DOT).
+        const destinationDeliveryFeeEther = await assetHubImpl.getAssetHubConversionPalletSwap(
             ether,
+            DOT_LOCATION,
             destinationDeliveryFeeDOT,
         )
 
@@ -188,17 +188,17 @@ export class PNAToParachain<T extends EthereumProviderTypes> implements Transfer
                 DOT_LOCATION,
             )
             destinationExecutionFeeEther = padFeeByPercentage(
-                await assetHubImpl.swapAsset1ForAsset2(
-                    DOT_LOCATION,
+                await assetHubImpl.getAssetHubConversionPalletSwap(
                     ether,
+                    DOT_LOCATION,
                     destinationExecutionFeeDOT,
                 ),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             )
         } else if (feeAsset == ether) {
             destinationExecutionFeeEther = padFeeByPercentage(
                 await destinationImpl.calculateXcmFee(destinationXcm, ether),
-                feePadPercentage ?? 33n,
+                feePadPercentage ?? 50n,
             )
         } else {
             throw Error(`Unsupported fee asset`)

--- a/web/packages/api/src/utils.ts
+++ b/web/packages/api/src/utils.ts
@@ -58,6 +58,10 @@ export const getEventIndex = (id: string) => {
     return `${blockNumber}-${eventIndex}`
 }
 
+// Pad a fee estimate by `padPercent` percent. For E->P fees computed by
+// quoting an ETH->DOT swap on AssetConversion, the padding also absorbs AMM
+// pool drift between estimation time and AH execution, slippage is rolled
+// into the same buffer rather than applied separately.
 export function padFeeByPercentage(fee: bigint, padPercent: bigint) {
     if (padPercent < 0 || padPercent > 100) {
         throw Error(`padPercent ${padPercent} not in range of 0 to 100.`)


### PR DESCRIPTION
Adds extra slippage to fees, in case ETH/DOT pool shifts. Also fixes the swap quote direction for an accurate LP fee inclusion - currently the fee quote asset swap direction is backwards, which might give an inaccurate LP fee.