### PR TITLE
docs(contracts): fix AssetHub initializer comment

### DIFF
--- a/contracts/src/Initializer.sol
+++ b/contracts/src/Initializer.sol
@@ -60,7 +60,7 @@ library Initializer {
             mode: OperatingMode.Normal, agent: bridgeHubAgent, inboundNonce: 0, outboundNonce: 0
         });
 
-        // Initialize agent for for AssetHub
+        // Initialize agent for AssetHub
         address assetHubAgent = address(new Agent(Constants.ASSET_HUB_AGENT_ID));
         core.agents[Constants.ASSET_HUB_AGENT_ID] = assetHubAgent;
 


### PR DESCRIPTION


Remove a duplicated word from the AssetHub initializer comment in `Initializer.sol`.
